### PR TITLE
refactor: tag parser tests

### DIFF
--- a/crates/djc-template-parser/tests/common/mod.rs
+++ b/crates/djc-template-parser/tests/common/mod.rs
@@ -1,0 +1,472 @@
+use djc_template_parser::ast::{
+    Tag, TagAttr, TagValue, TagValueFilter, TemplateVersion, Token, ValueKind,
+};
+use djc_template_parser::tag_parser::TagParser;
+use djc_template_parser::{ParseError, ParserConfig, ParserContext};
+
+/// Helper function to create a Token struct
+/// Takes content, start_index, line number, and column number
+/// Calculates end_index automatically as start_index + content.len()
+pub fn token(content: &str, start_index: usize, line: usize, col: usize) -> Token {
+    Token {
+        content: content.to_string(),
+        start_index,
+        end_index: start_index + content.len(),
+        line_col: (line, col),
+    }
+}
+
+/// Helper function to create a TagAttr
+/// Takes key (optional), value, and is_flag
+/// Calculates the token field internally from key token + "=" + value token
+/// If key is None, the token is just the value token
+pub fn tag_attr(key: Option<Token>, value: TagValue, is_flag: bool) -> TagAttr {
+    let attr_token = if let Some(ref key_token) = key {
+        // Calculate token content: key + "=" + value.token.content
+        let token_content = format!("{}={}", key_token.content, value.token.content);
+        Token {
+            content: token_content,
+            start_index: key_token.start_index,
+            end_index: value.token.end_index,
+            line_col: key_token.line_col,
+        }
+    } else {
+        // If no key, token is just the value token
+        value.token.clone()
+    };
+    TagAttr {
+        token: attr_token,
+        key,
+        value,
+        is_flag,
+    }
+}
+
+/// Helper function to create a plain TagValue with ValueKind::String.
+/// No filters, no children, and no used/assigned variables
+/// If spread is provided, the token includes the spread prefix, but value does not
+pub fn plain_string_value(
+    content: &str,
+    start_index: usize,
+    line: usize,
+    col: usize,
+    spread: Option<&str>,
+) -> TagValue {
+    let (token_val, value_token) = if let Some(spread_str) = spread {
+        let token_content = format!("{}{}", spread_str, content);
+        let value_start_index = start_index + spread_str.len();
+        let value_col = col + spread_str.len();
+        (
+            token(&token_content, start_index, line, col),
+            token(content, value_start_index, line, value_col),
+        )
+    } else {
+        let token_val = token(content, start_index, line, col);
+        (token_val.clone(), token_val)
+    };
+    TagValue {
+        token: token_val,
+        value: value_token,
+        children: vec![],
+        kind: ValueKind::String,
+        spread: spread.map(|s| s.to_string()),
+        filters: vec![],
+        used_variables: vec![],
+        assigned_variables: vec![],
+    }
+}
+
+/// Helper function to create a plain TagValue with ValueKind::Int.
+/// No filters, no children, and no used/assigned variables
+/// If spread is provided, the token includes the spread prefix, but value does not
+pub fn plain_int_value(
+    content: &str,
+    start_index: usize,
+    line: usize,
+    col: usize,
+    spread: Option<&str>,
+) -> TagValue {
+    let (token_val, value_token) = if let Some(spread_str) = spread {
+        let token_content = format!("{}{}", spread_str, content);
+        let value_start_index = start_index + spread_str.len();
+        let value_col = col + spread_str.len();
+        (
+            token(&token_content, start_index, line, col),
+            token(content, value_start_index, line, value_col),
+        )
+    } else {
+        let token_val = token(content, start_index, line, col);
+        (token_val.clone(), token_val)
+    };
+    TagValue {
+        token: token_val,
+        value: value_token,
+        children: vec![],
+        kind: ValueKind::Int,
+        spread: spread.map(|s| s.to_string()),
+        filters: vec![],
+        used_variables: vec![],
+        assigned_variables: vec![],
+    }
+}
+
+/// Helper function to create a plain TagValue with ValueKind::Float.
+/// No filters, no children, and no used/assigned variables
+/// If spread is provided, the token includes the spread prefix, but value does not
+pub fn plain_float_value(
+    content: &str,
+    start_index: usize,
+    line: usize,
+    col: usize,
+    spread: Option<&str>,
+) -> TagValue {
+    let (token_val, value_token) = if let Some(spread_str) = spread {
+        let token_content = format!("{}{}", spread_str, content);
+        let value_start_index = start_index + spread_str.len();
+        let value_col = col + spread_str.len();
+        (
+            token(&token_content, start_index, line, col),
+            token(content, value_start_index, line, value_col),
+        )
+    } else {
+        let token_val = token(content, start_index, line, col);
+        (token_val.clone(), token_val)
+    };
+    TagValue {
+        token: token_val,
+        value: value_token,
+        children: vec![],
+        kind: ValueKind::Float,
+        spread: spread.map(|s| s.to_string()),
+        filters: vec![],
+        used_variables: vec![],
+        assigned_variables: vec![],
+    }
+}
+
+/// Helper function to create a plain TagValue with ValueKind::Translation.
+/// No filters, no children, and no used/assigned variables
+/// If spread is provided, the token includes the spread prefix, but value does not
+pub fn plain_translation_value(
+    content: &str,
+    start_index: usize,
+    line: usize,
+    col: usize,
+    spread: Option<&str>,
+) -> TagValue {
+    let (token_val, value_token) = if let Some(spread_str) = spread {
+        let token_content = format!("{}{}", spread_str, content);
+        let value_start_index = start_index + spread_str.len();
+        let value_col = col + spread_str.len();
+        (
+            token(&token_content, start_index, line, col),
+            token(content, value_start_index, line, value_col),
+        )
+    } else {
+        let token_val = token(content, start_index, line, col);
+        (token_val.clone(), token_val)
+    };
+    TagValue {
+        token: token_val,
+        value: value_token,
+        children: vec![],
+        kind: ValueKind::Translation,
+        spread: spread.map(|s| s.to_string()),
+        filters: vec![],
+        used_variables: vec![],
+        assigned_variables: vec![],
+    }
+}
+
+/// Helper function to create a plain TagValue with ValueKind::Variable.
+/// No filters, no children, and no assigned_variables
+/// Populates used_variables with a single token for the root variable name
+/// (the part before the first dot, or the entire variable if no dots)
+/// If spread is provided, the token includes the spread prefix, but value does not
+pub fn plain_variable_value(
+    content: &str,
+    start_index: usize,
+    line: usize,
+    col: usize,
+    spread: Option<&str>,
+) -> TagValue {
+    let (token_val, value_token) = if let Some(spread_str) = spread {
+        let token_content = format!("{}{}", spread_str, content);
+        let value_start_index = start_index + spread_str.len();
+        let value_col = col + spread_str.len();
+        (
+            token(&token_content, start_index, line, col),
+            token(content, value_start_index, line, value_col),
+        )
+    } else {
+        let token_val = token(content, start_index, line, col);
+        (token_val.clone(), token_val)
+    };
+    // Extract root variable name (everything before first dot, or entire content if no dot)
+    let root_var = content.split('.').next().unwrap_or(content);
+    let used_var_start_index = if let Some(spread_str) = spread {
+        start_index + spread_str.len()
+    } else {
+        start_index
+    };
+    let used_var_col = if let Some(spread_str) = spread {
+        col + spread_str.len()
+    } else {
+        col
+    };
+    let used_var_token = token(root_var, used_var_start_index, line, used_var_col);
+    TagValue {
+        token: token_val,
+        value: value_token,
+        children: vec![],
+        kind: ValueKind::Variable,
+        spread: spread.map(|s| s.to_string()),
+        filters: vec![],
+        used_variables: vec![used_var_token],
+        assigned_variables: vec![],
+    }
+}
+
+/// Helper function to create a TagValue with ValueKind::String
+/// Creates a TagValue with empty children
+pub fn string_value(
+    token: Token,
+    value: Token,
+    spread: Option<&str>,
+    filters: Vec<TagValueFilter>,
+    used_variables: Vec<Token>,
+    assigned_variables: Vec<Token>,
+) -> TagValue {
+    TagValue {
+        token,
+        value,
+        children: vec![],
+        kind: ValueKind::String,
+        spread: spread.map(|s| s.to_string()),
+        filters,
+        used_variables,
+        assigned_variables,
+    }
+}
+
+/// Helper function to create a TagValue with ValueKind::Int
+/// Creates a TagValue with empty children
+pub fn int_value(
+    token: Token,
+    value: Token,
+    spread: Option<&str>,
+    filters: Vec<TagValueFilter>,
+    used_variables: Vec<Token>,
+    assigned_variables: Vec<Token>,
+) -> TagValue {
+    TagValue {
+        token,
+        value,
+        children: vec![],
+        kind: ValueKind::Int,
+        spread: spread.map(|s| s.to_string()),
+        filters,
+        used_variables,
+        assigned_variables,
+    }
+}
+
+/// Helper function to create a TagValue with ValueKind::Variable
+/// Creates a TagValue with empty children
+/// Automatically computes and adds the root variable name (before first dot) to used_variables
+pub fn variable_value(
+    full_token: Token,
+    value: Token,
+    spread: Option<&str>,
+    filters: Vec<TagValueFilter>,
+    mut used_variables: Vec<Token>,
+    assigned_variables: Vec<Token>,
+) -> TagValue {
+    // Extract root variable name (everything before first dot, or entire value if no dot)
+    let root_var = value
+        .content
+        .split('.')
+        .next()
+        .unwrap_or(value.content.as_str());
+    let used_var_token = token(
+        root_var,
+        value.start_index,
+        value.line_col.0,
+        value.line_col.1,
+    );
+    used_variables.push(used_var_token);
+    TagValue {
+        token: full_token,
+        value,
+        children: vec![],
+        kind: ValueKind::Variable,
+        spread: spread.map(|s| s.to_string()),
+        filters,
+        used_variables,
+        assigned_variables,
+    }
+}
+
+/// Helper function to create a TagValue with ValueKind::Float
+/// Creates a TagValue with empty children
+pub fn float_value(
+    token: Token,
+    value: Token,
+    spread: Option<&str>,
+    filters: Vec<TagValueFilter>,
+    used_variables: Vec<Token>,
+    assigned_variables: Vec<Token>,
+) -> TagValue {
+    TagValue {
+        token,
+        value,
+        children: vec![],
+        kind: ValueKind::Float,
+        spread: spread.map(|s| s.to_string()),
+        filters,
+        used_variables,
+        assigned_variables,
+    }
+}
+
+/// Helper function to create a TagValue with ValueKind::Translation
+/// Creates a TagValue with empty children
+pub fn translation_value(
+    token: Token,
+    value: Token,
+    spread: Option<&str>,
+    filters: Vec<TagValueFilter>,
+    used_variables: Vec<Token>,
+    assigned_variables: Vec<Token>,
+) -> TagValue {
+    TagValue {
+        token,
+        value,
+        children: vec![],
+        kind: ValueKind::Translation,
+        spread: spread.map(|s| s.to_string()),
+        filters,
+        used_variables,
+        assigned_variables,
+    }
+}
+
+/// Helper function to create a plain TagValue with ValueKind::TemplateString.
+/// No filters, no children, and no used/assigned variables
+/// If spread is provided, the token includes the spread prefix, but value does not
+pub fn plain_template_string_value(
+    content: &str,
+    start_index: usize,
+    line: usize,
+    col: usize,
+    spread: Option<&str>,
+) -> TagValue {
+    let (token_val, value_token) = if let Some(spread_str) = spread {
+        let token_content = format!("{}{}", spread_str, content);
+        let value_start_index = start_index + spread_str.len();
+        let value_col = col + spread_str.len();
+        (
+            token(&token_content, start_index, line, col),
+            token(content, value_start_index, line, value_col),
+        )
+    } else {
+        let token_val = token(content, start_index, line, col);
+        (token_val.clone(), token_val)
+    };
+    TagValue {
+        token: token_val,
+        value: value_token,
+        children: vec![],
+        kind: ValueKind::TemplateString,
+        spread: spread.map(|s| s.to_string()),
+        filters: vec![],
+        used_variables: vec![],
+        assigned_variables: vec![],
+    }
+}
+
+/// Helper function to create a TagValue with ValueKind::TemplateString
+/// Creates a TagValue with empty children
+pub fn template_string_value(
+    token: Token,
+    value: Token,
+    spread: Option<&str>,
+    filters: Vec<TagValueFilter>,
+    used_variables: Vec<Token>,
+    assigned_variables: Vec<Token>,
+) -> TagValue {
+    TagValue {
+        token,
+        value,
+        children: vec![],
+        kind: ValueKind::TemplateString,
+        spread: spread.map(|s| s.to_string()),
+        filters,
+        used_variables,
+        assigned_variables,
+    }
+}
+
+/// Helper function to create a plain TagValue with ValueKind::PythonExpr.
+/// No filters, no children, and no used/assigned variables
+/// If spread is provided, the token includes the spread prefix, but value does not
+pub fn plain_python_expr_value(
+    content: &str,
+    start_index: usize,
+    line: usize,
+    col: usize,
+    spread: Option<&str>,
+) -> TagValue {
+    let (token_val, value_token) = if let Some(spread_str) = spread {
+        let token_content = format!("{}{}", spread_str, content);
+        let value_start_index = start_index + spread_str.len();
+        let value_col = col + spread_str.len();
+        (
+            token(&token_content, start_index, line, col),
+            token(content, value_start_index, line, value_col),
+        )
+    } else {
+        let token_val = token(content, start_index, line, col);
+        (token_val.clone(), token_val)
+    };
+    TagValue {
+        token: token_val,
+        value: value_token,
+        children: vec![],
+        kind: ValueKind::PythonExpr,
+        spread: spread.map(|s| s.to_string()),
+        filters: vec![],
+        used_variables: vec![],
+        assigned_variables: vec![],
+    }
+}
+
+/// Helper function to create a TagValue with ValueKind::PythonExpr
+/// Creates a TagValue with empty children
+pub fn python_expr_value(
+    token: Token,
+    value: Token,
+    spread: Option<&str>,
+    filters: Vec<TagValueFilter>,
+    used_variables: Vec<Token>,
+    assigned_variables: Vec<Token>,
+) -> TagValue {
+    TagValue {
+        token,
+        value,
+        children: vec![],
+        kind: ValueKind::PythonExpr,
+        spread: spread.map(|s| s.to_string()),
+        filters,
+        used_variables,
+        assigned_variables,
+    }
+}
+
+pub fn plain_parse_tag_v1(input: &str) -> Result<(Tag, ParserContext), ParseError> {
+    TagParser::parse_tag(input, &ParserConfig::new(TemplateVersion::V1))
+}
+
+pub fn plain_parse_tag_v2(input: &str) -> Result<(Tag, ParserContext), ParseError> {
+    TagParser::parse_tag(input, &ParserConfig::new(TemplateVersion::V2))
+}

--- a/crates/djc-template-parser/tests/tag_compiler.rs
+++ b/crates/djc-template-parser/tests/tag_compiler.rs
@@ -1,0 +1,314 @@
+mod common;
+
+#[cfg(test)]
+mod tests {
+    use super::common::plain_parse_tag_v1;
+    use djc_template_parser::ast::TemplateVersion;
+    use djc_template_parser::error::CompileError;
+    use djc_template_parser::parser_config::{ParserConfig, TagConfig, TagSpec};
+    use djc_template_parser::tag_compiler::compile_tag_attrs;
+    use djc_template_parser::tag_parser::TagParser;
+
+    fn assert_compile_tag_attrs(input: &str, expected: &str) {
+        let (tag, _) = plain_parse_tag_v1(input).unwrap();
+        let attrs = &tag.as_generic().unwrap().attrs;
+        let result = compile_tag_attrs(attrs).unwrap();
+        assert_eq!(result, expected);
+    }
+
+    fn assert_compile_tag_attrs_errors(input: &str, expected: CompileError) {
+        let (tag, _) = plain_parse_tag_v1(input).unwrap();
+        let attrs = &tag.as_generic().unwrap().attrs;
+        let result = compile_tag_attrs(attrs);
+
+        assert!(result.is_err());
+        let error = result.unwrap_err();
+        assert_eq!(error, expected);
+    }
+
+    fn assert_compile_tag_attrs_with_flags(input: &str, expected: &str, flags: &[&str]) {
+        let mut config = ParserConfig::new(TemplateVersion::V1);
+        config.set_tag(TagConfig::PlainTag(TagSpec {
+            tag_name: "my_tag".to_string(),
+            flags: flags.iter().map(|f| f.to_string()).collect(),
+        }));
+        let (tag, _) = TagParser::parse_tag(input, &config).unwrap();
+        let attrs = &tag.as_generic().unwrap().attrs;
+        let result = compile_tag_attrs(attrs).unwrap();
+        assert_eq!(result, expected);
+    }
+
+    #[test]
+    fn test_compile_tag_attrs_positional_after_keyword() {
+        assert_compile_tag_attrs_errors(
+            "{% my_tag key=value second / %}",
+            CompileError::Syntax("positional argument follows keyword argument".to_string()),
+        );
+    }
+
+    #[test]
+    fn test_compile_tag_attrs_no_attributes() {
+        assert_compile_tag_attrs(
+            "{% my_tag / %}",
+            "def compiled_func(context):\n    args = []\n    kwargs = []\n    return args, kwargs",
+        );
+    }
+
+    #[test]
+    fn test_compile_tag_attrs_single_arg() {
+        assert_compile_tag_attrs(
+            "{% my_tag my_var / %}",
+            "def compiled_func(context):\n    args = []\n    kwargs = []\n    args.append(variable(context, source, (10, 16), filters, tags, 'my_var'))\n    return args, kwargs"
+        );
+    }
+
+    #[test]
+    fn test_multiple_args() {
+        assert_compile_tag_attrs(
+            "{% my_tag my_var 'hello' 123 / %}",
+            r#"def compiled_func(context):
+    args = []
+    kwargs = []
+    args.append(variable(context, source, (10, 16), filters, tags, 'my_var'))
+    args.append('hello')
+    args.append(123)
+    return args, kwargs"#,
+        );
+    }
+
+    #[test]
+    fn test_single_kwarg() {
+        assert_compile_tag_attrs(
+            "{% my_tag key=my_var / %}",
+            r#"def compiled_func(context):
+    args = []
+    kwargs = []
+    kwargs.append(('key', variable(context, source, (14, 20), filters, tags, 'my_var')))
+    return args, kwargs"#,
+        );
+    }
+
+    #[test]
+    fn test_multiple_kwargs() {
+        assert_compile_tag_attrs(
+            "{% my_tag key1=my_var key2='hello' / %}",
+            r#"def compiled_func(context):
+    args = []
+    kwargs = []
+    kwargs.append(('key1', variable(context, source, (15, 21), filters, tags, 'my_var')))
+    kwargs.append(('key2', 'hello'))
+    return args, kwargs"#,
+        );
+    }
+
+    #[test]
+    fn test_mixed_args_and_kwargs() {
+        assert_compile_tag_attrs(
+            "{% my_tag 42 key='value' / %}",
+            r#"def compiled_func(context):
+    args = []
+    kwargs = []
+    args.append(42)
+    kwargs.append(('key', 'value'))
+    return args, kwargs"#,
+        );
+    }
+
+    #[test]
+    fn test_spread_kwargs() {
+        assert_compile_tag_attrs(
+            "{% my_tag ...options key='value' / %}",
+            r#"def compiled_func(context):
+    args = []
+    kwargs = []
+    kwarg_seen = False
+    kwarg_seen = _handle_spread(variable(context, source, (10, 20), filters, tags, 'options'), """options""", args, kwargs, kwarg_seen)
+    kwargs.append(('key', 'value'))
+    kwarg_seen = True
+    return args, kwargs"#,
+        );
+    }
+
+    #[test]
+    fn test_spread_kwargs_order_preserved() {
+        assert_compile_tag_attrs(
+            "{% my_tag key1='value1' ...options key2='value2' / %}",
+            r#"def compiled_func(context):
+    args = []
+    kwargs = []
+    kwargs.append(('key1', 'value1'))
+    kwarg_seen = True
+    kwarg_seen = _handle_spread(variable(context, source, (24, 34), filters, tags, 'options'), """options""", args, kwargs, kwarg_seen)
+    kwargs.append(('key2', 'value2'))
+    return args, kwargs"#,
+        );
+    }
+
+    #[test]
+    fn test_template_string_arg() {
+        assert_compile_tag_attrs(
+            "{% my_tag \"{{ my_var }}\" / %}",
+            r#"def compiled_func(context):
+    args = []
+    kwargs = []
+    args.append(template_string(context, source, (10, 24), filters, tags, "{{ my_var }}"))
+    return args, kwargs"#,
+        );
+    }
+
+    #[test]
+    fn test_translation_arg() {
+        assert_compile_tag_attrs(
+            "{% my_tag _('hello world') / %}",
+            r#"def compiled_func(context):
+    args = []
+    kwargs = []
+    args.append(translation(context, source, (10, 26), filters, tags, 'hello world'))
+    return args, kwargs"#,
+        );
+    }
+
+    #[test]
+    fn test_filter() {
+        assert_compile_tag_attrs(
+            "{% my_tag my_var|upper / %}",
+            r#"def compiled_func(context):
+    args = []
+    kwargs = []
+    args.append(filter(context, source, (16, 22), filters, tags, 'upper', variable(context, source, (10, 22), filters, tags, 'my_var'), None))
+    return args, kwargs"#,
+        );
+    }
+
+    #[test]
+    fn test_filter_with_arg() {
+        assert_compile_tag_attrs(
+            "{% my_tag my_var|default:'none' / %}",
+            r#"def compiled_func(context):
+    args = []
+    kwargs = []
+    args.append(filter(context, source, (16, 31), filters, tags, 'default', variable(context, source, (10, 31), filters, tags, 'my_var'), 'none'))
+    return args, kwargs"#,
+        );
+    }
+
+    #[test]
+    fn test_multiple_filters() {
+        assert_compile_tag_attrs(
+            "{% my_tag my_var|upper|default:'none' / %}",
+            r#"def compiled_func(context):
+    args = []
+    kwargs = []
+    args.append(filter(context, source, (22, 37), filters, tags, 'default', filter(context, source, (16, 22), filters, tags, 'upper', variable(context, source, (10, 37), filters, tags, 'my_var'), None), 'none'))
+    return args, kwargs"#,
+        );
+    }
+
+    #[test]
+    fn test_list_value() {
+        assert_compile_tag_attrs(
+            "{% my_tag [1, my_var] / %}",
+            r#"def compiled_func(context):
+    args = []
+    kwargs = []
+    args.append([1, variable(context, source, (14, 20), filters, tags, 'my_var')])
+    return args, kwargs"#,
+        );
+    }
+
+    #[test]
+    fn test_dict_value() {
+        assert_compile_tag_attrs(
+            "{% my_tag {'key': my_var} / %}",
+            r#"def compiled_func(context):
+    args = []
+    kwargs = []
+    args.append({'key': variable(context, source, (18, 24), filters, tags, 'my_var')})
+    return args, kwargs"#,
+        );
+    }
+
+    #[test]
+    fn test_multiple_spreads() {
+        assert_compile_tag_attrs(
+            "{% my_tag key1='value1' ...options1 key2='value2' ...options2 / %}",
+            r#"def compiled_func(context):
+    args = []
+    kwargs = []
+    kwargs.append(('key1', 'value1'))
+    kwarg_seen = True
+    kwarg_seen = _handle_spread(variable(context, source, (24, 35), filters, tags, 'options1'), """options1""", args, kwargs, kwarg_seen)
+    kwargs.append(('key2', 'value2'))
+    kwarg_seen = _handle_spread(variable(context, source, (50, 61), filters, tags, 'options2'), """options2""", args, kwargs, kwarg_seen)
+    return args, kwargs"#,
+        );
+    }
+
+    #[test]
+    fn test_compiler_skips_flags() {
+        assert_compile_tag_attrs_with_flags(
+            "{% my_tag key='value' disabled / %}",
+            r#"def compiled_func(context):
+    args = []
+    kwargs = []
+    kwargs.append(('key', 'value'))
+    return args, kwargs"#,
+            &["disabled"],
+        );
+    }
+
+    #[test]
+    fn test_python_expression() {
+        assert_compile_tag_attrs(
+            "{% my_tag (items + 1) / %}",
+            "def compiled_func(context):\n    args = []\n    kwargs = []\n    args.append(expr(context, source, (10, 21), filters, tags, \"\"\"(items + 1)\"\"\"))\n    return args, kwargs"
+        );
+    }
+
+    // ###########################################
+    // PARAMETER ORDERING TESTS
+    // ###########################################
+
+    #[test]
+    fn test_arg_after_kwarg_error() {
+        // The parser should allow this syntax, but the compiler should raise an error
+        assert_compile_tag_attrs_errors(
+            r#"{% component key="value" positional_arg %}"#,
+            CompileError::Syntax("positional argument follows keyword argument".to_string()),
+        );
+    }
+
+    #[test]
+    fn test_arg_after_spread() {
+        // Altho we can see that we're spreading a literal dict,
+        // spreads are evaluated only at runtime, so this should parse and compile.
+        assert_compile_tag_attrs(
+            r#"{% component ...{"key": "value"} positional_arg %}"#,
+            r#"def compiled_func(context):
+    args = []
+    kwargs = []
+    kwarg_seen = False
+    kwarg_seen = _handle_spread({"key": "value"}, """{\"key\": \"value\"}""", args, kwargs, kwarg_seen)
+    if kwarg_seen:
+        raise SyntaxError("positional argument follows keyword argument")
+    args.append(variable(context, source, (33, 47), filters, tags, 'positional_arg'))
+    return args, kwargs"#,
+        );
+    }
+
+    #[test]
+    fn test_kwarg_after_spread() {
+        // This is totally fine
+        assert_compile_tag_attrs(
+            r#"{% component ...[1, 2, 3] key="value" %}"#,
+            r#"def compiled_func(context):
+    args = []
+    kwargs = []
+    kwarg_seen = False
+    kwarg_seen = _handle_spread([1, 2, 3], """[1, 2, 3]""", args, kwargs, kwarg_seen)
+    kwargs.append(('key', "value"))
+    kwarg_seen = True
+    return args, kwargs"#,
+        );
+    }
+}

--- a/crates/djc-template-parser/tests/tag_parser.rs
+++ b/crates/djc-template-parser/tests/tag_parser.rs
@@ -1,0 +1,829 @@
+// Other test files `tag_parser_<data_type>.rs` all test the same cases, but with different data types.
+// This file tests any other edge cases that don't fit those other files.
+
+mod common;
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashSet;
+
+    use super::common::{
+        plain_int_value, plain_parse_tag_v1, plain_string_value, plain_variable_value, tag_attr,
+        token, variable_value,
+    };
+    use djc_template_parser::ast::{
+        GenericTag, Tag, TagMeta, TagValue, TagValueFilter, TemplateVersion, ValueChild, ValueKind,
+    };
+    use djc_template_parser::parser_config::{
+        ParserConfig, TagConfig, TagSectionSpec, TagSpec, TagWithBodySpec,
+    };
+    use djc_template_parser::tag_parser::TagParser;
+
+    // #######################################
+    // TAG
+    // #######################################
+
+    #[test]
+    fn test_tag_no_spaces_between_delimiters() {
+        let input = "{%my_tag%}";
+        let (result, _context) = plain_parse_tag_v1(input).unwrap();
+
+        assert_eq!(
+            result,
+            Tag::Generic(GenericTag {
+                meta: TagMeta {
+                    token: token("{%my_tag%}", 0, 1, 1),
+                    name: token("my_tag", 2, 1, 3),
+                    used_variables: vec![],
+                    assigned_variables: vec![],
+                },
+                attrs: vec![],
+                is_self_closing: false,
+            })
+        );
+    }
+
+    #[test]
+    fn test_tag_no_spaces_between_delimiters_with_args() {
+        let input = "{%my_tag key=val%}";
+        let (result, _context) = plain_parse_tag_v1(input).unwrap();
+
+        assert_eq!(
+            result,
+            Tag::Generic(GenericTag {
+                meta: TagMeta {
+                    token: token("{%my_tag key=val%}", 0, 1, 1),
+                    name: token("my_tag", 2, 1, 3),
+                    used_variables: vec![token("val", 13, 1, 14)],
+                    assigned_variables: vec![],
+                },
+                attrs: vec![tag_attr(
+                    Some(token("key", 9, 1, 10)),
+                    plain_variable_value("val", 13, 1, 14, None),
+                    false
+                )],
+                is_self_closing: false,
+            })
+        );
+    }
+
+    // #######################################
+    // ARGS
+    // #######################################
+
+    #[test]
+    fn test_arg_invalid() {
+        let inputs = vec!["{% my_tag .arg %}"];
+
+        for input in inputs {
+            assert!(
+                plain_parse_tag_v1(input).is_err(),
+                "Input should fail: {}",
+                input
+            );
+        }
+    }
+
+    // #######################################
+    // KWARGS
+    // #######################################
+
+    #[test]
+    fn test_kwarg_special_chars() {
+        let input = r#"{% my_tag @click.stop=handler attr:key=val %}"#;
+        let (result, _context) = plain_parse_tag_v1(input).unwrap();
+        assert_eq!(
+            result,
+            Tag::Generic(GenericTag {
+                meta: TagMeta {
+                    token: token(r#"{% my_tag @click.stop=handler attr:key=val %}"#, 0, 1, 1),
+                    name: token("my_tag", 3, 1, 4),
+                    used_variables: vec![token("handler", 22, 1, 23), token("val", 39, 1, 40)],
+                    assigned_variables: vec![],
+                },
+                attrs: vec![
+                    tag_attr(
+                        Some(token("@click.stop", 10, 1, 11)),
+                        plain_variable_value("handler", 22, 1, 23, None),
+                        false
+                    ),
+                    tag_attr(
+                        Some(token("attr:key", 30, 1, 31)),
+                        plain_variable_value("val", 39, 1, 40, None),
+                        false
+                    )
+                ],
+                is_self_closing: false,
+            }),
+        );
+    }
+
+    #[test]
+    fn test_kwarg_invalid() {
+        let inputs = vec![
+            "{% my_tag key= val %}",
+            "{% my_tag key =val %}",
+            "{% my_tag key = val %}",
+            "{% my_tag key1= val1 key2 =val2 key3 = val3 %}",
+            "{% my_tag :key=val %}",
+            "{% my_tag .key=val %}",
+            "{% my_tag ...key=val %}",
+            "{% my_tag _('hello')=val %}",
+            r#"{% my_tag "key"=val %}"#,
+            "{% my_tag key[0]=val %}",
+        ];
+
+        for input in inputs {
+            assert!(
+                plain_parse_tag_v1(input).is_err(),
+                "Input should fail: {}",
+                input
+            );
+        }
+    }
+
+    // #######################################
+    // SPREADS
+    // #######################################
+
+    #[test]
+    fn test_spread_between() {
+        // Test spread with other attributes
+        let input = "{% my_tag key1=val1 ...myvalue key2=val2 %}";
+        let (result, _context) = plain_parse_tag_v1(input).unwrap();
+        assert_eq!(
+            result,
+            Tag::Generic(GenericTag {
+                meta: TagMeta {
+                    token: token("{% my_tag key1=val1 ...myvalue key2=val2 %}", 0, 1, 1),
+                    name: token("my_tag", 3, 1, 4),
+                    used_variables: vec![
+                        token("val1", 15, 1, 16),
+                        token("myvalue", 23, 1, 24),
+                        token("val2", 36, 1, 37)
+                    ],
+                    assigned_variables: vec![],
+                },
+                attrs: vec![
+                    tag_attr(
+                        Some(token("key1", 10, 1, 11)),
+                        plain_variable_value("val1", 15, 1, 16, None),
+                        false
+                    ),
+                    tag_attr(
+                        None,
+                        plain_variable_value("myvalue", 20, 1, 21, Some("...")),
+                        false
+                    ),
+                    tag_attr(
+                        Some(token("key2", 31, 1, 32)),
+                        plain_variable_value("val2", 36, 1, 37, None),
+                        false
+                    )
+                ],
+                is_self_closing: false,
+            }),
+        );
+    }
+
+    #[test]
+    fn test_spread_multiple() {
+        let input = "{% my_tag ...dict1 key=val ...dict2 %}";
+        let (result, _context) = plain_parse_tag_v1(input).unwrap();
+        assert_eq!(
+            result,
+            Tag::Generic(GenericTag {
+                meta: TagMeta {
+                    token: token("{% my_tag ...dict1 key=val ...dict2 %}", 0, 1, 1),
+                    name: token("my_tag", 3, 1, 4),
+                    used_variables: vec![
+                        token("dict1", 13, 1, 14),
+                        token("val", 23, 1, 24),
+                        token("dict2", 30, 1, 31)
+                    ],
+                    assigned_variables: vec![],
+                },
+                attrs: vec![
+                    tag_attr(
+                        None,
+                        plain_variable_value("dict1", 10, 1, 11, Some("...")),
+                        false
+                    ),
+                    tag_attr(
+                        Some(token("key", 19, 1, 20)),
+                        plain_variable_value("val", 23, 1, 24, None),
+                        false
+                    ),
+                    tag_attr(
+                        None,
+                        plain_variable_value("dict2", 27, 1, 28, Some("...")),
+                        false
+                    )
+                ],
+                is_self_closing: false,
+            }),
+        );
+    }
+
+    // NOTE: While there cannot be whitespace between the attribute and `...`,
+    //       there CAN be whitespace between `*` / `**` and the value,
+    //       because we're scoped inside `{ .. }` dict or `[ .. ]` list.
+    #[test]
+    fn test_spread_whitespace() {
+        let input = r#"{% component dict={"a": "b", ** my_attr} list=["a", * my_list] %}"#;
+        let (result, _context) = plain_parse_tag_v1(input).unwrap();
+
+        // Manually construct spread variable values to match parser output
+        // The parser includes the position where ** or * starts (before whitespace)
+        let my_attr_spread = TagValue {
+            token: token("** my_attr", 29, 1, 30), // Starts at 29 (where ** begins), includes space
+            value: token("my_attr", 32, 1, 33),    // Value token (no whitespace)
+            children: vec![],
+            kind: ValueKind::Variable,
+            spread: Some("**".to_string()),
+            filters: vec![],
+            used_variables: vec![token("my_attr", 32, 1, 33)],
+            assigned_variables: vec![],
+        };
+
+        let my_list_spread = TagValue {
+            token: token("* my_list", 52, 1, 53), // Starts at 52 (where * begins), includes space
+            value: token("my_list", 54, 1, 55),   // Value token (no whitespace)
+            children: vec![],
+            kind: ValueKind::Variable,
+            spread: Some("*".to_string()),
+            filters: vec![],
+            used_variables: vec![token("my_list", 54, 1, 55)],
+            assigned_variables: vec![],
+        };
+
+        let dict_value = TagValue {
+            token: token(r#"{"a": "b", ** my_attr}"#, 18, 1, 19),
+            value: token(r#"{"a": "b", ** my_attr}"#, 18, 1, 19),
+            children: vec![
+                ValueChild::Value(plain_string_value(r#""a""#, 19, 1, 20, None)),
+                ValueChild::Value(plain_string_value(r#""b""#, 24, 1, 25, None)),
+                ValueChild::Value(my_attr_spread),
+            ],
+            kind: ValueKind::Dict,
+            spread: None,
+            filters: vec![],
+            used_variables: vec![],
+            assigned_variables: vec![],
+        };
+
+        let list_value = TagValue {
+            token: token(r#"["a", * my_list]"#, 46, 1, 47),
+            value: token(r#"["a", * my_list]"#, 46, 1, 47),
+            children: vec![
+                ValueChild::Value(plain_string_value(r#""a""#, 47, 1, 48, None)),
+                ValueChild::Value(my_list_spread),
+            ],
+            kind: ValueKind::List,
+            spread: None,
+            filters: vec![],
+            used_variables: vec![],
+            assigned_variables: vec![],
+        };
+
+        assert_eq!(
+            result,
+            Tag::Generic(GenericTag {
+                meta: TagMeta {
+                    token: token(
+                        r#"{% component dict={"a": "b", ** my_attr} list=["a", * my_list] %}"#,
+                        0,
+                        1,
+                        1
+                    ),
+                    name: token("component", 3, 1, 4),
+                    used_variables: vec![token("my_attr", 32, 1, 33), token("my_list", 54, 1, 55)],
+                    assigned_variables: vec![],
+                },
+                attrs: vec![
+                    tag_attr(Some(token("dict", 13, 1, 14)), dict_value, false),
+                    tag_attr(Some(token("list", 41, 1, 42)), list_value, false),
+                ],
+                is_self_closing: false,
+            })
+        );
+    }
+
+    #[test]
+    fn test_spread_invalid() {
+        // Test spread missing value
+        let input = "{% my_tag ... %}";
+        assert!(
+            plain_parse_tag_v1(input).is_err(),
+            "Should not allow spread operator without a value"
+        );
+        // Test spread whitespace between operator and value
+        let input = "{% my_tag ...  myvalue %}";
+        assert!(
+            plain_parse_tag_v1(input).is_err(),
+            "Should not allow spread operator with whitespace between operator and value"
+        );
+
+        // Test spread in key position
+        let input = "{% my_tag ...key=val %}";
+        assert!(
+            plain_parse_tag_v1(input).is_err(),
+            "Should not allow spread operator in key position"
+        );
+
+        // Test spread in value position of key-value pair
+        let input = "{% my_tag key=...val %}";
+        assert!(
+            plain_parse_tag_v1(input).is_err(),
+            "Should not allow spread operator in value position of key-value pair"
+        );
+
+        // Test spread operator inside list
+        let input = "{% my_tag [1, ...my_list, 2] %}";
+        assert!(
+            plain_parse_tag_v1(input).is_err(),
+            "Should not allow ... spread operator inside list"
+        );
+
+        // Test spread operator inside list with filters
+        let input = "{% my_tag [1, ...my_list|filter, 2] %}";
+        assert!(
+            plain_parse_tag_v1(input).is_err(),
+            "Should not allow ... spread operator inside list with filters"
+        );
+
+        // Test spread operator inside dict
+        let input = "{% my_tag {...my_dict} %}";
+        assert!(
+            plain_parse_tag_v1(input).is_err(),
+            "Should not allow ... spread operator inside dict"
+        );
+
+        // Test spread operator inside dict with filters
+        let input = "{% my_tag {...my_dict|filter} %}";
+        assert!(
+            plain_parse_tag_v1(input).is_err(),
+            "Should not allow ... spread operator inside dict with filters"
+        );
+    }
+
+    // #######################################
+    // SELF-CLOSING TAGS
+    // #######################################
+
+    #[test]
+    fn test_self_closing_tag() {
+        let input = "{% my_tag / %}";
+        let (result, _context) = plain_parse_tag_v1(input).unwrap();
+
+        assert_eq!(
+            result,
+            Tag::Generic(GenericTag {
+                meta: TagMeta {
+                    token: token("{% my_tag / %}", 0, 1, 1),
+                    name: token("my_tag", 3, 1, 4),
+                    used_variables: vec![],
+                    assigned_variables: vec![],
+                },
+                attrs: vec![],
+                is_self_closing: true,
+            })
+        );
+    }
+
+    #[test]
+    fn test_self_closing_tag_with_args() {
+        let input = "{% my_tag key=val / %}";
+        let (result, _context) = plain_parse_tag_v1(input).unwrap();
+
+        assert_eq!(
+            result,
+            Tag::Generic(GenericTag {
+                meta: TagMeta {
+                    token: token("{% my_tag key=val / %}", 0, 1, 1),
+                    name: token("my_tag", 3, 1, 4),
+                    used_variables: vec![token("val", 14, 1, 15)],
+                    assigned_variables: vec![],
+                },
+                attrs: vec![tag_attr(
+                    Some(token("key", 10, 1, 11)),
+                    plain_variable_value("val", 14, 1, 15, None),
+                    false
+                )],
+                is_self_closing: true,
+            })
+        );
+    }
+
+    #[test]
+    fn test_self_closing_tag_in_middle_errors() {
+        let input = "{% my_tag / key=val %}";
+        let result = plain_parse_tag_v1(input);
+        assert!(
+            result.is_err(),
+            "Self-closing slash in the middle should be an error"
+        );
+    }
+
+    #[test]
+    fn test_self_closing_tag_no_spaces() {
+        let input = "{%my_tag/%}";
+        let (result, _context) = plain_parse_tag_v1(input).unwrap();
+
+        assert_eq!(
+            result,
+            Tag::Generic(GenericTag {
+                meta: TagMeta {
+                    token: token("{%my_tag/%}", 0, 1, 1),
+                    name: token("my_tag", 2, 1, 3),
+                    used_variables: vec![],
+                    assigned_variables: vec![],
+                },
+                attrs: vec![],
+                is_self_closing: true,
+            })
+        );
+    }
+
+    #[test]
+    fn test_self_closing_tag_no_spaces_with_args() {
+        let input = "{%my_tag key=val/%}";
+        let (result, _context) = plain_parse_tag_v1(input).unwrap();
+
+        assert_eq!(
+            result,
+            Tag::Generic(GenericTag {
+                meta: TagMeta {
+                    token: token("{%my_tag key=val/%}", 0, 1, 1),
+                    name: token("my_tag", 2, 1, 3),
+                    used_variables: vec![token("val", 13, 1, 14)],
+                    assigned_variables: vec![],
+                },
+                attrs: vec![tag_attr(
+                    Some(token("key", 9, 1, 10)),
+                    plain_variable_value("val", 13, 1, 14, None),
+                    false
+                )],
+                is_self_closing: true,
+            })
+        );
+    }
+
+    // #######################################
+    // FILTERS
+    // #######################################
+
+    #[test]
+    fn test_filter_multiple() {
+        let input = "{% my_tag value|lower|title:arg|default:'hello' %}";
+        let (result, _context) = plain_parse_tag_v1(input).unwrap();
+        assert_eq!(
+            result,
+            Tag::Generic(GenericTag {
+                meta: TagMeta {
+                    token: token(
+                        "{% my_tag value|lower|title:arg|default:'hello' %}",
+                        0,
+                        1,
+                        1
+                    ),
+                    name: token("my_tag", 3, 1, 4),
+                    used_variables: vec![token("value", 10, 1, 11), token("arg", 28, 1, 29)],
+                    assigned_variables: vec![],
+                },
+                attrs: vec![tag_attr(
+                    None,
+                    variable_value(
+                        token("value|lower|title:arg|default:'hello'", 10, 1, 11),
+                        token("value", 10, 1, 11),
+                        None,
+                        vec![
+                            TagValueFilter {
+                                name: token("lower", 16, 1, 17),
+                                token: token("|lower", 15, 1, 16),
+                                arg: None,
+                            },
+                            TagValueFilter {
+                                name: token("title", 22, 1, 23),
+                                token: token("|title:arg", 21, 1, 22),
+                                arg: Some(plain_variable_value("arg", 28, 1, 29, None)),
+                            },
+                            TagValueFilter {
+                                name: token("default", 32, 1, 33),
+                                token: token("|default:'hello'", 31, 1, 32),
+                                arg: Some(plain_string_value("'hello'", 40, 1, 41, None)),
+                            }
+                        ],
+                        vec![],
+                        vec![],
+                    ),
+                    false,
+                )],
+                is_self_closing: false,
+            }),
+        );
+    }
+
+    #[test]
+    fn test_filter_invalid() {
+        // Test using colon instead of pipe
+        let input = "{% my_tag value:filter %}";
+        assert!(
+            plain_parse_tag_v1(input).is_err(),
+            "Should not allow colon instead of pipe for filter"
+        );
+
+        // Test using colon with filter argument
+        let input = "{% my_tag value:filter:arg %}";
+        assert!(
+            plain_parse_tag_v1(input).is_err(),
+            "Should not allow colon instead of pipe for filter with argument"
+        );
+
+        // Test using colon after a valid filter
+        let input = "{% my_tag value|filter:arg:filter2 %}";
+        assert!(
+            plain_parse_tag_v1(input).is_err(),
+            "Should not allow colon to start a new filter after an argument"
+        );
+    }
+
+    // #######################################
+    // FLAGS
+    // #######################################
+
+    #[test]
+    fn test_flag() {
+        let input = "{% my_tag 123 my_flag key='val' %}";
+        let mut config = ParserConfig::new(TemplateVersion::V1);
+        config.set_tag(TagConfig::PlainTag(TagSpec {
+            tag_name: "my_tag".to_string(),
+            flags: HashSet::from(["my_flag".to_string()]),
+        }));
+        let (result, _context) = TagParser::parse_tag(input, &config).unwrap();
+        assert_eq!(
+            result,
+            Tag::Generic(GenericTag {
+                meta: TagMeta {
+                    token: token("{% my_tag 123 my_flag key='val' %}", 0, 1, 1),
+                    name: token("my_tag", 3, 1, 4),
+                    used_variables: vec![],
+                    assigned_variables: vec![],
+                },
+                attrs: vec![
+                    tag_attr(None, plain_int_value("123", 10, 1, 11, None), false),
+                    // This `true` is what we're testing
+                    tag_attr(None, plain_variable_value("my_flag", 14, 1, 15, None), true),
+                    tag_attr(
+                        Some(token("key", 22, 1, 23)),
+                        plain_string_value("'val'", 26, 1, 27, None),
+                        false
+                    ),
+                ],
+                is_self_closing: false,
+            }),
+        );
+    }
+
+    #[test]
+    fn test_flag_not_as_flag() {
+        // Same as test_flag, but `my_flag` is not in the flags set
+        let input = "{% my_tag 123 my_flag key='val' %}";
+        let config = ParserConfig::new(TemplateVersion::V1);
+        let (result, _context) = TagParser::parse_tag(input, &config).unwrap();
+        assert_eq!(
+            result,
+            Tag::Generic(GenericTag {
+                meta: TagMeta {
+                    token: token("{% my_tag 123 my_flag key='val' %}", 0, 1, 1),
+                    name: token("my_tag", 3, 1, 4),
+                    used_variables: vec![token("my_flag", 14, 1, 15)],
+                    assigned_variables: vec![],
+                },
+                attrs: vec![
+                    tag_attr(None, plain_int_value("123", 10, 1, 11, None), false),
+                    tag_attr(
+                        None,
+                        plain_variable_value("my_flag", 14, 1, 15, None),
+                        // This `false` is what we're testing
+                        false
+                    ),
+                    tag_attr(
+                        Some(token("key", 22, 1, 23)),
+                        plain_string_value("'val'", 26, 1, 27, None),
+                        false
+                    ),
+                ],
+                is_self_closing: false,
+            }),
+        );
+    }
+
+    #[test]
+    fn test_flag_as_spread() {
+        let input = "{% my_tag ...my_flag %}";
+        let mut config = ParserConfig::new(TemplateVersion::V1);
+        config.set_tag(TagConfig::PlainTag(TagSpec {
+            tag_name: "my_tag".to_string(),
+            flags: HashSet::from(["my_flag".to_string()]),
+        }));
+        let (result, _context) = TagParser::parse_tag(input, &config).unwrap();
+
+        assert_eq!(
+            result,
+            Tag::Generic(GenericTag {
+                meta: TagMeta {
+                    token: token("{% my_tag ...my_flag %}", 0, 1, 1),
+                    name: token("my_tag", 3, 1, 4),
+                    used_variables: vec![token("my_flag", 13, 1, 14)],
+                    assigned_variables: vec![],
+                },
+                attrs: vec![tag_attr(
+                    None,
+                    plain_variable_value("my_flag", 10, 1, 11, Some("...")),
+                    false, // This is what we're testing
+                )],
+                is_self_closing: false,
+            }),
+        );
+    }
+
+    #[test]
+    fn test_flag_as_kwarg() {
+        let input = "{% my_tag my_flag=123 %}";
+        let mut config = ParserConfig::new(TemplateVersion::V1);
+        config.set_tag(TagConfig::PlainTag(TagSpec {
+            tag_name: "my_tag".to_string(),
+            flags: HashSet::from(["my_flag".to_string()]),
+        }));
+        let (result, _context) = TagParser::parse_tag(input, &config).unwrap();
+
+        assert_eq!(
+            result,
+            Tag::Generic(GenericTag {
+                meta: TagMeta {
+                    token: token("{% my_tag my_flag=123 %}", 0, 1, 1),
+                    name: token("my_tag", 3, 1, 4),
+                    used_variables: vec![],
+                    assigned_variables: vec![],
+                },
+                attrs: vec![tag_attr(
+                    Some(token("my_flag", 10, 1, 11)),
+                    plain_int_value("123", 18, 1, 19, None),
+                    false
+                )],
+                is_self_closing: false,
+            }),
+        );
+    }
+
+    #[test]
+    fn test_flag_duplicate() {
+        let input = "{% my_tag my_flag my_flag %}";
+        let mut config = ParserConfig::new(TemplateVersion::V1);
+        config.set_tag(TagConfig::PlainTag(TagSpec {
+            tag_name: "my_tag".to_string(),
+            flags: HashSet::from(["my_flag".to_string()]),
+        }));
+        let result = TagParser::parse_tag(input, &config);
+        assert!(result.is_err());
+        assert_eq!(
+            result.unwrap_err().to_string(),
+            "Parse error:  --> 1:19\n  |\n1 | {% my_tag my_flag my_flag %}\n  |                   ^-----^\n  |\n  = Flag 'my_flag' may be specified only once."
+        );
+    }
+
+    #[test]
+    fn test_flag_case_sensitive() {
+        let input = "{% my_tag my_flag %}";
+        let mut config = ParserConfig::new(TemplateVersion::V1);
+        config.set_tag(TagConfig::PlainTag(TagSpec {
+            tag_name: "my_tag".to_string(),
+            flags: HashSet::from(["MY_FLAG".to_string()]), // Different case
+        }));
+        let (result, _context) = TagParser::parse_tag(input, &config).unwrap();
+
+        assert_eq!(
+            result,
+            Tag::Generic(GenericTag {
+                meta: TagMeta {
+                    token: token("{% my_tag my_flag %}", 0, 1, 1),
+                    name: token("my_tag", 3, 1, 4),
+                    used_variables: vec![token("my_flag", 10, 1, 11)],
+                    assigned_variables: vec![],
+                },
+                attrs: vec![tag_attr(
+                    None,
+                    plain_variable_value("my_flag", 10, 1, 11, None),
+                    false, // This is what we're testing
+                )],
+                is_self_closing: false,
+            }),
+        );
+    }
+
+    // #######################################
+    // CONFIG
+    // #######################################
+
+    #[test]
+    fn test_config_tag_sections_must_be_unique_from_tags() {
+        let mut config = ParserConfig::new(TemplateVersion::V1);
+        config.set_tag(TagConfig::TagWithBody(TagWithBodySpec {
+            tag: TagSpec {
+                tag_name: "tag1".to_string(),
+                flags: HashSet::new(),
+            },
+            sections: vec![TagSectionSpec {
+                tag: TagSpec {
+                    tag_name: "conflict".to_string(),
+                    flags: HashSet::new(),
+                },
+                repeatable: false,
+            }],
+        }));
+        config.set_tag(TagConfig::PlainTag(TagSpec {
+            tag_name: "conflict".to_string(), // This conflicts with the section tag name
+            flags: HashSet::new(),
+        }));
+
+        let result = TagParser::parse_tag("{% my_tag %}", &config);
+        assert!(result.is_err());
+        assert!(result
+            .unwrap_err()
+            .to_string()
+            .contains("conflicts with existing tag name"));
+    }
+
+    #[test]
+    fn test_config_tag_sections_must_be_unique() {
+        // Section tag name conflicts with another section tag name
+        // Note: The validation only works if sections have flags, as build_flags_map
+        // only tracks section names that have flags
+        let mut config = ParserConfig::new(TemplateVersion::V1);
+        config.set_tag(TagConfig::TagWithBody(TagWithBodySpec {
+            tag: TagSpec {
+                tag_name: "tag1".to_string(),
+                flags: HashSet::new(),
+            },
+            sections: vec![TagSectionSpec {
+                tag: TagSpec {
+                    tag_name: "conflict".to_string(),
+                    flags: HashSet::from(["flag1".to_string()]), // Add flag so it's tracked
+                },
+                repeatable: false,
+            }],
+        }));
+        config.set_tag(TagConfig::TagWithBody(TagWithBodySpec {
+            tag: TagSpec {
+                tag_name: "tag2".to_string(),
+                flags: HashSet::new(),
+            },
+            sections: vec![TagSectionSpec {
+                tag: TagSpec {
+                    tag_name: "conflict".to_string(), // This conflicts with tag1's section
+                    flags: HashSet::from(["flag2".to_string()]), // Add flag so it's tracked
+                },
+                repeatable: false,
+            }],
+        }));
+
+        let result = config.build_flags_map();
+        assert!(result.is_err());
+        assert!(result
+            .unwrap_err()
+            .contains("conflicts with another section tag"));
+    }
+
+    #[test]
+    fn test_config_for_tag_not_allowed() {
+        let mut config = ParserConfig::new(TemplateVersion::V1);
+        config.set_tag(TagConfig::PlainTag(TagSpec {
+            tag_name: "for".to_string(), // This should fail
+            flags: HashSet::new(),
+        }));
+
+        let result = config.build_flags_map();
+        assert!(result.is_err());
+        assert_eq!(
+            result.unwrap_err(),
+            "Tag 'for' is reserved and cannot be specified in tag config"
+        );
+    }
+
+    #[test]
+    fn test_config_correctly_passed_to_parsing_context() {
+        // Verify that config (specifically flags) are correctly passed to parsing context
+        let input = "{% my_tag my_flag %}";
+        let mut config = ParserConfig::new(TemplateVersion::V1);
+        config.set_tag(TagConfig::PlainTag(TagSpec {
+            tag_name: "my_tag".to_string(),
+            flags: HashSet::from(["my_flag".to_string()]),
+        }));
+        let (_result, context) = TagParser::parse_tag(input, &config).unwrap();
+
+        // Verify the flag is recognized
+        let flags = context.flags.get("my_tag").unwrap();
+        assert!(flags.contains("my_flag"));
+    }
+}

--- a/crates/djc-template-parser/tests/tag_parser_comment.rs
+++ b/crates/djc-template-parser/tests/tag_parser_comment.rs
@@ -1,0 +1,933 @@
+// ============================================================================
+// COMMENT PLACEMENT LOCATIONS
+// ============================================================================
+//
+// Based on grammar.pest analysis, comments {# ... #} can appear in the following locations:
+//
+// 1. TEMPLATE LEVEL (SKIPPED - requires template_parser):
+//    - Between template elements (text, tags, expressions)
+//    - Inside expressions: {{ {# comment #} value {# comment #} }}
+//    - In verbatim start/end tags: {% {# comment #} verbatim {# comment #} %}
+//    - In comment start/end tags: {% {# comment #} comment {# comment #} %}
+//
+// 2. TAG DELIMITERS:
+//    - Before tag_content: {% {# comment #} tag_name ... %}
+//    - After tag_content: {% ... tag_name {# comment #} %}
+//
+// 3. TAG CONTENT (Generic Tags):
+//    - Between tag_name and first attribute: tag_name {# comment #} key=val
+//    - Between attributes: key1=val1 {# comment #} key2=val2
+//    - After last attribute, before self-closing slash: key=val {# comment #} /
+//    - After self-closing slash, before closing %}: / {# comment #} %}
+//
+// 4. FOR LOOP TAGS:
+//    - Between "for" and forloop_tag_content: for {# comment #} item in items
+//    - Between loop variables: for x {# comment #}, {# comment #} y in items
+//    - Between forloop_vars and "in": for x, y {# comment #} in items
+//    - Between "in" and iterable: for x in {# comment #} items
+//
+// 5. ATTRIBUTES:
+//    - NOT ALLOWED: Around spread operator: ...{# comment #}value
+//    - NOT ALLOWED: Between key and "=" (atomic rule: key = @{ ... })
+//    - NOT ALLOWED: Between "=" and value (atomic rule: key ~ "=" ~ filtered_value)
+//
+// 6. FILTERS:
+//    - Between value and filter chain: value {# comment #} |filter
+//    - Between filters: value|filter1 {# comment #} |filter2
+//    - Around filter pipe: value {# comment #} | {# comment #} filter
+//    - Around filter name: | {# comment #} filter_name {# comment #}
+//    - Around filter arg colon: filter {# comment #} : {# comment #} arg
+//    - Around filter argument: |filter: {# comment #} arg {# comment #}
+//
+// 7. LISTS:
+//    - After opening bracket: [ {# comment #} item1, item2 ]
+//    - Between list items: [ item1 {# comment #}, {# comment #} item2 ]
+//    - Around list item spread operator: [ {# comment #} * {# comment #} item ]
+//    - Before closing bracket: [ item1, item2 {# comment #} ]
+//    - Around trailing comma: [ item1, {# comment #}, ]
+//
+// 8. DICTIONARIES:
+//    - After opening brace: { {# comment #} "key": "val" }
+//    - Between dict items: { "key1": "val1" {# comment #}, {# comment #} "key2": "val2" }
+//    - Around dict_item_pair colon: { "key" {# comment #} : {# comment #} "val" }
+//    - Around dict_item_spread: { {# comment #} ** {# comment #} value }
+//    - Before closing brace: { "key": "val" {# comment #} }
+//    - Around trailing comma: { "key": "val", {# comment #} }
+//
+// 9. TRANSLATION STRINGS:
+//    - Around string literal in _("..."): _( {# comment #} "string" {# comment #} )
+//
+// 10. PYTHON EXPRESSIONS:
+//     - NOT ALLOWED: Comments cannot appear inside Python expressions: ( {# comment #} items + other_items )
+//
+// 11. VALUES (General):
+//     - Around any value type (string, int, float, variable, etc.) when used in contexts
+//       that allow spacing (not in atomic contexts like key names)
+//
+// ============================================================================
+
+mod common;
+
+#[cfg(test)]
+mod tests {
+    use std::vec;
+
+    use djc_template_parser::ast::Comment;
+
+    use super::common::{plain_parse_tag_v1, token};
+
+    // ============================================
+    // TAG DELIMITERS
+    // ============================================
+
+    #[test]
+    fn test_comment_tag_before_name() {
+        let input = "{% {# before #} my_tag key=val %}";
+        let (_result, context) = plain_parse_tag_v1(input).unwrap();
+        let comments = context.take_comments();
+        assert_eq!(
+            comments,
+            vec![Comment {
+                token: token("{# before #}", 3, 1, 4),
+                value: token(" before ", 5, 1, 6),
+            }]
+        );
+    }
+
+    #[test]
+    fn test_comment_tag_after_attrs() {
+        let input = "{% my_tag key=val {# after #} %}";
+        let (_result, context) = plain_parse_tag_v1(input).unwrap();
+        let comments = context.take_comments();
+        assert_eq!(
+            comments,
+            vec![Comment {
+                token: token("{# after #}", 18, 1, 19),
+                value: token(" after ", 20, 1, 21),
+            }]
+        );
+    }
+
+    #[test]
+    fn test_comment_tag_multiple() {
+        let input = "{% my_tag {# c1 #} key1=val1 {# c2 #} key2=val2 {# c3 #} / %}";
+        let (_result, context) = plain_parse_tag_v1(input).unwrap();
+        let comments = context.take_comments();
+        assert_eq!(
+            comments,
+            vec![
+                Comment {
+                    token: token("{# c1 #}", 10, 1, 11),
+                    value: token(" c1 ", 12, 1, 13),
+                },
+                Comment {
+                    token: token("{# c2 #}", 29, 1, 30),
+                    value: token(" c2 ", 31, 1, 32),
+                },
+                Comment {
+                    token: token("{# c3 #}", 48, 1, 49),
+                    value: token(" c3 ", 50, 1, 51),
+                },
+            ]
+        );
+    }
+
+    #[test]
+    fn test_comment_kwarg_attr_not_allowed() {
+        let input = "{% my_tag key{# comment #}=val %}";
+        assert!(plain_parse_tag_v1(input).is_err());
+
+        let input = "{% my_tag key={# comment #}val %}";
+        assert!(plain_parse_tag_v1(input).is_err());
+    }
+
+    #[test]
+    fn test_comment_requires_whitespace_between_tag_name_and_attributes() {
+        let input = "{% my_tag{# comment #}key=val %}";
+        let result = plain_parse_tag_v1(input);
+        assert!(result.is_err());
+    }
+
+    // ============================================
+    // TAG - GENERIC
+    // ============================================
+
+    #[test]
+    fn test_comment_tag_between_name_and_attr() {
+        let input = "{% my_tag {# comment #} key=val %}";
+        let (_result, context) = plain_parse_tag_v1(input).unwrap();
+        let comments = context.take_comments();
+        assert_eq!(
+            comments,
+            vec![Comment {
+                token: token("{# comment #}", 10, 1, 11),
+                value: token(" comment ", 12, 1, 13),
+            }]
+        );
+    }
+
+    #[test]
+    fn test_comment_tag_between_attrs() {
+        let input = "{% my_tag key1=val1 {# comment #} key2=val2 %}";
+        let (_result, context) = plain_parse_tag_v1(input).unwrap();
+        let comments = context.take_comments();
+        assert_eq!(
+            comments,
+            vec![Comment {
+                token: token("{# comment #}", 20, 1, 21),
+                value: token(" comment ", 22, 1, 23),
+            }]
+        );
+    }
+
+    #[test]
+    fn test_comment_tag_before_self_closing_slash() {
+        let input = "{% my_tag key=val {# comment #} / %}";
+        let (_result, context) = plain_parse_tag_v1(input).unwrap();
+        let comments = context.take_comments();
+        assert_eq!(
+            comments,
+            vec![Comment {
+                token: token("{# comment #}", 18, 1, 19),
+                value: token(" comment ", 20, 1, 21),
+            }]
+        );
+    }
+
+    #[test]
+    fn test_comment_tag_after_self_closing_slash() {
+        let input = "{% my_tag key=val / {# comment #} %}";
+        let (_result, context) = plain_parse_tag_v1(input).unwrap();
+        let comments = context.take_comments();
+        assert_eq!(
+            comments,
+            vec![Comment {
+                token: token("{# comment #}", 20, 1, 21),
+                value: token(" comment ", 22, 1, 23),
+            }]
+        );
+    }
+
+    // ============================================
+    // TAG - FORLOOOP
+    // ============================================
+
+    #[test]
+    fn test_comment_forloop_before_tag_name() {
+        let input = "{% {# comment #} for item in items %}";
+        let (_result, context) = plain_parse_tag_v1(input).unwrap();
+        let comments = context.take_comments();
+        assert_eq!(
+            comments,
+            vec![Comment {
+                token: token("{# comment #}", 3, 1, 4),
+                value: token(" comment ", 5, 1, 6),
+            }]
+        );
+    }
+
+    #[test]
+    fn test_comment_forloop_between_for_and_content() {
+        let input = "{% for {# comment #} item in items %}";
+        let (_result, context) = plain_parse_tag_v1(input).unwrap();
+        let comments = context.take_comments();
+        assert_eq!(
+            comments,
+            vec![Comment {
+                token: token("{# comment #}", 7, 1, 8),
+                value: token(" comment ", 9, 1, 10),
+            }]
+        );
+    }
+
+    #[test]
+    fn test_comment_forloop_between_loop_variables() {
+        let input = "{% for x {# c1 #}, {# c2 #} y in items %}";
+        let (_result, context) = plain_parse_tag_v1(input).unwrap();
+        let comments = context.take_comments();
+        assert_eq!(
+            comments,
+            vec![
+                Comment {
+                    token: token("{# c1 #}", 9, 1, 10),
+                    value: token(" c1 ", 11, 1, 12),
+                },
+                Comment {
+                    token: token("{# c2 #}", 19, 1, 20),
+                    value: token(" c2 ", 21, 1, 22),
+                },
+            ]
+        );
+    }
+
+    #[test]
+    fn test_comment_forloop_between_forloop_vars_and_in() {
+        let input = "{% for x, y {# comment #} in items %}";
+        let (_result, context) = plain_parse_tag_v1(input).unwrap();
+        let comments = context.take_comments();
+        assert_eq!(
+            comments,
+            vec![Comment {
+                token: token("{# comment #}", 12, 1, 13),
+                value: token(" comment ", 14, 1, 15),
+            }]
+        );
+    }
+
+    #[test]
+    fn test_comment_forloop_between_in_and_iterable() {
+        let input = "{% for x in {# comment #} items %}";
+        let (_result, context) = plain_parse_tag_v1(input).unwrap();
+        let comments = context.take_comments();
+        assert_eq!(
+            comments,
+            vec![Comment {
+                token: token("{# comment #}", 12, 1, 13),
+                value: token(" comment ", 14, 1, 15),
+            }]
+        );
+    }
+
+    // ============================================
+    // TAG - END
+    // ============================================
+
+    #[test]
+    fn test_comment_endtag_with_whitespace() {
+        let input = "{% {# c1 #} endslot {# c2 #} %}";
+        let (_result, context) = plain_parse_tag_v1(input).unwrap();
+
+        assert_eq!(
+            context.take_comments(),
+            vec![
+                Comment {
+                    token: token("{# c1 #}", 3, 1, 4),
+                    value: token(" c1 ", 5, 1, 6),
+                },
+                Comment {
+                    token: token("{# c2 #}", 20, 1, 21),
+                    value: token(" c2 ", 22, 1, 23),
+                },
+            ]
+        );
+    }
+
+    #[test]
+    fn test_comment_endtag_no_spaces() {
+        let input = "{%{# c1 #}endslot{# c2 #}%}";
+        let (_result, context) = plain_parse_tag_v1(input).unwrap();
+
+        assert_eq!(
+            context.take_comments(),
+            vec![
+                Comment {
+                    token: token("{# c1 #}", 2, 1, 3),
+                    value: token(" c1 ", 4, 1, 5),
+                },
+                Comment {
+                    token: token("{# c2 #}", 17, 1, 18),
+                    value: token(" c2 ", 19, 1, 20),
+                },
+            ]
+        );
+    }
+
+    // ============================================
+    // ATTRIBUTES
+    // ============================================
+
+    #[test]
+    fn test_comment_not_allowed_around_spread_operator() {
+        let input = "{% my_tag ...{# comment #}myvalue %}";
+        let result = plain_parse_tag_v1(input);
+        assert_eq!(result.is_err(), true);
+    }
+
+    // ============================================
+    // FILTERS
+    // ============================================
+
+    #[test]
+    fn test_comment_filter_between_value_and_pipe() {
+        let input = "{% my_tag value {# comment #} |filter %}";
+        let (_result, context) = plain_parse_tag_v1(input).unwrap();
+        let comments = context.take_comments();
+        assert_eq!(
+            comments,
+            vec![Comment {
+                token: token("{# comment #}", 16, 1, 17),
+                value: token(" comment ", 18, 1, 19),
+            }]
+        );
+    }
+
+    #[test]
+    fn test_comment_filter_between_next_filter() {
+        let input = "{% my_tag value|filter1 {# comment #} |filter2 %}";
+        let (_result, context) = plain_parse_tag_v1(input).unwrap();
+        let comments = context.take_comments();
+        assert_eq!(
+            comments,
+            vec![Comment {
+                token: token("{# comment #}", 24, 1, 25),
+                value: token(" comment ", 26, 1, 27),
+            }]
+        );
+    }
+
+    #[test]
+    fn test_comment_filter_around_pipe() {
+        let input = "{% my_tag value {# c1 #} | {# c2 #} filter %}";
+        let (_result, context) = plain_parse_tag_v1(input).unwrap();
+        let comments = context.take_comments();
+        assert_eq!(
+            comments,
+            vec![
+                Comment {
+                    token: token("{# c1 #}", 16, 1, 17),
+                    value: token(" c1 ", 18, 1, 19),
+                },
+                Comment {
+                    token: token("{# c2 #}", 27, 1, 28),
+                    value: token(" c2 ", 29, 1, 30),
+                }
+            ]
+        );
+    }
+
+    #[test]
+    fn test_comment_filter_around_name() {
+        let input = "{% my_tag value| {# c1 #} filter {# c2 #} %}";
+        let (_result, context) = plain_parse_tag_v1(input).unwrap();
+        let comments = context.take_comments();
+        assert_eq!(
+            comments,
+            vec![
+                Comment {
+                    token: token("{# c2 #}", 33, 1, 34),
+                    value: token(" c2 ", 35, 1, 36),
+                },
+                Comment {
+                    token: token("{# c1 #}", 17, 1, 18),
+                    value: token(" c1 ", 19, 1, 20),
+                },
+            ]
+        );
+    }
+
+    #[test]
+    fn test_comment_filter_around_filter_arg_colon() {
+        let input = "{% my_tag value|filter {# c1 #} : {# c2 #} arg %}";
+        let (_result, context) = plain_parse_tag_v1(input).unwrap();
+        let comments = context.take_comments();
+        assert_eq!(
+            comments,
+            vec![
+                Comment {
+                    token: token("{# c1 #}", 23, 1, 24),
+                    value: token(" c1 ", 25, 1, 26),
+                },
+                Comment {
+                    token: token("{# c2 #}", 34, 1, 35),
+                    value: token(" c2 ", 36, 1, 37),
+                }
+            ]
+        );
+    }
+
+    #[test]
+    fn test_comment_filter_around_filter_arg() {
+        let input = "{% my_tag value|filter: {# c1 #} arg {# c2 #} %}";
+        let (_result, context) = plain_parse_tag_v1(input).unwrap();
+        let comments = context.take_comments();
+        assert_eq!(
+            comments,
+            vec![
+                Comment {
+                    token: token("{# c2 #}", 37, 1, 38),
+                    value: token(" c2 ", 39, 1, 40),
+                },
+                Comment {
+                    token: token("{# c1 #}", 24, 1, 25),
+                    value: token(" c1 ", 26, 1, 27),
+                },
+            ]
+        );
+    }
+
+    // ============================================
+    // LISTS
+    // ============================================
+
+    #[test]
+    fn test_comment_list_after_opening_bracket() {
+        let input = "{% my_tag [ {# comment #} item1, item2 ] %}";
+        let (_result, context) = plain_parse_tag_v1(input).unwrap();
+        let comments = context.take_comments();
+        assert_eq!(
+            comments,
+            vec![Comment {
+                token: token("{# comment #}", 12, 1, 13),
+                value: token(" comment ", 14, 1, 15),
+            }]
+        );
+    }
+
+    #[test]
+    fn test_comment_list_between_items() {
+        let input = "{% my_tag [ item1 {# c1 #}, {# c2 #} item2 ] %}";
+        let (_result, context) = plain_parse_tag_v1(input).unwrap();
+        let comments = context.take_comments();
+        assert_eq!(
+            comments,
+            vec![
+                Comment {
+                    token: token("{# c1 #}", 18, 1, 19),
+                    value: token(" c1 ", 20, 1, 21),
+                },
+                Comment {
+                    token: token("{# c2 #}", 28, 1, 29),
+                    value: token(" c2 ", 30, 1, 31),
+                }
+            ]
+        );
+    }
+
+    #[test]
+    fn test_comment_list_around_spread_operator() {
+        let input = "{% my_tag [ {# c1 #} * {# c2 #} item ] %}";
+        let (_result, context) = plain_parse_tag_v1(input).unwrap();
+        let comments = context.take_comments();
+        assert_eq!(
+            comments,
+            vec![
+                Comment {
+                    token: token("{# c1 #}", 12, 1, 13),
+                    value: token(" c1 ", 14, 1, 15),
+                },
+                Comment {
+                    token: token("{# c2 #}", 23, 1, 24),
+                    value: token(" c2 ", 25, 1, 26),
+                }
+            ]
+        );
+    }
+
+    #[test]
+    fn test_comment_list_before_closing_bracket() {
+        let input = "{% my_tag [ item1, item2 {# comment #} ] %}";
+        let (_result, context) = plain_parse_tag_v1(input).unwrap();
+        let comments = context.take_comments();
+        assert_eq!(
+            comments,
+            vec![Comment {
+                token: token("{# comment #}", 25, 1, 26),
+                value: token(" comment ", 27, 1, 28),
+            }]
+        );
+    }
+
+    #[test]
+    fn test_comment_list_around_trailing_comma() {
+        let input = "{% my_tag [ item1{# c1 #},{# c2 #} ] %}";
+        let (_result, context) = plain_parse_tag_v1(input).unwrap();
+        let comments = context.take_comments();
+        assert_eq!(
+            comments,
+            vec![
+                Comment {
+                    token: token("{# c1 #}", 17, 1, 18),
+                    value: token(" c1 ", 19, 1, 20),
+                },
+                Comment {
+                    token: token("{# c2 #}", 26, 1, 27),
+                    value: token(" c2 ", 28, 1, 29),
+                }
+            ]
+        );
+    }
+
+    #[test]
+    fn test_comment_list_raises_on_multiple_commas_despite_comment() {
+        let input = "{% my_tag [ item1, {# comment #}, ] %}";
+        let result = plain_parse_tag_v1(input);
+        assert_eq!(result.is_err(), true);
+    }
+
+    // ============================================
+    // DICTIONARIES
+    // ============================================
+
+    #[test]
+    fn test_comment_dict_after_opening_brace() {
+        let input = r#"{% my_tag { {# comment #} "key": "val" } %}"#;
+        let (_result, context) = plain_parse_tag_v1(input).unwrap();
+        let comments = context.take_comments();
+        assert_eq!(
+            comments,
+            vec![Comment {
+                token: token("{# comment #}", 12, 1, 13),
+                value: token(" comment ", 14, 1, 15),
+            }]
+        );
+    }
+
+    #[test]
+    fn test_comment_dict_between_items() {
+        let input = r#"{% my_tag { "key1": "val1" {# c1 #}, {# c2 #} "key2": "val2" } %}"#;
+        let (_result, context) = plain_parse_tag_v1(input).unwrap();
+        let comments = context.take_comments();
+        assert_eq!(
+            comments,
+            vec![
+                Comment {
+                    token: token("{# c1 #}", 27, 1, 28),
+                    value: token(" c1 ", 29, 1, 30),
+                },
+                Comment {
+                    token: token("{# c2 #}", 37, 1, 38),
+                    value: token(" c2 ", 39, 1, 40),
+                }
+            ]
+        );
+    }
+
+    #[test]
+    fn test_comment_dict_around_colon() {
+        let input = r#"{% my_tag { "key" {# c1 #} : {# c2 #} "val" } %}"#;
+        let (_result, context) = plain_parse_tag_v1(input).unwrap();
+        let comments = context.take_comments();
+        assert_eq!(
+            comments,
+            vec![
+                Comment {
+                    token: token("{# c1 #}", 18, 1, 19),
+                    value: token(" c1 ", 20, 1, 21),
+                },
+                Comment {
+                    token: token("{# c2 #}", 29, 1, 30),
+                    value: token(" c2 ", 31, 1, 32),
+                }
+            ]
+        );
+    }
+
+    #[test]
+    fn test_comment_dict_around_spread() {
+        let input = "{% my_tag { {# c1 #} ** {# c2 #} value } %}";
+        let (_result, context) = plain_parse_tag_v1(input).unwrap();
+        let comments = context.take_comments();
+        assert_eq!(
+            comments,
+            vec![
+                Comment {
+                    token: token("{# c1 #}", 12, 1, 13),
+                    value: token(" c1 ", 14, 1, 15),
+                },
+                Comment {
+                    token: token("{# c2 #}", 24, 1, 25),
+                    value: token(" c2 ", 26, 1, 27),
+                }
+            ]
+        );
+    }
+
+    #[test]
+    fn test_comment_dict_before_closing_brace() {
+        let input = r#"{% my_tag { "key": "val" {# comment #} } %}"#;
+        let (_result, context) = plain_parse_tag_v1(input).unwrap();
+        let comments = context.take_comments();
+        assert_eq!(
+            comments,
+            vec![Comment {
+                token: token("{# comment #}", 25, 1, 26),
+                value: token(" comment ", 27, 1, 28),
+            }]
+        );
+    }
+
+    #[test]
+    fn test_comment_dict_around_trailing_comma() {
+        let input = r#"{% my_tag { "key": "val"{# c1 #},{# c2 #} } %}"#;
+        let (_result, context) = plain_parse_tag_v1(input).unwrap();
+        let comments = context.take_comments();
+        assert_eq!(
+            comments,
+            vec![
+                Comment {
+                    token: token("{# c1 #}", 24, 1, 25),
+                    value: token(" c1 ", 26, 1, 27),
+                },
+                Comment {
+                    token: token("{# c2 #}", 33, 1, 34),
+                    value: token(" c2 ", 35, 1, 36),
+                }
+            ]
+        );
+    }
+
+    #[test]
+    fn test_comment_dict_raises_on_multiple_commas_despite_comment() {
+        let input = r#"{% my_tag { "key": "val",{# c1 #},{# c2 #} } %}"#;
+        let result = plain_parse_tag_v1(input);
+        assert_eq!(result.is_err(), true);
+    }
+
+    // ============================================
+    // TRANSLATION STRINGS
+    // ============================================
+
+    #[test]
+    fn test_comment_translation_around_string() {
+        let input = r#"{% my_tag _( {# c1 #} "hello" {# c2 #} ) %}"#;
+        let (_result, context) = plain_parse_tag_v1(input).unwrap();
+        let comments = context.take_comments();
+        assert_eq!(
+            comments,
+            vec![
+                Comment {
+                    token: token("{# c1 #}", 13, 1, 14),
+                    value: token(" c1 ", 15, 1, 16),
+                },
+                Comment {
+                    token: token("{# c2 #}", 30, 1, 31),
+                    value: token(" c2 ", 32, 1, 33),
+                }
+            ]
+        );
+    }
+
+    // ============================================
+    // PYTHON EXPRESSIONS
+    // ============================================
+
+    #[test]
+    fn test_comment_python_expr_django_comment() {
+        // Inside Python expressions we expect python comments, NOT {# ... #}
+        // So the below will be interpreted as dict opening bracket folowed by comment
+        // `# comment #} items + other_items `
+        // Since it's an unclosed curly brace, it will be raise error
+        let input = "{% my_tag ( {# comment #} items + other_items ) %}";
+        let result = plain_parse_tag_v1(input);
+        assert_eq!(result.is_err(), true);
+        assert_eq!(
+            result.unwrap_err().to_string(),
+            "Parse error:  --> 1:11\n  |\n1 | {% my_tag ( {# comment #} items + other_items ) %}\n  |           ^-----------------------------------^\n  |\n  = Failed to collect used and assigned variables from Python expression: Parse error: Expected an expression at byte range 36..37",
+        );
+    }
+
+    #[test]
+    fn test_comment_python_expr_python_comment() {
+        let input = "{% my_tag ( items # COMMENT + other_items ) %}";
+        let (_result, context) = plain_parse_tag_v1(input).unwrap();
+        let comments = context.take_comments();
+        assert_eq!(
+            comments,
+            vec![Comment {
+                token: token("# COMMENT + other_items ", 18, 1, 19),
+                value: token(" COMMENT + other_items ", 19, 1, 20),
+            }]
+        );
+    }
+
+    #[test]
+    fn test_comment_python_expr_python_comment_multiline() {
+        let input = "{% my_tag ( [1, # c1\n# c2\n2, # c3\n3] #c4) %}";
+        let (_result, context) = plain_parse_tag_v1(input).unwrap();
+        let comments = context.take_comments();
+        assert_eq!(
+            comments,
+            vec![
+                Comment {
+                    token: token("# c1", 16, 1, 17),
+                    value: token(" c1", 17, 1, 18),
+                },
+                Comment {
+                    token: token("# c2", 21, 2, 1),
+                    value: token(" c2", 22, 2, 2),
+                },
+                Comment {
+                    token: token("# c3", 29, 3, 4),
+                    value: token(" c3", 30, 3, 5),
+                },
+                Comment {
+                    token: token("#c4", 37, 4, 4),
+                    value: token("c4", 38, 4, 5),
+                }
+            ],
+        )
+    }
+
+    // ============================================
+    // VALUES
+    // ============================================
+
+    #[test]
+    fn test_comment_variable_around() {
+        let input = "{% my_tag {# c1 #}myvar{# c2 #} %}";
+        let (_result, context) = plain_parse_tag_v1(input).unwrap();
+        let comments = context.take_comments();
+        assert_eq!(
+            comments,
+            vec![
+                Comment {
+                    token: token("{# c1 #}", 10, 1, 11),
+                    value: token(" c1 ", 12, 1, 13),
+                },
+                Comment {
+                    token: token("{# c2 #}", 23, 1, 24),
+                    value: token(" c2 ", 25, 1, 26),
+                }
+            ]
+        );
+    }
+
+    #[test]
+    fn test_comment_variable_inside_not_allowed() {
+        let input = "{% my_tag my{# c1 #}var %}";
+        let result = plain_parse_tag_v1(input);
+        assert_eq!(result.is_err(), true);
+
+        let input = "{% my_tag my.{# c1 #}var %}";
+        let result = plain_parse_tag_v1(input);
+        assert_eq!(result.is_err(), true);
+    }
+
+    #[test]
+    fn test_comment_string_around() {
+        let input = r#"{% my_tag {# c1 #}"hello"{# c2 #} %}"#;
+        let (_result, context) = plain_parse_tag_v1(input).unwrap();
+        let comments = context.take_comments();
+        assert_eq!(
+            comments,
+            vec![
+                Comment {
+                    token: token("{# c1 #}", 10, 1, 11),
+                    value: token(" c1 ", 12, 1, 13),
+                },
+                Comment {
+                    token: token("{# c2 #}", 25, 1, 26),
+                    value: token(" c2 ", 27, 1, 28),
+                }
+            ]
+        );
+    }
+
+    #[test]
+    fn test_comment_string_inside_not_allowed() {
+        let input = r#"{% my_tag "hello{# c1 #}world" %}"#;
+        let (_result, context) = plain_parse_tag_v1(input).unwrap();
+        let comments = context.take_comments();
+        assert_eq!(comments, vec![]);
+    }
+
+    #[test]
+    fn test_comment_template_string_around() {
+        let input = r#"{% my_tag {# c1 #}"hello {{ name }}"{# c2 #} %}"#;
+        let (_result, context) = plain_parse_tag_v1(input).unwrap();
+        let comments = context.take_comments();
+        assert_eq!(
+            comments,
+            vec![
+                Comment {
+                    token: token("{# c1 #}", 10, 1, 11),
+                    value: token(" c1 ", 12, 1, 13),
+                },
+                Comment {
+                    token: token("{# c2 #}", 36, 1, 37),
+                    value: token(" c2 ", 38, 1, 39),
+                }
+            ]
+        );
+    }
+
+    #[test]
+    fn test_comment_template_string_v1_inside_not_allowed() {
+        let input = r#"{% my_tag "hello{# c1 #} {{ name }}" %}"#;
+        let (_result, context) = plain_parse_tag_v1(input).unwrap();
+        let comments = context.take_comments();
+        assert_eq!(comments, vec![]);
+    }
+
+    #[test]
+    fn test_comment_int_around() {
+        let input = r#"{% my_tag {# c1 #}42{# c2 #} %}"#;
+        let (_result, context) = plain_parse_tag_v1(input).unwrap();
+        let comments = context.take_comments();
+        assert_eq!(
+            comments,
+            vec![
+                Comment {
+                    token: token("{# c1 #}", 10, 1, 11),
+                    value: token(" c1 ", 12, 1, 13),
+                },
+                Comment {
+                    token: token("{# c2 #}", 20, 1, 21),
+                    value: token(" c2 ", 22, 1, 23),
+                }
+            ]
+        );
+    }
+
+    #[test]
+    fn test_comment_int_inside_not_allowed() {
+        let input = "{% my_tag 4{# c1 #}2 %}";
+        let result = plain_parse_tag_v1(input);
+        assert_eq!(result.is_err(), true);
+    }
+
+    #[test]
+    fn test_comment_float_around() {
+        let input = r#"{% my_tag {# c1 #}4.2{# c2 #} %}"#;
+        let (_result, context) = plain_parse_tag_v1(input).unwrap();
+        let comments = context.take_comments();
+        assert_eq!(
+            comments,
+            vec![
+                Comment {
+                    token: token("{# c1 #}", 10, 1, 11),
+                    value: token(" c1 ", 12, 1, 13),
+                },
+                Comment {
+                    token: token("{# c2 #}", 21, 1, 22),
+                    value: token(" c2 ", 23, 1, 24),
+                }
+            ]
+        );
+    }
+
+    #[test]
+    fn test_comment_float_inside_not_allowed() {
+        let input = "{% my_tag 4.{# c1 #}2 %}";
+        let result = plain_parse_tag_v1(input);
+        assert_eq!(result.is_err(), true);
+
+        let input = "{% my_tag 4{# c1 #}.2 %}";
+        let result = plain_parse_tag_v1(input);
+        assert_eq!(result.is_err(), true);
+
+        let input = "{% my_tag .{# c1 #}2 %}";
+        let result = plain_parse_tag_v1(input);
+        assert_eq!(result.is_err(), true);
+
+        let input = "{% my_tag -{# c1 #}1.5 %}";
+        let result = plain_parse_tag_v1(input);
+        assert_eq!(result.is_err(), true);
+
+        let input = "{% my_tag +{# c1 #}1.5 %}";
+        let result = plain_parse_tag_v1(input);
+        assert_eq!(result.is_err(), true);
+
+        let input = "{% my_tag -1.2{# c1 #}e2 %}";
+        let result = plain_parse_tag_v1(input);
+        assert_eq!(result.is_err(), true);
+
+        let input = "{% my_tag -1.2e{# c1 #}2 %}";
+        let result = plain_parse_tag_v1(input);
+        assert_eq!(result.is_err(), true);
+
+        let input = "{% my_tag -1.2e-0{# c1 #}2 %}";
+        let result = plain_parse_tag_v1(input);
+        assert_eq!(result.is_err(), true);
+    }
+}

--- a/crates/djc-template-parser/tests/tag_parser_dict.rs
+++ b/crates/djc-template-parser/tests/tag_parser_dict.rs
@@ -1,0 +1,1803 @@
+// Each of the `tag_parser_<data_type>.rs` file tests following cases:
+//  1. as arg
+//  2. as multiple args
+//  3. as arg with filter without filter arg
+//  4. as arg with filter with filter arg
+//  5. as arg with `...` spread
+//  6. as kwarg
+//  7. as multiple kwargs
+//  8. as kwarg with filter without filter arg
+//  9. as kwarg with filter with filter arg
+// 10. as both arg and kwarg with filters
+// 11. as both arg and kwarg with filters and arg with `...` spreads
+// 12. inside list
+// 13. inside list with filter without filter arg
+// 14. inside list with filter with filter arg
+// 15. inside list with filter with filter arg and `*` spread.
+// 16. inside list with `*` spread.
+// 17. inside dict as value
+// 18. inside dict as value with filter with filter arg
+// 19. inside dict as key and value
+// 20. inside dict as key and value, both with filters, and value with filter arg.
+// 21. inside dict as neither key nor value, with `**` spread and filter without arg
+
+mod common;
+
+#[cfg(test)]
+mod tests {
+    use std::vec;
+
+    use djc_template_parser::ast::{
+        GenericTag, Tag, TagMeta, TagValue, TagValueFilter, Token, ValueChild, ValueKind,
+    };
+
+    use super::common::{
+        plain_int_value, plain_parse_tag_v1, plain_string_value, plain_variable_value,
+        string_value, tag_attr, template_string_value, token, translation_value, variable_value,
+    };
+
+    #[test]
+    fn test_dict_as_arg() {
+        let input = r#"{% my_tag {42: 'hello', **my_var} %}"#;
+        let (result, _context) = plain_parse_tag_v1(input).unwrap();
+        let dict_value = TagValue {
+            token: token(r#"{42: 'hello', **my_var}"#, 10, 1, 11),
+            value: token(r#"{42: 'hello', **my_var}"#, 10, 1, 11),
+            children: vec![
+                ValueChild::Value(plain_int_value("42", 11, 1, 12, None)),
+                ValueChild::Value(plain_string_value(r#"'hello'"#, 15, 1, 16, None)),
+                ValueChild::Value(plain_variable_value("my_var", 24, 1, 25, Some("**"))),
+            ],
+            kind: ValueKind::Dict,
+            spread: None,
+            filters: vec![],
+            used_variables: vec![],
+            assigned_variables: vec![],
+        };
+        assert_eq!(
+            result,
+            Tag::Generic(GenericTag {
+                meta: TagMeta {
+                    token: token(r#"{% my_tag {42: 'hello', **my_var} %}"#, 0, 1, 1),
+                    name: token("my_tag", 3, 1, 4),
+                    used_variables: vec![token("my_var", 26, 1, 27)],
+                    assigned_variables: vec![],
+                },
+                attrs: vec![tag_attr(None, dict_value, false)],
+                is_self_closing: false,
+            })
+        );
+    }
+
+    #[test]
+    fn test_dict_as_multiple_args() {
+        let input = r#"{% my_tag {42: 'hello', **my_var} {100: 'world', **other_var} %}"#;
+        let (result, _context) = plain_parse_tag_v1(input).unwrap();
+        let dict_value1 = TagValue {
+            token: token(r#"{42: 'hello', **my_var}"#, 10, 1, 11),
+            value: token(r#"{42: 'hello', **my_var}"#, 10, 1, 11),
+            children: vec![
+                ValueChild::Value(plain_int_value("42", 11, 1, 12, None)),
+                ValueChild::Value(plain_string_value(r#"'hello'"#, 15, 1, 16, None)),
+                ValueChild::Value(plain_variable_value("my_var", 24, 1, 25, Some("**"))),
+            ],
+            kind: ValueKind::Dict,
+            spread: None,
+            filters: vec![],
+            used_variables: vec![],
+            assigned_variables: vec![],
+        };
+        let dict_value2 = TagValue {
+            token: token(r#"{100: 'world', **other_var}"#, 34, 1, 35),
+            value: token(r#"{100: 'world', **other_var}"#, 34, 1, 35),
+            children: vec![
+                ValueChild::Value(plain_int_value("100", 35, 1, 36, None)),
+                ValueChild::Value(plain_string_value(r#"'world'"#, 40, 1, 41, None)),
+                ValueChild::Value(plain_variable_value("other_var", 49, 1, 50, Some("**"))),
+            ],
+            kind: ValueKind::Dict,
+            spread: None,
+            filters: vec![],
+            used_variables: vec![],
+            assigned_variables: vec![],
+        };
+        assert_eq!(
+            result,
+            Tag::Generic(GenericTag {
+                meta: TagMeta {
+                    token: token(
+                        r#"{% my_tag {42: 'hello', **my_var} {100: 'world', **other_var} %}"#,
+                        0,
+                        1,
+                        1
+                    ),
+                    name: token("my_tag", 3, 1, 4),
+                    used_variables: vec![token("my_var", 26, 1, 27), token("other_var", 51, 1, 52)],
+                    assigned_variables: vec![],
+                },
+                attrs: vec![
+                    tag_attr(None, dict_value1, false),
+                    tag_attr(None, dict_value2, false),
+                ],
+                is_self_closing: false,
+            })
+        );
+    }
+
+    #[test]
+    fn test_dict_as_arg_with_filter_without_arg() {
+        let input = r#"{% my_tag {42: 'hello', **my_var}|keys %}"#;
+        let (result, _context) = plain_parse_tag_v1(input).unwrap();
+        let dict_value = TagValue {
+            token: token(r#"{42: 'hello', **my_var}|keys"#, 10, 1, 11),
+            value: token(r#"{42: 'hello', **my_var}"#, 10, 1, 11),
+            children: vec![
+                ValueChild::Value(plain_int_value("42", 11, 1, 12, None)),
+                ValueChild::Value(plain_string_value(r#"'hello'"#, 15, 1, 16, None)),
+                ValueChild::Value(plain_variable_value("my_var", 24, 1, 25, Some("**"))),
+            ],
+            kind: ValueKind::Dict,
+            spread: None,
+            filters: vec![TagValueFilter {
+                token: token("|keys", 33, 1, 34),
+                name: token("keys", 34, 1, 35),
+                arg: None,
+            }],
+            used_variables: vec![],
+            assigned_variables: vec![],
+        };
+        assert_eq!(
+            result,
+            Tag::Generic(GenericTag {
+                meta: TagMeta {
+                    token: token(r#"{% my_tag {42: 'hello', **my_var}|keys %}"#, 0, 1, 1),
+                    name: token("my_tag", 3, 1, 4),
+                    used_variables: vec![token("my_var", 26, 1, 27)],
+                    assigned_variables: vec![],
+                },
+                attrs: vec![tag_attr(None, dict_value, false)],
+                is_self_closing: false,
+            })
+        );
+    }
+
+    #[test]
+    fn test_dict_as_arg_with_filter_with_arg() {
+        let input = r#"{% my_tag {42: 'hello', **my_var}|get:{1: test} %}"#;
+        let (result, _context) = plain_parse_tag_v1(input).unwrap();
+        let filter_arg_dict = TagValue {
+            token: token(r#"{1: test}"#, 38, 1, 39),
+            value: token(r#"{1: test}"#, 38, 1, 39),
+            children: vec![
+                ValueChild::Value(plain_int_value("1", 39, 1, 40, None)),
+                ValueChild::Value(plain_variable_value("test", 42, 1, 43, None)),
+            ],
+            kind: ValueKind::Dict,
+            spread: None,
+            filters: vec![],
+            used_variables: vec![],
+            assigned_variables: vec![],
+        };
+        let dict_value = TagValue {
+            token: token(r#"{42: 'hello', **my_var}|get:{1: test}"#, 10, 1, 11),
+            value: token(r#"{42: 'hello', **my_var}"#, 10, 1, 11),
+            children: vec![
+                ValueChild::Value(plain_int_value("42", 11, 1, 12, None)),
+                ValueChild::Value(plain_string_value(r#"'hello'"#, 15, 1, 16, None)),
+                ValueChild::Value(plain_variable_value("my_var", 24, 1, 25, Some("**"))),
+            ],
+            kind: ValueKind::Dict,
+            spread: None,
+            filters: vec![TagValueFilter {
+                token: token(r#"|get:{1: test}"#, 33, 1, 34),
+                name: token("get", 34, 1, 35),
+                arg: Some(filter_arg_dict),
+            }],
+            used_variables: vec![],
+            assigned_variables: vec![],
+        };
+        assert_eq!(
+            result,
+            Tag::Generic(GenericTag {
+                meta: TagMeta {
+                    token: token(
+                        r#"{% my_tag {42: 'hello', **my_var}|get:{1: test} %}"#,
+                        0,
+                        1,
+                        1
+                    ),
+                    name: token("my_tag", 3, 1, 4),
+                    used_variables: vec![token("my_var", 26, 1, 27), token("test", 42, 1, 43)],
+                    assigned_variables: vec![],
+                },
+                attrs: vec![tag_attr(None, dict_value, false)],
+                is_self_closing: false,
+            })
+        );
+    }
+
+    #[test]
+    fn test_dict_as_arg_with_spread() {
+        let input = r#"{% my_tag ...{42: 'hello', **my_var} %}"#;
+        let (result, _context) = plain_parse_tag_v1(input).unwrap();
+        let dict_value = TagValue {
+            token: token(r#"...{42: 'hello', **my_var}"#, 10, 1, 11),
+            value: token(r#"{42: 'hello', **my_var}"#, 13, 1, 14),
+            children: vec![
+                ValueChild::Value(plain_int_value("42", 14, 1, 15, None)),
+                ValueChild::Value(plain_string_value(r#"'hello'"#, 18, 1, 19, None)),
+                ValueChild::Value(plain_variable_value("my_var", 27, 1, 28, Some("**"))),
+            ],
+            kind: ValueKind::Dict,
+            spread: Some("...".to_string()),
+            filters: vec![],
+            used_variables: vec![],
+            assigned_variables: vec![],
+        };
+        assert_eq!(
+            result,
+            Tag::Generic(GenericTag {
+                meta: TagMeta {
+                    token: token(r#"{% my_tag ...{42: 'hello', **my_var} %}"#, 0, 1, 1),
+                    name: token("my_tag", 3, 1, 4),
+                    used_variables: vec![token("my_var", 29, 1, 30)],
+                    assigned_variables: vec![],
+                },
+                attrs: vec![tag_attr(None, dict_value, false)],
+                is_self_closing: false,
+            })
+        );
+    }
+
+    #[test]
+    fn test_dict_as_kwarg() {
+        let input = r#"{% my_tag key={42: 'hello', **my_var} %}"#;
+        let (result, _context) = plain_parse_tag_v1(input).unwrap();
+        let dict_value = TagValue {
+            token: token(r#"{42: 'hello', **my_var}"#, 14, 1, 15),
+            value: token(r#"{42: 'hello', **my_var}"#, 14, 1, 15),
+            children: vec![
+                ValueChild::Value(plain_int_value("42", 15, 1, 16, None)),
+                ValueChild::Value(plain_string_value(r#"'hello'"#, 19, 1, 20, None)),
+                ValueChild::Value(plain_variable_value("my_var", 28, 1, 29, Some("**"))),
+            ],
+            kind: ValueKind::Dict,
+            spread: None,
+            filters: vec![],
+            used_variables: vec![],
+            assigned_variables: vec![],
+        };
+        assert_eq!(
+            result,
+            Tag::Generic(GenericTag {
+                meta: TagMeta {
+                    token: token(r#"{% my_tag key={42: 'hello', **my_var} %}"#, 0, 1, 1),
+                    name: token("my_tag", 3, 1, 4),
+                    used_variables: vec![token("my_var", 30, 1, 31)],
+                    assigned_variables: vec![],
+                },
+                attrs: vec![tag_attr(Some(token("key", 10, 1, 11)), dict_value, false)],
+                is_self_closing: false,
+            })
+        );
+    }
+
+    #[test]
+    fn test_dict_as_multiple_kwargs() {
+        let input = r#"{% my_tag key1={42: 'hello', **my_var} key2={100: 'world', **other_var} %}"#;
+        let (result, _context) = plain_parse_tag_v1(input).unwrap();
+        let dict_value1 = TagValue {
+            token: token(r#"{42: 'hello', **my_var}"#, 15, 1, 16),
+            value: token(r#"{42: 'hello', **my_var}"#, 15, 1, 16),
+            children: vec![
+                ValueChild::Value(plain_int_value("42", 16, 1, 17, None)),
+                ValueChild::Value(plain_string_value(r#"'hello'"#, 20, 1, 21, None)),
+                ValueChild::Value(plain_variable_value("my_var", 29, 1, 30, Some("**"))),
+            ],
+            kind: ValueKind::Dict,
+            spread: None,
+            filters: vec![],
+            used_variables: vec![],
+            assigned_variables: vec![],
+        };
+        let dict_value2 = TagValue {
+            token: token(r#"{100: 'world', **other_var}"#, 44, 1, 45),
+            value: token(r#"{100: 'world', **other_var}"#, 44, 1, 45),
+            children: vec![
+                ValueChild::Value(plain_int_value("100", 45, 1, 46, None)),
+                ValueChild::Value(plain_string_value(r#"'world'"#, 50, 1, 51, None)),
+                ValueChild::Value(plain_variable_value("other_var", 59, 1, 60, Some("**"))),
+            ],
+            kind: ValueKind::Dict,
+            spread: None,
+            filters: vec![],
+            used_variables: vec![],
+            assigned_variables: vec![],
+        };
+        assert_eq!(
+            result,
+            Tag::Generic(GenericTag {
+                meta: TagMeta {
+                    token: token(
+                        r#"{% my_tag key1={42: 'hello', **my_var} key2={100: 'world', **other_var} %}"#,
+                        0,
+                        1,
+                        1
+                    ),
+                    name: token("my_tag", 3, 1, 4),
+                    used_variables: vec![token("my_var", 31, 1, 32), token("other_var", 61, 1, 62)],
+                    assigned_variables: vec![],
+                },
+                attrs: vec![
+                    tag_attr(Some(token("key1", 10, 1, 11)), dict_value1, false),
+                    tag_attr(Some(token("key2", 39, 1, 40)), dict_value2, false),
+                ],
+                is_self_closing: false,
+            })
+        );
+    }
+
+    #[test]
+    fn test_dict_as_kwarg_with_filter_without_arg() {
+        let input = r#"{% my_tag key={42: 'hello', **my_var}|keys %}"#;
+        let (result, _context) = plain_parse_tag_v1(input).unwrap();
+        let dict_value = TagValue {
+            token: token(r#"{42: 'hello', **my_var}|keys"#, 14, 1, 15),
+            value: token(r#"{42: 'hello', **my_var}"#, 14, 1, 15),
+            children: vec![
+                ValueChild::Value(plain_int_value("42", 15, 1, 16, None)),
+                ValueChild::Value(plain_string_value(r#"'hello'"#, 19, 1, 20, None)),
+                ValueChild::Value(plain_variable_value("my_var", 28, 1, 29, Some("**"))),
+            ],
+            kind: ValueKind::Dict,
+            spread: None,
+            filters: vec![TagValueFilter {
+                token: token("|keys", 37, 1, 38),
+                name: token("keys", 38, 1, 39),
+                arg: None,
+            }],
+            used_variables: vec![],
+            assigned_variables: vec![],
+        };
+        assert_eq!(
+            result,
+            Tag::Generic(GenericTag {
+                meta: TagMeta {
+                    token: token(r#"{% my_tag key={42: 'hello', **my_var}|keys %}"#, 0, 1, 1),
+                    name: token("my_tag", 3, 1, 4),
+                    used_variables: vec![token("my_var", 30, 1, 31)],
+                    assigned_variables: vec![],
+                },
+                attrs: vec![tag_attr(Some(token("key", 10, 1, 11)), dict_value, false)],
+                is_self_closing: false,
+            })
+        );
+    }
+
+    #[test]
+    fn test_dict_as_kwarg_with_filter_with_arg() {
+        let input = r#"{% my_tag key={42: 'hello', **my_var}|get:{1: test} %}"#;
+        let (result, _context) = plain_parse_tag_v1(input).unwrap();
+        let filter_arg_dict = TagValue {
+            token: token(r#"{1: test}"#, 42, 1, 43),
+            value: token(r#"{1: test}"#, 42, 1, 43),
+            children: vec![
+                ValueChild::Value(plain_int_value("1", 43, 1, 44, None)),
+                ValueChild::Value(plain_variable_value("test", 46, 1, 47, None)),
+            ],
+            kind: ValueKind::Dict,
+            spread: None,
+            filters: vec![],
+            used_variables: vec![],
+            assigned_variables: vec![],
+        };
+        let dict_value = TagValue {
+            token: token(r#"{42: 'hello', **my_var}|get:{1: test}"#, 14, 1, 15),
+            value: token(r#"{42: 'hello', **my_var}"#, 14, 1, 15),
+            children: vec![
+                ValueChild::Value(plain_int_value("42", 15, 1, 16, None)),
+                ValueChild::Value(plain_string_value(r#"'hello'"#, 19, 1, 20, None)),
+                ValueChild::Value(plain_variable_value("my_var", 28, 1, 29, Some("**"))),
+            ],
+            kind: ValueKind::Dict,
+            spread: None,
+            filters: vec![TagValueFilter {
+                token: token(r#"|get:{1: test}"#, 37, 1, 38),
+                name: token("get", 38, 1, 39),
+                arg: Some(filter_arg_dict),
+            }],
+            used_variables: vec![],
+            assigned_variables: vec![],
+        };
+        assert_eq!(
+            result,
+            Tag::Generic(GenericTag {
+                meta: TagMeta {
+                    token: token(
+                        r#"{% my_tag key={42: 'hello', **my_var}|get:{1: test} %}"#,
+                        0,
+                        1,
+                        1
+                    ),
+                    name: token("my_tag", 3, 1, 4),
+                    used_variables: vec![token("my_var", 30, 1, 31), token("test", 46, 1, 47)],
+                    assigned_variables: vec![],
+                },
+                attrs: vec![tag_attr(Some(token("key", 10, 1, 11)), dict_value, false)],
+                is_self_closing: false,
+            })
+        );
+    }
+
+    #[test]
+    fn test_dict_as_both_arg_and_kwarg_with_filters() {
+        let input = r#"{% my_tag {42: 'hello', **my_var}|keys key={100: 'world', **other_var}|get:{1: test} %}"#;
+        let (result, _context) = plain_parse_tag_v1(input).unwrap();
+        let dict_value1 = TagValue {
+            token: token(r#"{42: 'hello', **my_var}|keys"#, 10, 1, 11),
+            value: token(r#"{42: 'hello', **my_var}"#, 10, 1, 11),
+            children: vec![
+                ValueChild::Value(plain_int_value("42", 11, 1, 12, None)),
+                ValueChild::Value(plain_string_value(r#"'hello'"#, 15, 1, 16, None)),
+                ValueChild::Value(plain_variable_value("my_var", 24, 1, 25, Some("**"))),
+            ],
+            kind: ValueKind::Dict,
+            spread: None,
+            filters: vec![TagValueFilter {
+                token: token("|keys", 33, 1, 34),
+                name: token("keys", 34, 1, 35),
+                arg: None,
+            }],
+            used_variables: vec![],
+            assigned_variables: vec![],
+        };
+        let filter_arg_dict = TagValue {
+            token: token(r#"{1: test}"#, 75, 1, 76),
+            value: token(r#"{1: test}"#, 75, 1, 76),
+            children: vec![
+                ValueChild::Value(plain_int_value("1", 76, 1, 77, None)),
+                ValueChild::Value(plain_variable_value("test", 79, 1, 80, None)),
+            ],
+            kind: ValueKind::Dict,
+            spread: None,
+            filters: vec![],
+            used_variables: vec![],
+            assigned_variables: vec![],
+        };
+        let dict_value2 = TagValue {
+            token: token(r#"{100: 'world', **other_var}|get:{1: test}"#, 43, 1, 44),
+            value: token(r#"{100: 'world', **other_var}"#, 43, 1, 44),
+            children: vec![
+                ValueChild::Value(plain_int_value("100", 44, 1, 45, None)),
+                ValueChild::Value(plain_string_value(r#"'world'"#, 49, 1, 50, None)),
+                ValueChild::Value(plain_variable_value("other_var", 58, 1, 59, Some("**"))),
+            ],
+            kind: ValueKind::Dict,
+            spread: None,
+            filters: vec![TagValueFilter {
+                token: token(r#"|get:{1: test}"#, 70, 1, 71),
+                name: token("get", 71, 1, 72),
+                arg: Some(filter_arg_dict),
+            }],
+            used_variables: vec![],
+            assigned_variables: vec![],
+        };
+        assert_eq!(
+            result,
+            Tag::Generic(GenericTag {
+                meta: TagMeta {
+                    token: token(
+                        r#"{% my_tag {42: 'hello', **my_var}|keys key={100: 'world', **other_var}|get:{1: test} %}"#,
+                        0,
+                        1,
+                        1
+                    ),
+                    name: token("my_tag", 3, 1, 4),
+                    used_variables: vec![
+                        token("my_var", 26, 1, 27),
+                        token("other_var", 60, 1, 61),
+                        token("test", 79, 1, 80)
+                    ],
+                    assigned_variables: vec![],
+                },
+                attrs: vec![
+                    tag_attr(None, dict_value1, false),
+                    tag_attr(Some(token("key", 39, 1, 40)), dict_value2, false),
+                ],
+                is_self_closing: false,
+            })
+        );
+    }
+
+    #[test]
+    fn test_dict_as_both_arg_and_kwarg_with_filters_and_spread() {
+        let input = r#"{% my_tag ...{42: 'hello', **my_var}|keys key={100: 'world', **other_var}|get:{1: test} %}"#;
+        let (result, _context) = plain_parse_tag_v1(input).unwrap();
+        let dict_value1 = TagValue {
+            token: token(r#"...{42: 'hello', **my_var}|keys"#, 10, 1, 11),
+            value: token(r#"{42: 'hello', **my_var}"#, 13, 1, 14),
+            children: vec![
+                ValueChild::Value(plain_int_value("42", 14, 1, 15, None)),
+                ValueChild::Value(plain_string_value(r#"'hello'"#, 18, 1, 19, None)),
+                ValueChild::Value(plain_variable_value("my_var", 27, 1, 28, Some("**"))),
+            ],
+            kind: ValueKind::Dict,
+            spread: Some("...".to_string()),
+            filters: vec![TagValueFilter {
+                token: token("|keys", 36, 1, 37),
+                name: token("keys", 37, 1, 38),
+                arg: None,
+            }],
+            used_variables: vec![],
+            assigned_variables: vec![],
+        };
+        let filter_arg_dict = TagValue {
+            token: token(r#"{1: test}"#, 78, 1, 79),
+            value: token(r#"{1: test}"#, 78, 1, 79),
+            children: vec![
+                ValueChild::Value(plain_int_value("1", 79, 1, 80, None)),
+                ValueChild::Value(plain_variable_value("test", 82, 1, 83, None)),
+            ],
+            kind: ValueKind::Dict,
+            spread: None,
+            filters: vec![],
+            used_variables: vec![],
+            assigned_variables: vec![],
+        };
+        let dict_value2 = TagValue {
+            token: token(r#"{100: 'world', **other_var}|get:{1: test}"#, 46, 1, 47),
+            value: token(r#"{100: 'world', **other_var}"#, 46, 1, 47),
+            children: vec![
+                ValueChild::Value(plain_int_value("100", 47, 1, 48, None)),
+                ValueChild::Value(plain_string_value(r#"'world'"#, 52, 1, 53, None)),
+                ValueChild::Value(plain_variable_value("other_var", 61, 1, 62, Some("**"))),
+            ],
+            kind: ValueKind::Dict,
+            spread: None,
+            filters: vec![TagValueFilter {
+                token: token(r#"|get:{1: test}"#, 73, 1, 74),
+                name: token("get", 74, 1, 75),
+                arg: Some(filter_arg_dict),
+            }],
+            used_variables: vec![],
+            assigned_variables: vec![],
+        };
+        assert_eq!(
+            result,
+            Tag::Generic(GenericTag {
+                meta: TagMeta {
+                    token: token(
+                        r#"{% my_tag ...{42: 'hello', **my_var}|keys key={100: 'world', **other_var}|get:{1: test} %}"#,
+                        0,
+                        1,
+                        1
+                    ),
+                    name: token("my_tag", 3, 1, 4),
+                    used_variables: vec![
+                        token("my_var", 29, 1, 30),
+                        token("other_var", 63, 1, 64),
+                        token("test", 82, 1, 83)
+                    ],
+                    assigned_variables: vec![],
+                },
+                attrs: vec![
+                    tag_attr(None, dict_value1, false),
+                    tag_attr(Some(token("key", 42, 1, 43)), dict_value2, false),
+                ],
+                is_self_closing: false,
+            })
+        );
+    }
+
+    #[test]
+    fn test_dict_inside_list() {
+        let input = r#"{% my_tag [{42: 'hello', **my_var}] %}"#;
+        let (result, _context) = plain_parse_tag_v1(input).unwrap();
+        let dict_value = TagValue {
+            token: token(r#"{42: 'hello', **my_var}"#, 11, 1, 12),
+            value: token(r#"{42: 'hello', **my_var}"#, 11, 1, 12),
+            children: vec![
+                ValueChild::Value(plain_int_value("42", 12, 1, 13, None)),
+                ValueChild::Value(plain_string_value(r#"'hello'"#, 16, 1, 17, None)),
+                ValueChild::Value(plain_variable_value("my_var", 25, 1, 26, Some("**"))),
+            ],
+            kind: ValueKind::Dict,
+            spread: None,
+            filters: vec![],
+            used_variables: vec![],
+            assigned_variables: vec![],
+        };
+        let list_value = TagValue {
+            token: token(r#"[{42: 'hello', **my_var}]"#, 10, 1, 11),
+            value: token(r#"[{42: 'hello', **my_var}]"#, 10, 1, 11),
+            children: vec![ValueChild::Value(dict_value)],
+            kind: ValueKind::List,
+            spread: None,
+            filters: vec![],
+            used_variables: vec![],
+            assigned_variables: vec![],
+        };
+        assert_eq!(
+            result,
+            Tag::Generic(GenericTag {
+                meta: TagMeta {
+                    token: token(r#"{% my_tag [{42: 'hello', **my_var}] %}"#, 0, 1, 1),
+                    name: token("my_tag", 3, 1, 4),
+                    used_variables: vec![token("my_var", 27, 1, 28)],
+                    assigned_variables: vec![],
+                },
+                attrs: vec![tag_attr(None, list_value, false)],
+                is_self_closing: false,
+            })
+        );
+    }
+
+    #[test]
+    fn test_dict_inside_list_with_filter_without_arg() {
+        let input = r#"{% my_tag [{42: 'hello', **my_var}|keys] %}"#;
+        let (result, _context) = plain_parse_tag_v1(input).unwrap();
+        let dict_value = TagValue {
+            token: token(r#"{42: 'hello', **my_var}|keys"#, 11, 1, 12),
+            value: token(r#"{42: 'hello', **my_var}"#, 11, 1, 12),
+            children: vec![
+                ValueChild::Value(plain_int_value("42", 12, 1, 13, None)),
+                ValueChild::Value(plain_string_value(r#"'hello'"#, 16, 1, 17, None)),
+                ValueChild::Value(plain_variable_value("my_var", 25, 1, 26, Some("**"))),
+            ],
+            kind: ValueKind::Dict,
+            spread: None,
+            filters: vec![TagValueFilter {
+                token: token("|keys", 34, 1, 35),
+                name: token("keys", 35, 1, 36),
+                arg: None,
+            }],
+            used_variables: vec![],
+            assigned_variables: vec![],
+        };
+        let list_value = TagValue {
+            token: token(r#"[{42: 'hello', **my_var}|keys]"#, 10, 1, 11),
+            value: token(r#"[{42: 'hello', **my_var}|keys]"#, 10, 1, 11),
+            children: vec![ValueChild::Value(dict_value)],
+            kind: ValueKind::List,
+            spread: None,
+            filters: vec![],
+            used_variables: vec![],
+            assigned_variables: vec![],
+        };
+        assert_eq!(
+            result,
+            Tag::Generic(GenericTag {
+                meta: TagMeta {
+                    token: token(r#"{% my_tag [{42: 'hello', **my_var}|keys] %}"#, 0, 1, 1),
+                    name: token("my_tag", 3, 1, 4),
+                    used_variables: vec![token("my_var", 27, 1, 28)],
+                    assigned_variables: vec![],
+                },
+                attrs: vec![tag_attr(None, list_value, false)],
+                is_self_closing: false,
+            })
+        );
+    }
+
+    #[test]
+    fn test_dict_inside_list_with_filter_with_arg() {
+        let input = r#"{% my_tag [{42: 'hello', **my_var}|get:{1: test}] %}"#;
+        let (result, _context) = plain_parse_tag_v1(input).unwrap();
+        let filter_arg_dict = TagValue {
+            token: token(r#"{1: test}"#, 39, 1, 40),
+            value: token(r#"{1: test}"#, 39, 1, 40),
+            children: vec![
+                ValueChild::Value(plain_int_value("1", 40, 1, 41, None)),
+                ValueChild::Value(plain_variable_value("test", 43, 1, 44, None)),
+            ],
+            kind: ValueKind::Dict,
+            spread: None,
+            filters: vec![],
+            used_variables: vec![],
+            assigned_variables: vec![],
+        };
+        let dict_value = TagValue {
+            token: token(r#"{42: 'hello', **my_var}|get:{1: test}"#, 11, 1, 12),
+            value: token(r#"{42: 'hello', **my_var}"#, 11, 1, 12),
+            children: vec![
+                ValueChild::Value(plain_int_value("42", 12, 1, 13, None)),
+                ValueChild::Value(plain_string_value(r#"'hello'"#, 16, 1, 17, None)),
+                ValueChild::Value(plain_variable_value("my_var", 25, 1, 26, Some("**"))),
+            ],
+            kind: ValueKind::Dict,
+            spread: None,
+            filters: vec![TagValueFilter {
+                token: token(r#"|get:{1: test}"#, 34, 1, 35),
+                name: token("get", 35, 1, 36),
+                arg: Some(filter_arg_dict),
+            }],
+            used_variables: vec![],
+            assigned_variables: vec![],
+        };
+        let list_value = TagValue {
+            token: token(r#"[{42: 'hello', **my_var}|get:{1: test}]"#, 10, 1, 11),
+            value: token(r#"[{42: 'hello', **my_var}|get:{1: test}]"#, 10, 1, 11),
+            children: vec![ValueChild::Value(dict_value)],
+            kind: ValueKind::List,
+            spread: None,
+            filters: vec![],
+            used_variables: vec![],
+            assigned_variables: vec![],
+        };
+        assert_eq!(
+            result,
+            Tag::Generic(GenericTag {
+                meta: TagMeta {
+                    token: token(
+                        r#"{% my_tag [{42: 'hello', **my_var}|get:{1: test}] %}"#,
+                        0,
+                        1,
+                        1
+                    ),
+                    name: token("my_tag", 3, 1, 4),
+                    used_variables: vec![token("my_var", 27, 1, 28), token("test", 43, 1, 44)],
+                    assigned_variables: vec![],
+                },
+                attrs: vec![tag_attr(None, list_value, false)],
+                is_self_closing: false,
+            })
+        );
+    }
+
+    #[test]
+    fn test_dict_inside_list_with_filter_with_arg_and_spread() {
+        let input = r#"{% my_tag [*{42: 'hello', **my_var}|get:{1: test}] %}"#;
+        let (result, _context) = plain_parse_tag_v1(input).unwrap();
+        let filter_arg_dict = TagValue {
+            token: token(r#"{1: test}"#, 40, 1, 41),
+            value: token(r#"{1: test}"#, 40, 1, 41),
+            children: vec![
+                ValueChild::Value(plain_int_value("1", 41, 1, 42, None)),
+                ValueChild::Value(plain_variable_value("test", 44, 1, 45, None)),
+            ],
+            kind: ValueKind::Dict,
+            spread: None,
+            filters: vec![],
+            used_variables: vec![],
+            assigned_variables: vec![],
+        };
+        let dict_value = TagValue {
+            token: token(r#"*{42: 'hello', **my_var}|get:{1: test}"#, 11, 1, 12),
+            value: token(r#"{42: 'hello', **my_var}"#, 12, 1, 13),
+            children: vec![
+                ValueChild::Value(plain_int_value("42", 13, 1, 14, None)),
+                ValueChild::Value(plain_string_value(r#"'hello'"#, 17, 1, 18, None)),
+                ValueChild::Value(plain_variable_value("my_var", 26, 1, 27, Some("**"))),
+            ],
+            kind: ValueKind::Dict,
+            spread: Some("*".to_string()),
+            filters: vec![TagValueFilter {
+                token: token(r#"|get:{1: test}"#, 35, 1, 36),
+                name: token("get", 36, 1, 37),
+                arg: Some(filter_arg_dict),
+            }],
+            used_variables: vec![],
+            assigned_variables: vec![],
+        };
+        let list_value = TagValue {
+            token: token(r#"[*{42: 'hello', **my_var}|get:{1: test}]"#, 10, 1, 11),
+            value: token(r#"[*{42: 'hello', **my_var}|get:{1: test}]"#, 10, 1, 11),
+            children: vec![ValueChild::Value(dict_value)],
+            kind: ValueKind::List,
+            spread: None,
+            filters: vec![],
+            used_variables: vec![],
+            assigned_variables: vec![],
+        };
+        assert_eq!(
+            result,
+            Tag::Generic(GenericTag {
+                meta: TagMeta {
+                    token: token(
+                        r#"{% my_tag [*{42: 'hello', **my_var}|get:{1: test}] %}"#,
+                        0,
+                        1,
+                        1
+                    ),
+                    name: token("my_tag", 3, 1, 4),
+                    used_variables: vec![token("my_var", 28, 1, 29), token("test", 44, 1, 45)],
+                    assigned_variables: vec![],
+                },
+                attrs: vec![tag_attr(None, list_value, false)],
+                is_self_closing: false,
+            })
+        );
+    }
+
+    #[test]
+    fn test_dict_inside_list_with_spread() {
+        let input = r#"{% my_tag [*{42: 'hello', **my_var}] %}"#;
+        let (result, _context) = plain_parse_tag_v1(input).unwrap();
+        let dict_value = TagValue {
+            token: token(r#"*{42: 'hello', **my_var}"#, 11, 1, 12),
+            value: token(r#"{42: 'hello', **my_var}"#, 12, 1, 13),
+            children: vec![
+                ValueChild::Value(plain_int_value("42", 13, 1, 14, None)),
+                ValueChild::Value(plain_string_value(r#"'hello'"#, 17, 1, 18, None)),
+                ValueChild::Value(plain_variable_value("my_var", 26, 1, 27, Some("**"))),
+            ],
+            kind: ValueKind::Dict,
+            spread: Some("*".to_string()),
+            filters: vec![],
+            used_variables: vec![],
+            assigned_variables: vec![],
+        };
+        let list_value = TagValue {
+            token: token(r#"[*{42: 'hello', **my_var}]"#, 10, 1, 11),
+            value: token(r#"[*{42: 'hello', **my_var}]"#, 10, 1, 11),
+            children: vec![ValueChild::Value(dict_value)],
+            kind: ValueKind::List,
+            spread: None,
+            filters: vec![],
+            used_variables: vec![],
+            assigned_variables: vec![],
+        };
+        assert_eq!(
+            result,
+            Tag::Generic(GenericTag {
+                meta: TagMeta {
+                    token: token(r#"{% my_tag [*{42: 'hello', **my_var}] %}"#, 0, 1, 1),
+                    name: token("my_tag", 3, 1, 4),
+                    used_variables: vec![token("my_var", 28, 1, 29)],
+                    assigned_variables: vec![],
+                },
+                attrs: vec![tag_attr(None, list_value, false)],
+                is_self_closing: false,
+            })
+        );
+    }
+
+    #[test]
+    fn test_dict_inside_dict_as_value() {
+        let input = r#"{% my_tag {key: {42: 'hello', **my_var}} %}"#;
+        let (result, _context) = plain_parse_tag_v1(input).unwrap();
+        let inner_dict = TagValue {
+            token: token(r#"{42: 'hello', **my_var}"#, 16, 1, 17),
+            value: token(r#"{42: 'hello', **my_var}"#, 16, 1, 17),
+            children: vec![
+                ValueChild::Value(plain_int_value("42", 17, 1, 18, None)),
+                ValueChild::Value(plain_string_value(r#"'hello'"#, 21, 1, 22, None)),
+                ValueChild::Value(plain_variable_value("my_var", 30, 1, 31, Some("**"))),
+            ],
+            kind: ValueKind::Dict,
+            spread: None,
+            filters: vec![],
+            used_variables: vec![],
+            assigned_variables: vec![],
+        };
+        let outer_dict = TagValue {
+            token: token(r#"{key: {42: 'hello', **my_var}}"#, 10, 1, 11),
+            value: token(r#"{key: {42: 'hello', **my_var}}"#, 10, 1, 11),
+            children: vec![
+                ValueChild::Value(plain_variable_value("key", 11, 1, 12, None)),
+                ValueChild::Value(inner_dict),
+            ],
+            kind: ValueKind::Dict,
+            spread: None,
+            filters: vec![],
+            used_variables: vec![],
+            assigned_variables: vec![],
+        };
+        assert_eq!(
+            result,
+            Tag::Generic(GenericTag {
+                meta: TagMeta {
+                    token: token(r#"{% my_tag {key: {42: 'hello', **my_var}} %}"#, 0, 1, 1),
+                    name: token("my_tag", 3, 1, 4),
+                    used_variables: vec![token("key", 11, 1, 12), token("my_var", 32, 1, 33)],
+                    assigned_variables: vec![],
+                },
+                attrs: vec![tag_attr(None, outer_dict, false)],
+                is_self_closing: false,
+            })
+        );
+    }
+
+    #[test]
+    fn test_dict_inside_dict_as_value_with_filter_with_arg() {
+        let input = r#"{% my_tag {key: {42: 'hello', **my_var}|get:{1: test}} %}"#;
+        let (result, _context) = plain_parse_tag_v1(input).unwrap();
+        let filter_arg_dict = TagValue {
+            token: token(r#"{1: test}"#, 44, 1, 45),
+            value: token(r#"{1: test}"#, 44, 1, 45),
+            children: vec![
+                ValueChild::Value(plain_int_value("1", 45, 1, 46, None)),
+                ValueChild::Value(plain_variable_value("test", 48, 1, 49, None)),
+            ],
+            kind: ValueKind::Dict,
+            spread: None,
+            filters: vec![],
+            used_variables: vec![],
+            assigned_variables: vec![],
+        };
+        let inner_dict = TagValue {
+            token: token(r#"{42: 'hello', **my_var}|get:{1: test}"#, 16, 1, 17),
+            value: token(r#"{42: 'hello', **my_var}"#, 16, 1, 17),
+            children: vec![
+                ValueChild::Value(plain_int_value("42", 17, 1, 18, None)),
+                ValueChild::Value(plain_string_value(r#"'hello'"#, 21, 1, 22, None)),
+                ValueChild::Value(plain_variable_value("my_var", 30, 1, 31, Some("**"))),
+            ],
+            kind: ValueKind::Dict,
+            spread: None,
+            filters: vec![TagValueFilter {
+                token: token(r#"|get:{1: test}"#, 39, 1, 40),
+                name: token("get", 40, 1, 41),
+                arg: Some(filter_arg_dict),
+            }],
+            used_variables: vec![],
+            assigned_variables: vec![],
+        };
+        let outer_dict = TagValue {
+            token: token(r#"{key: {42: 'hello', **my_var}|get:{1: test}}"#, 10, 1, 11),
+            value: token(r#"{key: {42: 'hello', **my_var}|get:{1: test}}"#, 10, 1, 11),
+            children: vec![
+                ValueChild::Value(plain_variable_value("key", 11, 1, 12, None)),
+                ValueChild::Value(inner_dict),
+            ],
+            kind: ValueKind::Dict,
+            spread: None,
+            filters: vec![],
+            used_variables: vec![],
+            assigned_variables: vec![],
+        };
+        assert_eq!(
+            result,
+            Tag::Generic(GenericTag {
+                meta: TagMeta {
+                    token: token(
+                        r#"{% my_tag {key: {42: 'hello', **my_var}|get:{1: test}} %}"#,
+                        0,
+                        1,
+                        1
+                    ),
+                    name: token("my_tag", 3, 1, 4),
+                    used_variables: vec![
+                        token("key", 11, 1, 12),
+                        token("my_var", 32, 1, 33),
+                        token("test", 48, 1, 49)
+                    ],
+                    assigned_variables: vec![],
+                },
+                attrs: vec![tag_attr(None, outer_dict, false)],
+                is_self_closing: false,
+            })
+        );
+    }
+
+    #[test]
+    #[should_panic(expected = "ParsingError")]
+    fn test_dict_inside_dict_as_key_and_value() {
+        // Dictionaries cannot be used as dictionary keys - this should fail to parse
+        let input = r#"{% my_tag {{42: 'hello', **my_var}: {100: 'world', **other_var}} %}"#;
+        let (_result, _context) = plain_parse_tag_v1(input).unwrap();
+    }
+
+    #[test]
+    #[should_panic(expected = "ParsingError")]
+    fn test_dict_inside_dict_as_key_and_value_with_filters_and_arg() {
+        // Dictionaries cannot be used as dictionary keys - this should fail to parse
+        let input = r#"{% my_tag {{42: 'hello', **my_var}|keys: {100: 'world', **other_var}|get:{1: test}} %}"#;
+        let (_result, _context) = plain_parse_tag_v1(input).unwrap();
+    }
+
+    #[test]
+    fn test_dict_inside_dict_with_spread_and_filter() {
+        let input = r#"{% my_tag {**{42: 'hello', **my_var}|keys} %}"#;
+        let (result, _context) = plain_parse_tag_v1(input).unwrap();
+        let inner_dict = TagValue {
+            token: token(r#"**{42: 'hello', **my_var}|keys"#, 11, 1, 12),
+            value: token(r#"{42: 'hello', **my_var}"#, 13, 1, 14),
+            children: vec![
+                ValueChild::Value(plain_int_value("42", 14, 1, 15, None)),
+                ValueChild::Value(plain_string_value(r#"'hello'"#, 18, 1, 19, None)),
+                ValueChild::Value(plain_variable_value("my_var", 27, 1, 28, Some("**"))),
+            ],
+            kind: ValueKind::Dict,
+            spread: Some("**".to_string()),
+            filters: vec![TagValueFilter {
+                token: token("|keys", 36, 1, 37),
+                name: token("keys", 37, 1, 38),
+                arg: None,
+            }],
+            used_variables: vec![],
+            assigned_variables: vec![],
+        };
+        let outer_dict = TagValue {
+            token: token(r#"{**{42: 'hello', **my_var}|keys}"#, 10, 1, 11),
+            value: token(r#"{**{42: 'hello', **my_var}|keys}"#, 10, 1, 11),
+            children: vec![ValueChild::Value(inner_dict)],
+            kind: ValueKind::Dict,
+            spread: None,
+            filters: vec![],
+            used_variables: vec![],
+            assigned_variables: vec![],
+        };
+        assert_eq!(
+            result,
+            Tag::Generic(GenericTag {
+                meta: TagMeta {
+                    token: token(r#"{% my_tag {**{42: 'hello', **my_var}|keys} %}"#, 0, 1, 1),
+                    name: token("my_tag", 3, 1, 4),
+                    used_variables: vec![token("my_var", 29, 1, 30)],
+                    assigned_variables: vec![],
+                },
+                attrs: vec![tag_attr(None, outer_dict, false)],
+                is_self_closing: false,
+            })
+        );
+    }
+
+    // #######################################
+    // DICT EDGE CASES
+    // #######################################
+
+    #[test]
+    fn test_dict_filters_key() {
+        // Test filters on keys
+        let input = r#"{% my_tag {"key"|upper|lower: "value"} %}"#;
+        let (result, _context) = plain_parse_tag_v1(input).unwrap();
+
+        assert_eq!(
+            result,
+            Tag::Generic(GenericTag {
+                meta: TagMeta {
+                    token: token(r#"{% my_tag {"key"|upper|lower: "value"} %}"#, 0, 1, 1),
+                    name: token("my_tag", 3, 1, 4),
+                    used_variables: vec![],
+                    assigned_variables: vec![],
+                },
+                attrs: vec![tag_attr(
+                    None,
+                    TagValue {
+                        token: token(r#"{"key"|upper|lower: "value"}"#, 10, 1, 11),
+                        value: token(r#"{"key"|upper|lower: "value"}"#, 10, 1, 11),
+                        children: vec![
+                            ValueChild::Value(string_value(
+                                token(r#""key"|upper|lower"#, 11, 1, 12),
+                                token(r#""key""#, 11, 1, 12),
+                                None,
+                                vec![
+                                    TagValueFilter {
+                                        name: token("upper", 17, 1, 18),
+                                        token: token("|upper", 16, 1, 17),
+                                        arg: None,
+                                    },
+                                    TagValueFilter {
+                                        name: token("lower", 23, 1, 24),
+                                        token: token("|lower", 22, 1, 23),
+                                        arg: None,
+                                    },
+                                ],
+                                vec![],
+                                vec![],
+                            )),
+                            ValueChild::Value(plain_string_value(r#""value""#, 30, 1, 31, None)),
+                        ],
+                        spread: None,
+                        filters: vec![],
+                        kind: ValueKind::Dict,
+                        used_variables: vec![],
+                        assigned_variables: vec![],
+                    },
+                    false,
+                )],
+                is_self_closing: false,
+            })
+        );
+    }
+
+    #[test]
+    fn test_dict_filters_value() {
+        // Test filters on values
+        let input = r#"{% my_tag {"key": "value"|upper|lower} %}"#;
+        let (result, _context) = plain_parse_tag_v1(input).unwrap();
+
+        assert_eq!(
+            result,
+            Tag::Generic(GenericTag {
+                meta: TagMeta {
+                    token: token(r#"{% my_tag {"key": "value"|upper|lower} %}"#, 0, 1, 1),
+                    name: token("my_tag", 3, 1, 4),
+                    used_variables: vec![],
+                    assigned_variables: vec![],
+                },
+                attrs: vec![tag_attr(
+                    None,
+                    TagValue {
+                        token: token(r#"{"key": "value"|upper|lower}"#, 10, 1, 11),
+                        value: token(r#"{"key": "value"|upper|lower}"#, 10, 1, 11),
+                        children: vec![
+                            ValueChild::Value(plain_string_value(r#""key""#, 11, 1, 12, None)),
+                            ValueChild::Value(string_value(
+                                token(r#""value"|upper|lower"#, 18, 1, 19),
+                                token(r#""value""#, 18, 1, 19),
+                                None,
+                                vec![
+                                    TagValueFilter {
+                                        name: token("upper", 26, 1, 27),
+                                        token: token("|upper", 25, 1, 26),
+                                        arg: None,
+                                    },
+                                    TagValueFilter {
+                                        name: token("lower", 32, 1, 33),
+                                        token: token("|lower", 31, 1, 32),
+                                        arg: None,
+                                    },
+                                ],
+                                vec![],
+                                vec![],
+                            )),
+                        ],
+                        spread: None,
+                        filters: vec![],
+                        kind: ValueKind::Dict,
+                        used_variables: vec![],
+                        assigned_variables: vec![],
+                    },
+                    false,
+                )],
+                is_self_closing: false,
+            })
+        );
+    }
+
+    #[test]
+    fn test_dict_filters_whitespace() {
+        // Test filter on all dict
+        let input = r#"{% my_tag {"key" | default: "value" | default : empty_dict} | default : empty_dict %}"#;
+        let (result, _context) = plain_parse_tag_v1(input).unwrap();
+        assert_eq!(
+            result,
+            Tag::Generic(GenericTag {
+                meta: TagMeta {
+                    token: token(
+                        r#"{% my_tag {"key" | default: "value" | default : empty_dict} | default : empty_dict %}"#,
+                        0,
+                        1,
+                        1
+                    ),
+                    name: token("my_tag", 3, 1, 4),
+                    used_variables: vec![
+                        token("empty_dict", 48, 1, 49),
+                        token("empty_dict", 72, 1, 73)
+                    ],
+                    assigned_variables: vec![],
+                },
+                attrs: vec![tag_attr(
+                    None,
+                    TagValue {
+                        token: token(
+                            r#"{"key" | default: "value" | default : empty_dict} | default : empty_dict"#,
+                            10,
+                            1,
+                            11
+                        ),
+                        value: token(
+                            r#"{"key" | default: "value" | default : empty_dict}"#,
+                            10,
+                            1,
+                            11
+                        ),
+                        children: vec![
+                            ValueChild::Value(string_value(
+                                token(r#""key" | default"#, 11, 1, 12),
+                                token(r#""key""#, 11, 1, 12),
+                                None,
+                                vec![TagValueFilter {
+                                    name: token("default", 19, 1, 20),
+                                    token: token("| default", 17, 1, 18),
+                                    arg: None,
+                                }],
+                                vec![],
+                                vec![],
+                            )),
+                            ValueChild::Value(string_value(
+                                token(r#""value" | default : empty_dict"#, 28, 1, 29),
+                                token(r#""value""#, 28, 1, 29),
+                                None,
+                                vec![TagValueFilter {
+                                    name: token("default", 38, 1, 39),
+                                    token: token("| default : empty_dict", 36, 1, 37),
+                                    arg: Some(plain_variable_value("empty_dict", 48, 1, 49, None)),
+                                }],
+                                vec![],
+                                vec![],
+                            )),
+                        ],
+                        spread: None,
+                        filters: vec![TagValueFilter {
+                            name: token("default", 62, 1, 63),
+                            token: token("| default : empty_dict", 60, 1, 61),
+                            arg: Some(plain_variable_value("empty_dict", 72, 1, 73, None)),
+                        }],
+                        kind: ValueKind::Dict,
+                        used_variables: vec![],
+                        assigned_variables: vec![],
+                    },
+                    false,
+                )],
+                is_self_closing: false,
+            })
+        );
+    }
+
+    #[test]
+    fn test_dict_nested() {
+        // Test dict in list
+        let input = r#"{% my_tag [1, {"key": "val"}, 2] %}"#;
+        let (result, _context) = plain_parse_tag_v1(input).unwrap();
+        assert_eq!(
+            result,
+            Tag::Generic(GenericTag {
+                meta: TagMeta {
+                    token: token(r#"{% my_tag [1, {"key": "val"}, 2] %}"#, 0, 1, 1),
+                    name: token("my_tag", 3, 1, 4),
+                    used_variables: vec![],
+                    assigned_variables: vec![],
+                },
+                attrs: vec![tag_attr(
+                    None,
+                    TagValue {
+                        token: token(r#"[1, {"key": "val"}, 2]"#, 10, 1, 11),
+                        value: token(r#"[1, {"key": "val"}, 2]"#, 10, 1, 11),
+                        children: vec![
+                            ValueChild::Value(plain_int_value("1", 11, 1, 12, None)),
+                            ValueChild::Value(TagValue {
+                                token: token(r#"{"key": "val"}"#, 14, 1, 15),
+                                value: token(r#"{"key": "val"}"#, 14, 1, 15),
+                                children: vec![
+                                    ValueChild::Value(plain_string_value(
+                                        r#""key""#, 15, 1, 16, None
+                                    )),
+                                    ValueChild::Value(plain_string_value(
+                                        r#""val""#, 22, 1, 23, None
+                                    )),
+                                ],
+                                spread: None,
+                                filters: vec![],
+                                kind: ValueKind::Dict,
+                                used_variables: vec![],
+                                assigned_variables: vec![],
+                            }),
+                            ValueChild::Value(plain_int_value("2", 30, 1, 31, None)),
+                        ],
+                        spread: None,
+                        filters: vec![],
+                        kind: ValueKind::List,
+                        used_variables: vec![],
+                        assigned_variables: vec![],
+                    },
+                    false,
+                )],
+                is_self_closing: false,
+            })
+        );
+    }
+
+    #[test]
+    fn test_dict_invalid() {
+        let invalid_inputs = vec![
+            (
+                r#"{% my_tag {key|lower:my_arg: 123} %}"#,
+                "filter arguments in dictionary keys",
+            ),
+            (
+                r#"{% my_tag {"key"|default:empty_dict: "value"|default:empty_dict} %}"#,
+                "filter arguments in dictionary keys",
+            ),
+            ("{% my_tag {key} %}", "missing value"),
+            ("{% my_tag {key,} %}", "missing value with comma"),
+            ("{% my_tag {key:} %}", "missing value after colon"),
+            ("{% my_tag {:value} %}", "missing key"),
+            ("{% my_tag {key: key:} %}", "double colon"),
+            ("{% my_tag {:key :key} %}", "double key"),
+        ];
+
+        for (input, msg) in invalid_inputs {
+            assert!(
+                plain_parse_tag_v1(input).is_err(),
+                "Should not allow {}: {}",
+                msg,
+                input
+            );
+        }
+    }
+
+    #[test]
+    fn test_dict_spread() {
+        // Test spreading into dict
+        let input = r#"{% my_tag {"key1": "val1", **other_dict, "key2": "val2", **"{{ key3 }}", **_( " key4 ")} %}"#;
+        let (result, _context) = plain_parse_tag_v1(input).unwrap();
+        assert_eq!(
+            result,
+            Tag::Generic(GenericTag {
+                meta: TagMeta {
+                    token: token(
+                        r#"{% my_tag {"key1": "val1", **other_dict, "key2": "val2", **"{{ key3 }}", **_( " key4 ")} %}"#,
+                        0,
+                        1,
+                        1
+                    ),
+                    name: token("my_tag", 3, 1, 4),
+                    used_variables: vec![token("other_dict", 29, 1, 30)],
+                    assigned_variables: vec![],
+                },
+                attrs: vec![tag_attr(
+                    None,
+                    TagValue {
+                        token: token(
+                            r#"{"key1": "val1", **other_dict, "key2": "val2", **"{{ key3 }}", **_( " key4 ")}"#,
+                            10,
+                            1,
+                            11
+                        ),
+                        value: token(
+                            r#"{"key1": "val1", **other_dict, "key2": "val2", **"{{ key3 }}", **_( " key4 ")}"#,
+                            10,
+                            1,
+                            11
+                        ),
+                        children: vec![
+                            ValueChild::Value(plain_string_value(r#""key1""#, 11, 1, 12, None)),
+                            ValueChild::Value(plain_string_value(r#""val1""#, 19, 1, 20, None)),
+                            ValueChild::Value(plain_variable_value(
+                                "other_dict",
+                                27,
+                                1,
+                                28,
+                                Some("**")
+                            )),
+                            ValueChild::Value(plain_string_value(r#""key2""#, 41, 1, 42, None)),
+                            ValueChild::Value(plain_string_value(r#""val2""#, 49, 1, 50, None)),
+                            ValueChild::Value(template_string_value(
+                                token(r#"**"{{ key3 }}""#, 57, 1, 58),
+                                token(r#""{{ key3 }}""#, 59, 1, 60),
+                                Some("**"),
+                                vec![],
+                                vec![],
+                                vec![],
+                            )),
+                            ValueChild::Value(translation_value(
+                                token(r#"**_( " key4 ")"#, 73, 1, 74),
+                                Token {
+                                    content: r#"_(" key4 ")"#.to_string(),
+                                    start_index: 75,
+                                    end_index: 87,
+                                    line_col: (1, 76),
+                                },
+                                Some("**"),
+                                vec![],
+                                vec![],
+                                vec![],
+                            )),
+                        ],
+                        spread: None,
+                        filters: vec![],
+                        kind: ValueKind::Dict,
+                        used_variables: vec![],
+                        assigned_variables: vec![],
+                    },
+                    false,
+                )],
+                is_self_closing: false,
+            })
+        );
+    }
+
+    #[test]
+    fn test_dict_spread_filters() {
+        // Test spreading into dict + filters
+        let input = r#"{% my_tag {"key1": "val1"|upper, **other_dict|join:my_var, "key2": "val2"|lower, **"{{ key3 }}", **_( " key4 ")|escape} %}"#;
+        let (result, _context) = plain_parse_tag_v1(input).unwrap();
+        assert_eq!(
+            result,
+            Tag::Generic(GenericTag {
+                meta: TagMeta {
+                    token: token(
+                        r#"{% my_tag {"key1": "val1"|upper, **other_dict|join:my_var, "key2": "val2"|lower, **"{{ key3 }}", **_( " key4 ")|escape} %}"#,
+                        0,
+                        1,
+                        1
+                    ),
+                    name: token("my_tag", 3, 1, 4),
+                    used_variables: vec![
+                        token("other_dict", 35, 1, 36),
+                        token("my_var", 51, 1, 52)
+                    ],
+                    assigned_variables: vec![],
+                },
+                attrs: vec![tag_attr(
+                    None,
+                    TagValue {
+                        token: token(
+                            r#"{"key1": "val1"|upper, **other_dict|join:my_var, "key2": "val2"|lower, **"{{ key3 }}", **_( " key4 ")|escape}"#,
+                            10,
+                            1,
+                            11
+                        ),
+                        value: token(
+                            r#"{"key1": "val1"|upper, **other_dict|join:my_var, "key2": "val2"|lower, **"{{ key3 }}", **_( " key4 ")|escape}"#,
+                            10,
+                            1,
+                            11
+                        ),
+                        children: vec![
+                            ValueChild::Value(plain_string_value(r#""key1""#, 11, 1, 12, None)),
+                            ValueChild::Value(string_value(
+                                token(r#""val1"|upper"#, 19, 1, 20),
+                                token(r#""val1""#, 19, 1, 20),
+                                None,
+                                vec![TagValueFilter {
+                                    name: token("upper", 26, 1, 27),
+                                    token: token("|upper", 25, 1, 26),
+                                    arg: None,
+                                }],
+                                vec![],
+                                vec![],
+                            )),
+                            ValueChild::Value(variable_value(
+                                token(r#"**other_dict|join:my_var"#, 33, 1, 34),
+                                token("other_dict", 35, 1, 36),
+                                Some("**"),
+                                vec![TagValueFilter {
+                                    name: token("join", 46, 1, 47),
+                                    token: token("|join:my_var", 45, 1, 46),
+                                    arg: Some(plain_variable_value("my_var", 51, 1, 52, None)),
+                                }],
+                                vec![],
+                                vec![],
+                            )),
+                            ValueChild::Value(plain_string_value(r#""key2""#, 59, 1, 60, None)),
+                            ValueChild::Value(string_value(
+                                token(r#""val2"|lower"#, 67, 1, 68),
+                                token(r#""val2""#, 67, 1, 68),
+                                None,
+                                vec![TagValueFilter {
+                                    name: token("lower", 74, 1, 75),
+                                    token: token("|lower", 73, 1, 74),
+                                    arg: None,
+                                }],
+                                vec![],
+                                vec![],
+                            )),
+                            ValueChild::Value(template_string_value(
+                                token(r#"**"{{ key3 }}""#, 81, 1, 82),
+                                token(r#""{{ key3 }}""#, 83, 1, 84),
+                                Some("**"),
+                                vec![],
+                                vec![],
+                                vec![],
+                            )),
+                            ValueChild::Value(translation_value(
+                                token(r#"**_( " key4 ")|escape"#, 97, 1, 98),
+                                Token {
+                                    content: r#"_(" key4 ")"#.to_string(),
+                                    start_index: 99,
+                                    end_index: 111,
+                                    line_col: (1, 100),
+                                },
+                                Some("**"),
+                                vec![TagValueFilter {
+                                    name: token("escape", 112, 1, 113),
+                                    token: token("|escape", 111, 1, 112),
+                                    arg: None,
+                                }],
+                                vec![],
+                                vec![],
+                            )),
+                        ],
+                        spread: None,
+                        filters: vec![],
+                        kind: ValueKind::Dict,
+                        used_variables: vec![],
+                        assigned_variables: vec![],
+                    },
+                    false,
+                )],
+                is_self_closing: false,
+            })
+        );
+    }
+
+    #[test]
+    fn test_dict_spread_in_dict() {
+        // Test spreading literal dict
+        let input = r#"{% my_tag {"key1": "val1", **{"inner": "value"}, "key2": "val2"} %}"#;
+        let (result, _context) = plain_parse_tag_v1(input).unwrap();
+        assert_eq!(
+            result,
+            Tag::Generic(GenericTag {
+                meta: TagMeta {
+                    token: token(
+                        r#"{% my_tag {"key1": "val1", **{"inner": "value"}, "key2": "val2"} %}"#,
+                        0,
+                        1,
+                        1
+                    ),
+                    name: token("my_tag", 3, 1, 4),
+                    used_variables: vec![],
+                    assigned_variables: vec![],
+                },
+                attrs: vec![tag_attr(
+                    None,
+                    TagValue {
+                        token: token(
+                            r#"{"key1": "val1", **{"inner": "value"}, "key2": "val2"}"#,
+                            10,
+                            1,
+                            11
+                        ),
+                        value: token(
+                            r#"{"key1": "val1", **{"inner": "value"}, "key2": "val2"}"#,
+                            10,
+                            1,
+                            11
+                        ),
+                        children: vec![
+                            ValueChild::Value(plain_string_value(r#""key1""#, 11, 1, 12, None)),
+                            ValueChild::Value(plain_string_value(r#""val1""#, 19, 1, 20, None)),
+                            ValueChild::Value(TagValue {
+                                token: token(r#"**{"inner": "value"}"#, 27, 1, 28),
+                                value: token(r#"{"inner": "value"}"#, 29, 1, 30),
+                                children: vec![
+                                    ValueChild::Value(plain_string_value(
+                                        r#""inner""#,
+                                        30,
+                                        1,
+                                        31,
+                                        None
+                                    )),
+                                    ValueChild::Value(plain_string_value(
+                                        r#""value""#,
+                                        39,
+                                        1,
+                                        40,
+                                        None
+                                    )),
+                                ],
+                                spread: Some("**".to_string()),
+                                filters: vec![],
+                                kind: ValueKind::Dict,
+                                used_variables: vec![],
+                                assigned_variables: vec![],
+                            }),
+                            ValueChild::Value(plain_string_value(r#""key2""#, 49, 1, 50, None)),
+                            ValueChild::Value(plain_string_value(r#""val2""#, 57, 1, 58, None)),
+                        ],
+                        spread: None,
+                        filters: vec![],
+                        kind: ValueKind::Dict,
+                        used_variables: vec![],
+                        assigned_variables: vec![],
+                    },
+                    false,
+                )],
+                is_self_closing: false,
+            })
+        );
+    }
+
+    #[test]
+    fn test_dict_with_comments() {
+        // Test comments after values
+        let input = r#"{% my_tag {# comment before dict #}{{# comment after dict start #}
+            "key1": "value1", {# comment after first value #}
+            "key2": "value2"
+        {# comment before dict end #}}{# comment after dict #} %}"#;
+        let (result, _context) = plain_parse_tag_v1(input).unwrap();
+        assert_eq!(
+            result,
+            Tag::Generic(GenericTag {
+                meta: TagMeta {
+                    token: token(
+                        r#"{% my_tag {# comment before dict #}{{# comment after dict start #}
+            "key1": "value1", {# comment after first value #}
+            "key2": "value2"
+        {# comment before dict end #}}{# comment after dict #} %}"#,
+                        0,
+                        1,
+                        1
+                    ),
+                    name: token("my_tag", 3, 1, 4),
+                    used_variables: vec![],
+                    assigned_variables: vec![],
+                },
+                attrs: vec![tag_attr(
+                    None,
+                    TagValue {
+                        token: token(
+                            r#"{{# comment after dict start #}
+            "key1": "value1", {# comment after first value #}
+            "key2": "value2"
+        {# comment before dict end #}}"#,
+                            35,
+                            1,
+                            36
+                        ),
+                        value: token(
+                            r#"{{# comment after dict start #}
+            "key1": "value1", {# comment after first value #}
+            "key2": "value2"
+        {# comment before dict end #}}"#,
+                            35,
+                            1,
+                            36
+                        ),
+                        children: vec![
+                            ValueChild::Value(plain_string_value(r#""key1""#, 79, 2, 13, None)),
+                            ValueChild::Value(plain_string_value(r#""value1""#, 87, 2, 21, None)),
+                            ValueChild::Value(plain_string_value(r#""key2""#, 141, 3, 13, None)),
+                            ValueChild::Value(plain_string_value(r#""value2""#, 149, 3, 21, None)),
+                        ],
+                        spread: None,
+                        filters: vec![],
+                        kind: ValueKind::Dict,
+                        used_variables: vec![],
+                        assigned_variables: vec![],
+                    },
+                    false,
+                )],
+                is_self_closing: false,
+            })
+        );
+    }
+
+    #[test]
+    fn test_dict_comments_colons_commas() {
+        // Test comments around colons and commas
+        let input = r#"{% my_tag {
+            "key1" {# comment before colon #}: {# comment after colon #} "value1" {# comment before comma #}, {# comment after comma #}
+            "key2": "value2"
+        } %}"#;
+        let (result, _context) = plain_parse_tag_v1(input).unwrap();
+        assert_eq!(
+            result,
+            Tag::Generic(GenericTag {
+                meta: TagMeta {
+                    token: token(
+                        r#"{% my_tag {
+            "key1" {# comment before colon #}: {# comment after colon #} "value1" {# comment before comma #}, {# comment after comma #}
+            "key2": "value2"
+        } %}"#,
+                        0,
+                        1,
+                        1
+                    ),
+                    name: token("my_tag", 3, 1, 4),
+                    used_variables: vec![],
+                    assigned_variables: vec![],
+                },
+                attrs: vec![tag_attr(
+                    None,
+                    TagValue {
+                        token: token(
+                            r#"{
+            "key1" {# comment before colon #}: {# comment after colon #} "value1" {# comment before comma #}, {# comment after comma #}
+            "key2": "value2"
+        }"#,
+                            10,
+                            1,
+                            11
+                        ),
+                        value: token(
+                            r#"{
+            "key1" {# comment before colon #}: {# comment after colon #} "value1" {# comment before comma #}, {# comment after comma #}
+            "key2": "value2"
+        }"#,
+                            10,
+                            1,
+                            11
+                        ),
+                        children: vec![
+                            ValueChild::Value(plain_string_value(r#""key1""#, 24, 2, 13, None)),
+                            ValueChild::Value(plain_string_value(r#""value1""#, 85, 2, 74, None)),
+                            ValueChild::Value(plain_string_value(r#""key2""#, 160, 3, 13, None)),
+                            ValueChild::Value(plain_string_value(r#""value2""#, 168, 3, 21, None)),
+                        ],
+                        spread: None,
+                        filters: vec![],
+                        kind: ValueKind::Dict,
+                        used_variables: vec![],
+                        assigned_variables: vec![],
+                    },
+                    false,
+                )],
+                is_self_closing: false,
+            })
+        );
+    }
+
+    #[test]
+    fn test_dict_comments_spread() {
+        // Test comments around spread operator
+        let input = r#"{% my_tag {
+            "key1": "value1",
+            {# comment before spread #}**{# comment after spread #}{"key2": "value2"}
+        } %}"#;
+        let (result, _context) = plain_parse_tag_v1(input).unwrap();
+        assert_eq!(
+            result,
+            Tag::Generic(GenericTag {
+                meta: TagMeta {
+                    token: token(
+                        r#"{% my_tag {
+            "key1": "value1",
+            {# comment before spread #}**{# comment after spread #}{"key2": "value2"}
+        } %}"#,
+                        0,
+                        1,
+                        1
+                    ),
+                    name: token("my_tag", 3, 1, 4),
+                    used_variables: vec![],
+                    assigned_variables: vec![],
+                },
+                attrs: vec![tag_attr(
+                    None,
+                    TagValue {
+                        token: token(
+                            r#"{
+            "key1": "value1",
+            {# comment before spread #}**{# comment after spread #}{"key2": "value2"}
+        }"#,
+                            10,
+                            1,
+                            11
+                        ),
+                        value: token(
+                            r#"{
+            "key1": "value1",
+            {# comment before spread #}**{# comment after spread #}{"key2": "value2"}
+        }"#,
+                            10,
+                            1,
+                            11
+                        ),
+                        children: vec![
+                            ValueChild::Value(plain_string_value(r#""key1""#, 24, 2, 13, None)),
+                            ValueChild::Value(plain_string_value(r#""value1""#, 32, 2, 21, None)),
+                            ValueChild::Value(TagValue {
+                                token: token(r#"**{# comment after spread #}{"key2": "value2"}"#, 81, 3, 40),
+                                value: token(r#"{"key2": "value2"}"#, 109, 3, 68),
+                                children: vec![
+                                    ValueChild::Value(plain_string_value(
+                                        r#""key2""#,
+                                        110,
+                                        3,
+                                        69,
+                                        None
+                                    )),
+                                    ValueChild::Value(plain_string_value(
+                                        r#""value2""#,
+                                        118,
+                                        3,
+                                        77,
+                                        None
+                                    )),
+                                ],
+                                spread: Some("**".to_string()),
+                                filters: vec![],
+                                kind: ValueKind::Dict,
+                                used_variables: vec![],
+                                assigned_variables: vec![],
+                            }),
+                        ],
+                        spread: None,
+                        filters: vec![],
+                        kind: ValueKind::Dict,
+                        used_variables: vec![],
+                        assigned_variables: vec![],
+                    },
+                    false,
+                )],
+                is_self_closing: false,
+            })
+        );
+    }
+}

--- a/crates/djc-template-parser/tests/tag_parser_endtag.rs
+++ b/crates/djc-template-parser/tests/tag_parser_endtag.rs
@@ -1,0 +1,118 @@
+mod common;
+
+#[cfg(test)]
+mod tests {
+    use djc_template_parser::ast::{EndTag, GenericTag, Tag, TagMeta};
+
+    use super::common::{plain_parse_tag_v1, token};
+
+    #[test]
+    fn test_endtag_basic() {
+        let input = "{% endslot %}";
+        let (result, _context) = plain_parse_tag_v1(input).unwrap();
+
+        assert_eq!(
+            result,
+            Tag::End(EndTag {
+                meta: TagMeta {
+                    token: token("{% endslot %}", 0, 1, 1),
+                    name: token("endslot", 3, 1, 4),
+                    used_variables: vec![],
+                    assigned_variables: vec![],
+                }
+            })
+        );
+    }
+
+    #[test]
+    fn test_endtag_no_whitespace() {
+        let input = "{%endslot%}";
+        let (result, _context) = plain_parse_tag_v1(input).unwrap();
+
+        assert_eq!(
+            result,
+            Tag::End(EndTag {
+                meta: TagMeta {
+                    token: token("{%endslot%}", 0, 1, 1),
+                    name: token("endslot", 2, 1, 3),
+                    used_variables: vec![],
+                    assigned_variables: vec![],
+                }
+            })
+        );
+    }
+
+    #[test]
+    fn test_endtag_with_comments() {
+        let input = "{% {# c1 #} endslot {# c2 #} %}";
+        let (result, _context) = plain_parse_tag_v1(input).unwrap();
+
+        assert_eq!(
+            result,
+            Tag::End(EndTag {
+                meta: TagMeta {
+                    token: token("{% {# c1 #} endslot {# c2 #} %}", 0, 1, 1),
+                    name: token("endslot", 12, 1, 13),
+                    used_variables: vec![],
+                    assigned_variables: vec![],
+                }
+            })
+        );
+    }
+
+    #[test]
+    fn test_endtag_with_comments_no_spaces() {
+        let input = "{%{# c1 #}endslot{# c2 #}%}";
+        let (result, _context) = plain_parse_tag_v1(input).unwrap();
+
+        assert_eq!(
+            result,
+            Tag::End(EndTag {
+                meta: TagMeta {
+                    token: token("{%{# c1 #}endslot{# c2 #}%}", 0, 1, 1),
+                    name: token("endslot", 10, 1, 11),
+                    used_variables: vec![],
+                    assigned_variables: vec![],
+                }
+            })
+        );
+    }
+
+    #[test]
+    fn test_endtag_with_attribute_errors() {
+        let input = "{% endslot key=val %}";
+        assert!(
+            plain_parse_tag_v1(input).is_err(),
+            "End tags should not allow attributes"
+        );
+    }
+
+    #[test]
+    fn test_endtag_self_closing_errors() {
+        let input = "{% endslot / %}";
+        assert!(
+            plain_parse_tag_v1(input).is_err(),
+            "End tags should not be self-closing"
+        );
+    }
+
+    #[test]
+    fn test_end_as_generic_tag() {
+        let input = "{% end %}";
+        let (result, _context) = plain_parse_tag_v1(input).unwrap();
+
+        assert_eq!(
+            result,
+            Tag::Generic(GenericTag {
+                meta: TagMeta {
+                    token: token("{% end %}", 0, 1, 1),
+                    name: token("end", 3, 1, 4),
+                    used_variables: vec![],
+                    assigned_variables: vec![],
+                },
+                attrs: vec![],
+                is_self_closing: false,
+            })
+        );
+    }
+}

--- a/crates/djc-template-parser/tests/tag_parser_float.rs
+++ b/crates/djc-template-parser/tests/tag_parser_float.rs
@@ -1,0 +1,927 @@
+// Each of the `tag_parser_<data_type>.rs` file tests following cases:
+//  1. as arg
+//  2. as multiple args
+//  3. as arg with filter without filter arg
+//  4. as arg with filter with filter arg
+//  5. as arg with `...` spread
+//  6. as kwarg
+//  7. as multiple kwargs
+//  8. as kwarg with filter without filter arg
+//  9. as kwarg with filter with filter arg
+// 10. as both arg and kwarg with filters
+// 11. as both arg and kwarg with filters and arg with `...` spreads
+// 12. inside list
+// 13. inside list with filter without filter arg
+// 14. inside list with filter with filter arg
+// 15. inside list with filter with filter arg and `*` spread.
+// 16. inside list with `*` spread.
+// 17. inside dict as value
+// 18. inside dict as value with filter with filter arg
+// 19. inside dict as key and value
+// 20. inside dict as key and value, both with filters, and value with filter arg.
+// 21. inside dict as neither key nor value, with `**` spread and filter without arg
+
+mod common;
+
+#[cfg(test)]
+mod tests {
+    use std::vec;
+
+    use djc_template_parser::ast::{
+        GenericTag, Tag, TagMeta, TagValue, TagValueFilter, ValueChild, ValueKind,
+    };
+
+    use super::common::{
+        float_value, plain_float_value, plain_parse_tag_v1, plain_variable_value, tag_attr, token,
+    };
+
+    #[test]
+    fn test_float_as_arg() {
+        let input = r#"{% my_tag 42.5 %}"#;
+        let (result, _context) = plain_parse_tag_v1(input).unwrap();
+        assert_eq!(
+            result,
+            Tag::Generic(GenericTag {
+                meta: TagMeta {
+                    token: token(r#"{% my_tag 42.5 %}"#, 0, 1, 1),
+                    name: token("my_tag", 3, 1, 4),
+                    used_variables: vec![],
+                    assigned_variables: vec![],
+                },
+                attrs: vec![tag_attr(
+                    None,
+                    plain_float_value("42.5", 10, 1, 11, None),
+                    false
+                )],
+                is_self_closing: false,
+            })
+        );
+    }
+
+    #[test]
+    fn test_float_as_multiple_args() {
+        let input = r#"{% my_tag 123.45 456.78 %}"#;
+        let (result, _context) = plain_parse_tag_v1(input).unwrap();
+        assert_eq!(
+            result,
+            Tag::Generic(GenericTag {
+                meta: TagMeta {
+                    token: token(r#"{% my_tag 123.45 456.78 %}"#, 0, 1, 1),
+                    name: token("my_tag", 3, 1, 4),
+                    used_variables: vec![],
+                    assigned_variables: vec![],
+                },
+                attrs: vec![
+                    tag_attr(None, plain_float_value("123.45", 10, 1, 11, None), false),
+                    tag_attr(None, plain_float_value("456.78", 17, 1, 18, None), false),
+                ],
+                is_self_closing: false,
+            })
+        );
+    }
+
+    #[test]
+    fn test_float_as_arg_with_filter_without_arg() {
+        let input = r#"{% my_tag 42.5|abs %}"#;
+        let (result, _context) = plain_parse_tag_v1(input).unwrap();
+        assert_eq!(
+            result,
+            Tag::Generic(GenericTag {
+                meta: TagMeta {
+                    token: token(r#"{% my_tag 42.5|abs %}"#, 0, 1, 1),
+                    name: token("my_tag", 3, 1, 4),
+                    used_variables: vec![],
+                    assigned_variables: vec![],
+                },
+                attrs: vec![tag_attr(
+                    None,
+                    float_value(
+                        token("42.5|abs", 10, 1, 11),
+                        token("42.5", 10, 1, 11),
+                        None,
+                        vec![TagValueFilter {
+                            token: token("|abs", 14, 1, 15),
+                            name: token("abs", 15, 1, 16),
+                            arg: None,
+                        }],
+                        vec![],
+                        vec![],
+                    ),
+                    false
+                )],
+                is_self_closing: false,
+            })
+        );
+    }
+
+    #[test]
+    fn test_float_as_arg_with_filter_with_arg() {
+        let input = r#"{% my_tag 42.5|add:5.5 %}"#;
+        let (result, _context) = plain_parse_tag_v1(input).unwrap();
+        assert_eq!(
+            result,
+            Tag::Generic(GenericTag {
+                meta: TagMeta {
+                    token: token(r#"{% my_tag 42.5|add:5.5 %}"#, 0, 1, 1),
+                    name: token("my_tag", 3, 1, 4),
+                    used_variables: vec![],
+                    assigned_variables: vec![],
+                },
+                attrs: vec![tag_attr(
+                    None,
+                    float_value(
+                        token("42.5|add:5.5", 10, 1, 11),
+                        token("42.5", 10, 1, 11),
+                        None,
+                        vec![TagValueFilter {
+                            token: token("|add:5.5", 14, 1, 15),
+                            name: token("add", 15, 1, 16),
+                            arg: Some(plain_float_value("5.5", 19, 1, 20, None)),
+                        }],
+                        vec![],
+                        vec![],
+                    ),
+                    false
+                )],
+                is_self_closing: false,
+            })
+        );
+    }
+
+    #[test]
+    fn test_float_as_arg_with_spread() {
+        let input = r#"{% my_tag ...42.5 %}"#;
+        let (result, _context) = plain_parse_tag_v1(input).unwrap();
+        assert_eq!(
+            result,
+            Tag::Generic(GenericTag {
+                meta: TagMeta {
+                    token: token(r#"{% my_tag ...42.5 %}"#, 0, 1, 1),
+                    name: token("my_tag", 3, 1, 4),
+                    used_variables: vec![],
+                    assigned_variables: vec![],
+                },
+                attrs: vec![tag_attr(
+                    None,
+                    plain_float_value("42.5", 10, 1, 11, Some("...")),
+                    false
+                )],
+                is_self_closing: false,
+            })
+        );
+    }
+
+    #[test]
+    fn test_float_as_kwarg() {
+        let input = r#"{% my_tag key=42.5 %}"#;
+        let (result, _context) = plain_parse_tag_v1(input).unwrap();
+        assert_eq!(
+            result,
+            Tag::Generic(GenericTag {
+                meta: TagMeta {
+                    token: token(r#"{% my_tag key=42.5 %}"#, 0, 1, 1),
+                    name: token("my_tag", 3, 1, 4),
+                    used_variables: vec![],
+                    assigned_variables: vec![],
+                },
+                attrs: vec![tag_attr(
+                    Some(token("key", 10, 1, 11)),
+                    plain_float_value("42.5", 14, 1, 15, None),
+                    false
+                )],
+                is_self_closing: false,
+            })
+        );
+    }
+
+    #[test]
+    fn test_float_as_multiple_kwargs() {
+        let input = r#"{% my_tag key1=123.45 key2=456.78 %}"#;
+        let (result, _context) = plain_parse_tag_v1(input).unwrap();
+        assert_eq!(
+            result,
+            Tag::Generic(GenericTag {
+                meta: TagMeta {
+                    token: token("{% my_tag key1=123.45 key2=456.78 %}", 0, 1, 1),
+                    name: token("my_tag", 3, 1, 4),
+                    used_variables: vec![],
+                    assigned_variables: vec![],
+                },
+                attrs: vec![
+                    tag_attr(
+                        Some(token("key1", 10, 1, 11)),
+                        plain_float_value("123.45", 15, 1, 16, None),
+                        false
+                    ),
+                    tag_attr(
+                        Some(token("key2", 22, 1, 23)),
+                        plain_float_value("456.78", 27, 1, 28, None),
+                        false
+                    ),
+                ],
+                is_self_closing: false,
+            })
+        );
+    }
+
+    #[test]
+    fn test_float_as_kwarg_with_filter_without_arg() {
+        let input = r#"{% my_tag key=42.5|abs %}"#;
+        let (result, _context) = plain_parse_tag_v1(input).unwrap();
+        assert_eq!(
+            result,
+            Tag::Generic(GenericTag {
+                meta: TagMeta {
+                    token: token(r#"{% my_tag key=42.5|abs %}"#, 0, 1, 1),
+                    name: token("my_tag", 3, 1, 4),
+                    used_variables: vec![],
+                    assigned_variables: vec![],
+                },
+                attrs: vec![tag_attr(
+                    Some(token("key", 10, 1, 11)),
+                    float_value(
+                        token("42.5|abs", 14, 1, 15),
+                        token("42.5", 14, 1, 15),
+                        None,
+                        vec![TagValueFilter {
+                            token: token("|abs", 18, 1, 19),
+                            name: token("abs", 19, 1, 20),
+                            arg: None,
+                        }],
+                        vec![],
+                        vec![],
+                    ),
+                    false
+                )],
+                is_self_closing: false,
+            })
+        );
+    }
+
+    #[test]
+    fn test_float_as_kwarg_with_filter_with_arg() {
+        let input = r#"{% my_tag key=42.5|add:5.5 %}"#;
+        let (result, _context) = plain_parse_tag_v1(input).unwrap();
+        assert_eq!(
+            result,
+            Tag::Generic(GenericTag {
+                meta: TagMeta {
+                    token: token(r#"{% my_tag key=42.5|add:5.5 %}"#, 0, 1, 1),
+                    name: token("my_tag", 3, 1, 4),
+                    used_variables: vec![],
+                    assigned_variables: vec![],
+                },
+                attrs: vec![tag_attr(
+                    Some(token("key", 10, 1, 11)),
+                    float_value(
+                        token("42.5|add:5.5", 14, 1, 15),
+                        token("42.5", 14, 1, 15),
+                        None,
+                        vec![TagValueFilter {
+                            token: token("|add:5.5", 18, 1, 19),
+                            name: token("add", 19, 1, 20),
+                            arg: Some(plain_float_value("5.5", 23, 1, 24, None)),
+                        }],
+                        vec![],
+                        vec![],
+                    ),
+                    false
+                )],
+                is_self_closing: false,
+            })
+        );
+    }
+
+    #[test]
+    fn test_float_as_both_arg_and_kwarg_with_filters() {
+        let input = r#"{% my_tag 42.5|abs key=123.45|abs %}"#;
+        let (result, _context) = plain_parse_tag_v1(input).unwrap();
+        assert_eq!(
+            result,
+            Tag::Generic(GenericTag {
+                meta: TagMeta {
+                    token: token(r#"{% my_tag 42.5|abs key=123.45|abs %}"#, 0, 1, 1),
+                    name: token("my_tag", 3, 1, 4),
+                    used_variables: vec![],
+                    assigned_variables: vec![],
+                },
+                attrs: vec![
+                    tag_attr(
+                        None,
+                        float_value(
+                            token("42.5|abs", 10, 1, 11),
+                            token("42.5", 10, 1, 11),
+                            None,
+                            vec![TagValueFilter {
+                                token: token("|abs", 14, 1, 15),
+                                name: token("abs", 15, 1, 16),
+                                arg: None,
+                            }],
+                            vec![],
+                            vec![],
+                        ),
+                        false
+                    ),
+                    tag_attr(
+                        Some(token("key", 19, 1, 20)),
+                        float_value(
+                            token("123.45|abs", 23, 1, 24),
+                            token("123.45", 23, 1, 24),
+                            None,
+                            vec![TagValueFilter {
+                                token: token("|abs", 29, 1, 30),
+                                name: token("abs", 30, 1, 31),
+                                arg: None,
+                            }],
+                            vec![],
+                            vec![],
+                        ),
+                        false
+                    ),
+                ],
+                is_self_closing: false,
+            })
+        );
+    }
+
+    #[test]
+    fn test_float_as_both_arg_and_kwarg_with_filters_and_spread() {
+        let input = r#"{% my_tag ...42.5|abs key=123.45|abs %}"#;
+        let (result, _context) = plain_parse_tag_v1(input).unwrap();
+        assert_eq!(
+            result,
+            Tag::Generic(GenericTag {
+                meta: TagMeta {
+                    token: token(r#"{% my_tag ...42.5|abs key=123.45|abs %}"#, 0, 1, 1),
+                    name: token("my_tag", 3, 1, 4),
+                    used_variables: vec![],
+                    assigned_variables: vec![],
+                },
+                attrs: vec![
+                    tag_attr(
+                        None,
+                        float_value(
+                            token("...42.5|abs", 10, 1, 11),
+                            token("42.5", 13, 1, 14),
+                            Some("..."),
+                            vec![TagValueFilter {
+                                token: token("|abs", 17, 1, 18),
+                                name: token("abs", 18, 1, 19),
+                                arg: None,
+                            }],
+                            vec![],
+                            vec![],
+                        ),
+                        false
+                    ),
+                    tag_attr(
+                        Some(token("key", 22, 1, 23)),
+                        float_value(
+                            token("123.45|abs", 26, 1, 27),
+                            token("123.45", 26, 1, 27),
+                            None,
+                            vec![TagValueFilter {
+                                token: token("|abs", 32, 1, 33),
+                                name: token("abs", 33, 1, 34),
+                                arg: None,
+                            }],
+                            vec![],
+                            vec![],
+                        ),
+                        false
+                    ),
+                ],
+                is_self_closing: false,
+            })
+        );
+    }
+
+    #[test]
+    fn test_float_inside_list() {
+        let input = r#"{% my_tag [42.5] %}"#;
+        let (result, _context) = plain_parse_tag_v1(input).unwrap();
+        let list_value = TagValue {
+            token: token("[42.5]", 10, 1, 11),
+            value: token("[42.5]", 10, 1, 11),
+            children: vec![ValueChild::Value(plain_float_value(
+                "42.5", 11, 1, 12, None,
+            ))],
+            kind: ValueKind::List,
+            spread: None,
+            filters: vec![],
+            used_variables: vec![],
+            assigned_variables: vec![],
+        };
+        assert_eq!(
+            result,
+            Tag::Generic(GenericTag {
+                meta: TagMeta {
+                    token: token(r#"{% my_tag [42.5] %}"#, 0, 1, 1),
+                    name: token("my_tag", 3, 1, 4),
+                    used_variables: vec![],
+                    assigned_variables: vec![],
+                },
+                attrs: vec![tag_attr(None, list_value, false)],
+                is_self_closing: false,
+            })
+        );
+    }
+
+    #[test]
+    fn test_float_inside_list_with_filter_without_arg() {
+        let input = r#"{% my_tag [42.5|abs] %}"#;
+        let (result, _context) = plain_parse_tag_v1(input).unwrap();
+        let list_value = TagValue {
+            token: token("[42.5|abs]", 10, 1, 11),
+            value: token("[42.5|abs]", 10, 1, 11),
+            children: vec![ValueChild::Value(float_value(
+                token("42.5|abs", 11, 1, 12),
+                token("42.5", 11, 1, 12),
+                None,
+                vec![TagValueFilter {
+                    token: token("|abs", 15, 1, 16),
+                    name: token("abs", 16, 1, 17),
+                    arg: None,
+                }],
+                vec![],
+                vec![],
+            ))],
+            kind: ValueKind::List,
+            spread: None,
+            filters: vec![],
+            used_variables: vec![],
+            assigned_variables: vec![],
+        };
+        assert_eq!(
+            result,
+            Tag::Generic(GenericTag {
+                meta: TagMeta {
+                    token: token(r#"{% my_tag [42.5|abs] %}"#, 0, 1, 1),
+                    name: token("my_tag", 3, 1, 4),
+                    used_variables: vec![],
+                    assigned_variables: vec![],
+                },
+                attrs: vec![tag_attr(None, list_value, false)],
+                is_self_closing: false,
+            })
+        );
+    }
+
+    #[test]
+    fn test_float_inside_list_with_filter_with_arg() {
+        let input = r#"{% my_tag [42.5|add:5.5] %}"#;
+        let (result, _context) = plain_parse_tag_v1(input).unwrap();
+        let list_value = TagValue {
+            token: token("[42.5|add:5.5]", 10, 1, 11),
+            value: token("[42.5|add:5.5]", 10, 1, 11),
+            children: vec![ValueChild::Value(float_value(
+                token("42.5|add:5.5", 11, 1, 12),
+                token("42.5", 11, 1, 12),
+                None,
+                vec![TagValueFilter {
+                    token: token("|add:5.5", 15, 1, 16),
+                    name: token("add", 16, 1, 17),
+                    arg: Some(plain_float_value("5.5", 20, 1, 21, None)),
+                }],
+                vec![],
+                vec![],
+            ))],
+            kind: ValueKind::List,
+            spread: None,
+            filters: vec![],
+            used_variables: vec![],
+            assigned_variables: vec![],
+        };
+        assert_eq!(
+            result,
+            Tag::Generic(GenericTag {
+                meta: TagMeta {
+                    token: token(r#"{% my_tag [42.5|add:5.5] %}"#, 0, 1, 1),
+                    name: token("my_tag", 3, 1, 4),
+                    used_variables: vec![],
+                    assigned_variables: vec![],
+                },
+                attrs: vec![tag_attr(None, list_value, false)],
+                is_self_closing: false,
+            })
+        );
+    }
+
+    #[test]
+    fn test_float_inside_list_with_filter_with_arg_and_spread() {
+        let input = r#"{% my_tag [*42.5|add:5.5] %}"#;
+        let (result, _context) = plain_parse_tag_v1(input).unwrap();
+        let list_value = TagValue {
+            token: token("[*42.5|add:5.5]", 10, 1, 11),
+            value: token("[*42.5|add:5.5]", 10, 1, 11),
+            children: vec![ValueChild::Value(float_value(
+                token("*42.5|add:5.5", 11, 1, 12),
+                token("42.5", 12, 1, 13),
+                Some("*"),
+                vec![TagValueFilter {
+                    token: token("|add:5.5", 16, 1, 17),
+                    name: token("add", 17, 1, 18),
+                    arg: Some(plain_float_value("5.5", 21, 1, 22, None)),
+                }],
+                vec![],
+                vec![],
+            ))],
+            kind: ValueKind::List,
+            spread: None,
+            filters: vec![],
+            used_variables: vec![],
+            assigned_variables: vec![],
+        };
+        assert_eq!(
+            result,
+            Tag::Generic(GenericTag {
+                meta: TagMeta {
+                    token: token(r#"{% my_tag [*42.5|add:5.5] %}"#, 0, 1, 1),
+                    name: token("my_tag", 3, 1, 4),
+                    used_variables: vec![],
+                    assigned_variables: vec![],
+                },
+                attrs: vec![tag_attr(None, list_value, false)],
+                is_self_closing: false,
+            })
+        );
+    }
+
+    #[test]
+    fn test_float_inside_list_with_spread() {
+        let input = r#"{% my_tag [*42.5] %}"#;
+        let (result, _context) = plain_parse_tag_v1(input).unwrap();
+        let list_value = TagValue {
+            token: token("[*42.5]", 10, 1, 11),
+            value: token("[*42.5]", 10, 1, 11),
+            children: vec![ValueChild::Value(plain_float_value(
+                "42.5",
+                11,
+                1,
+                12,
+                Some("*"),
+            ))],
+            kind: ValueKind::List,
+            spread: None,
+            filters: vec![],
+            used_variables: vec![],
+            assigned_variables: vec![],
+        };
+        assert_eq!(
+            result,
+            Tag::Generic(GenericTag {
+                meta: TagMeta {
+                    token: token(r#"{% my_tag [*42.5] %}"#, 0, 1, 1),
+                    name: token("my_tag", 3, 1, 4),
+                    used_variables: vec![],
+                    assigned_variables: vec![],
+                },
+                attrs: vec![tag_attr(None, list_value, false)],
+                is_self_closing: false,
+            })
+        );
+    }
+
+    #[test]
+    fn test_float_inside_dict_as_value() {
+        let input = r#"{% my_tag {key: 42.5} %}"#;
+        let (result, _context) = plain_parse_tag_v1(input).unwrap();
+        let dict_value = TagValue {
+            token: token("{key: 42.5}", 10, 1, 11),
+            value: token("{key: 42.5}", 10, 1, 11),
+            children: vec![
+                ValueChild::Value(plain_variable_value("key", 11, 1, 12, None)),
+                ValueChild::Value(plain_float_value("42.5", 16, 1, 17, None)),
+            ],
+            kind: ValueKind::Dict,
+            spread: None,
+            filters: vec![],
+            used_variables: vec![],
+            assigned_variables: vec![],
+        };
+        assert_eq!(
+            result,
+            Tag::Generic(GenericTag {
+                meta: TagMeta {
+                    token: token(r#"{% my_tag {key: 42.5} %}"#, 0, 1, 1),
+                    name: token("my_tag", 3, 1, 4),
+                    used_variables: vec![token("key", 11, 1, 12)],
+                    assigned_variables: vec![],
+                },
+                attrs: vec![tag_attr(None, dict_value, false)],
+                is_self_closing: false,
+            })
+        );
+    }
+
+    #[test]
+    fn test_float_inside_dict_as_value_with_filter_with_arg() {
+        let input = r#"{% my_tag {key: 42.5|add:5.5} %}"#;
+        let (result, _context) = plain_parse_tag_v1(input).unwrap();
+        let dict_value = TagValue {
+            token: token("{key: 42.5|add:5.5}", 10, 1, 11),
+            value: token("{key: 42.5|add:5.5}", 10, 1, 11),
+            children: vec![
+                ValueChild::Value(plain_variable_value("key", 11, 1, 12, None)),
+                ValueChild::Value(float_value(
+                    token("42.5|add:5.5", 16, 1, 17),
+                    token("42.5", 16, 1, 17),
+                    None,
+                    vec![TagValueFilter {
+                        token: token("|add:5.5", 20, 1, 21),
+                        name: token("add", 21, 1, 22),
+                        arg: Some(plain_float_value("5.5", 25, 1, 26, None)),
+                    }],
+                    vec![],
+                    vec![],
+                )),
+            ],
+            kind: ValueKind::Dict,
+            spread: None,
+            filters: vec![],
+            used_variables: vec![],
+            assigned_variables: vec![],
+        };
+        assert_eq!(
+            result,
+            Tag::Generic(GenericTag {
+                meta: TagMeta {
+                    token: token(r#"{% my_tag {key: 42.5|add:5.5} %}"#, 0, 1, 1),
+                    name: token("my_tag", 3, 1, 4),
+                    used_variables: vec![token("key", 11, 1, 12)],
+                    assigned_variables: vec![],
+                },
+                attrs: vec![tag_attr(None, dict_value, false)],
+                is_self_closing: false,
+            })
+        );
+    }
+
+    #[test]
+    fn test_float_inside_dict_as_key_and_value() {
+        let input = r#"{% my_tag {42.5: 123.45} %}"#;
+        let (result, _context) = plain_parse_tag_v1(input).unwrap();
+        let dict_value = TagValue {
+            token: token("{42.5: 123.45}", 10, 1, 11),
+            value: token("{42.5: 123.45}", 10, 1, 11),
+            children: vec![
+                ValueChild::Value(plain_float_value("42.5", 11, 1, 12, None)),
+                ValueChild::Value(plain_float_value("123.45", 17, 1, 18, None)),
+            ],
+            kind: ValueKind::Dict,
+            spread: None,
+            filters: vec![],
+            used_variables: vec![],
+            assigned_variables: vec![],
+        };
+        assert_eq!(
+            result,
+            Tag::Generic(GenericTag {
+                meta: TagMeta {
+                    token: token(r#"{% my_tag {42.5: 123.45} %}"#, 0, 1, 1),
+                    name: token("my_tag", 3, 1, 4),
+                    used_variables: vec![],
+                    assigned_variables: vec![],
+                },
+                attrs: vec![tag_attr(None, dict_value, false)],
+                is_self_closing: false,
+            })
+        );
+    }
+
+    #[test]
+    fn test_float_inside_dict_as_key_and_value_with_filters_and_arg() {
+        let input = r#"{% my_tag {42.5|abs: 123.45|add:5.5} %}"#;
+        let (result, _context) = plain_parse_tag_v1(input).unwrap();
+        let dict_value = TagValue {
+            token: token("{42.5|abs: 123.45|add:5.5}", 10, 1, 11),
+            value: token("{42.5|abs: 123.45|add:5.5}", 10, 1, 11),
+            children: vec![
+                ValueChild::Value(float_value(
+                    token("42.5|abs", 11, 1, 12),
+                    token("42.5", 11, 1, 12),
+                    None,
+                    vec![TagValueFilter {
+                        token: token("|abs", 15, 1, 16),
+                        name: token("abs", 16, 1, 17),
+                        arg: None,
+                    }],
+                    vec![],
+                    vec![],
+                )),
+                ValueChild::Value(float_value(
+                    token("123.45|add:5.5", 21, 1, 22),
+                    token("123.45", 21, 1, 22),
+                    None,
+                    vec![TagValueFilter {
+                        token: token("|add:5.5", 27, 1, 28),
+                        name: token("add", 28, 1, 29),
+                        arg: Some(plain_float_value("5.5", 32, 1, 33, None)),
+                    }],
+                    vec![],
+                    vec![],
+                )),
+            ],
+            kind: ValueKind::Dict,
+            spread: None,
+            filters: vec![],
+            used_variables: vec![],
+            assigned_variables: vec![],
+        };
+        assert_eq!(
+            result,
+            Tag::Generic(GenericTag {
+                meta: TagMeta {
+                    token: token(r#"{% my_tag {42.5|abs: 123.45|add:5.5} %}"#, 0, 1, 1),
+                    name: token("my_tag", 3, 1, 4),
+                    used_variables: vec![],
+                    assigned_variables: vec![],
+                },
+                attrs: vec![tag_attr(None, dict_value, false)],
+                is_self_closing: false,
+            })
+        );
+    }
+
+    #[test]
+    fn test_float_inside_dict_with_spread_and_filter() {
+        let input = r#"{% my_tag {**42.5|abs} %}"#;
+        let (result, _context) = plain_parse_tag_v1(input).unwrap();
+        let dict_value = TagValue {
+            token: token("{**42.5|abs}", 10, 1, 11),
+            value: token("{**42.5|abs}", 10, 1, 11),
+            children: vec![ValueChild::Value(float_value(
+                token("**42.5|abs", 11, 1, 12),
+                token("42.5", 13, 1, 14),
+                Some("**"),
+                vec![TagValueFilter {
+                    token: token("|abs", 17, 1, 18),
+                    name: token("abs", 18, 1, 19),
+                    arg: None,
+                }],
+                vec![],
+                vec![],
+            ))],
+            kind: ValueKind::Dict,
+            spread: None,
+            filters: vec![],
+            used_variables: vec![],
+            assigned_variables: vec![],
+        };
+        assert_eq!(
+            result,
+            Tag::Generic(GenericTag {
+                meta: TagMeta {
+                    token: token(r#"{% my_tag {**42.5|abs} %}"#, 0, 1, 1),
+                    name: token("my_tag", 3, 1, 4),
+                    used_variables: vec![],
+                    assigned_variables: vec![],
+                },
+                attrs: vec![tag_attr(None, dict_value, false)],
+                is_self_closing: false,
+            })
+        );
+    }
+
+    // #######################################
+    // FLOATS EDGE CASES
+    // #######################################
+
+    #[test]
+    fn test_float_negative() {
+        let input = "{% my_tag -1.5 %}";
+        let (result, _context) = plain_parse_tag_v1(input).unwrap();
+        assert_eq!(
+            result,
+            Tag::Generic(GenericTag {
+                meta: TagMeta {
+                    token: token("{% my_tag -1.5 %}", 0, 1, 1),
+                    name: token("my_tag", 3, 1, 4),
+                    used_variables: vec![],
+                    assigned_variables: vec![],
+                },
+                attrs: vec![tag_attr(
+                    None,
+                    plain_float_value("-1.5", 10, 1, 11, None),
+                    false
+                )],
+                is_self_closing: false,
+            })
+        );
+    }
+
+    #[test]
+    fn test_float_positive_with_sign() {
+        let input = "{% my_tag +2. %}";
+        let (result, _context) = plain_parse_tag_v1(input).unwrap();
+        assert_eq!(
+            result,
+            Tag::Generic(GenericTag {
+                meta: TagMeta {
+                    token: token("{% my_tag +2. %}", 0, 1, 1),
+                    name: token("my_tag", 3, 1, 4),
+                    used_variables: vec![],
+                    assigned_variables: vec![],
+                },
+                attrs: vec![tag_attr(
+                    None,
+                    plain_float_value("+2.", 10, 1, 11, None),
+                    false
+                )],
+                is_self_closing: false,
+            })
+        );
+    }
+
+    #[test]
+    fn test_float_positive_without_sign() {
+        let input = "{% my_tag .3 %}";
+        let (result, _context) = plain_parse_tag_v1(input).unwrap();
+        assert_eq!(
+            result,
+            Tag::Generic(GenericTag {
+                meta: TagMeta {
+                    token: token("{% my_tag .3 %}", 0, 1, 1),
+                    name: token("my_tag", 3, 1, 4),
+                    used_variables: vec![],
+                    assigned_variables: vec![],
+                },
+                attrs: vec![tag_attr(
+                    None,
+                    plain_float_value(".3", 10, 1, 11, None),
+                    false
+                )],
+                is_self_closing: false,
+            })
+        );
+    }
+
+    #[test]
+    fn test_float_scientific_negative_base() {
+        let input = "{% my_tag -1.2e2 %}";
+        let (result, _context) = plain_parse_tag_v1(input).unwrap();
+        assert_eq!(
+            result,
+            Tag::Generic(GenericTag {
+                meta: TagMeta {
+                    token: token("{% my_tag -1.2e2 %}", 0, 1, 1),
+                    name: token("my_tag", 3, 1, 4),
+                    used_variables: vec![],
+                    assigned_variables: vec![],
+                },
+                attrs: vec![tag_attr(
+                    None,
+                    plain_float_value("-1.2e2", 10, 1, 11, None),
+                    false
+                )],
+                is_self_closing: false,
+            })
+        );
+    }
+
+    #[test]
+    fn test_float_scientific_negative_exponent() {
+        let input = "{% my_tag .2e-02 %}";
+        let (result, _context) = plain_parse_tag_v1(input).unwrap();
+        assert_eq!(
+            result,
+            Tag::Generic(GenericTag {
+                meta: TagMeta {
+                    token: token("{% my_tag .2e-02 %}", 0, 1, 1),
+                    name: token("my_tag", 3, 1, 4),
+                    used_variables: vec![],
+                    assigned_variables: vec![],
+                },
+                attrs: vec![tag_attr(
+                    None,
+                    plain_float_value(".2e-02", 10, 1, 11, None),
+                    false
+                )],
+                is_self_closing: false,
+            })
+        );
+    }
+
+    #[test]
+    fn test_float_scientific_leading_zero_exponent() {
+        let input = "{% my_tag 20.e+02 %}";
+        let (result, _context) = plain_parse_tag_v1(input).unwrap();
+        assert_eq!(
+            result,
+            Tag::Generic(GenericTag {
+                meta: TagMeta {
+                    token: token("{% my_tag 20.e+02 %}", 0, 1, 1),
+                    name: token("my_tag", 3, 1, 4),
+                    used_variables: vec![],
+                    assigned_variables: vec![],
+                },
+                attrs: vec![tag_attr(
+                    None,
+                    plain_float_value("20.e+02", 10, 1, 11, None),
+                    false
+                )],
+                is_self_closing: false,
+            })
+        );
+    }
+}

--- a/crates/djc-template-parser/tests/tag_parser_forloop.rs
+++ b/crates/djc-template-parser/tests/tag_parser_forloop.rs
@@ -1,0 +1,236 @@
+mod common;
+
+#[cfg(test)]
+mod tests {
+    use std::vec;
+
+    use djc_template_parser::ast::{
+        ForLoopTag, Tag, TagMeta, TagValue, TagValueFilter, ValueKind,
+    };
+
+    use super::common::{plain_parse_tag_v1, plain_variable_value, token};
+
+    // ============================================
+    // Basic for loop tests
+    // ============================================
+
+    #[test]
+    fn test_basic_for_loop() {
+        // Basic for loop: {% for item in items %}
+        let input = "{% for item in items %}";
+        let (result, _context) = plain_parse_tag_v1(input).unwrap();
+        assert_eq!(
+            result,
+            Tag::ForLoop(ForLoopTag {
+                meta: TagMeta {
+                    token: token("{% for item in items %}", 0, 1, 1),
+                    name: token("for", 3, 1, 4),
+                    used_variables: vec![token("items", 15, 1, 16)],
+                    assigned_variables: vec![],
+                },
+                targets: vec![token("item", 7, 1, 8)],
+                iterable: plain_variable_value("items", 15, 1, 16, None),
+            })
+        );
+    }
+
+    #[test]
+    fn test_multiple_loop_variables() {
+        let input = "{% for x, y, z in matrix %}";
+        let (result, _context) = plain_parse_tag_v1(input).unwrap();
+        assert_eq!(
+            result,
+            Tag::ForLoop(ForLoopTag {
+                meta: TagMeta {
+                    token: token("{% for x, y, z in matrix %}", 0, 1, 1),
+                    name: token("for", 3, 1, 4),
+                    used_variables: vec![token("matrix", 18, 1, 19)],
+                    assigned_variables: vec![],
+                },
+                targets: vec![
+                    token("x", 7, 1, 8),
+                    token("y", 10, 1, 11),
+                    token("z", 13, 1, 14),
+                ],
+                iterable: plain_variable_value("matrix", 18, 1, 19, None),
+            })
+        );
+    }
+
+    #[test]
+    fn test_for_loop_with_filters_on_iterable() {
+        let input = "{% for item in items|filter:arg %}";
+        let (result, _context) = plain_parse_tag_v1(input).unwrap();
+        assert_eq!(
+            result,
+            Tag::ForLoop(ForLoopTag {
+                meta: TagMeta {
+                    token: token("{% for item in items|filter:arg %}", 0, 1, 1),
+                    name: token("for", 3, 1, 4),
+                    used_variables: vec![token("items", 15, 1, 16), token("arg", 28, 1, 29),],
+                    assigned_variables: vec![],
+                },
+                targets: vec![token("item", 7, 1, 8)],
+                iterable: TagValue {
+                    token: token("items|filter:arg", 15, 1, 16),
+                    value: token("items", 15, 1, 16),
+                    children: vec![],
+                    kind: ValueKind::Variable,
+                    spread: None,
+                    filters: vec![TagValueFilter {
+                        name: token("filter", 21, 1, 22),
+                        token: token("|filter:arg", 20, 1, 21),
+                        arg: Some(plain_variable_value("arg", 28, 1, 29, None)),
+                    }],
+                    used_variables: vec![token("items", 15, 1, 16)],
+                    assigned_variables: vec![],
+                },
+            })
+        );
+    }
+
+    #[test]
+    fn test_for_loop_with_python_expression_iterable() {
+        let input = "{% for item in (items + other_items) %}";
+        let (result, _context) = plain_parse_tag_v1(input).unwrap();
+        // The iterable should be parsed as a Python expression
+        assert_eq!(
+            result,
+            Tag::ForLoop(ForLoopTag {
+                meta: TagMeta {
+                    token: token("{% for item in (items + other_items) %}", 0, 1, 1),
+                    name: token("for", 3, 1, 4),
+                    used_variables: vec![token("items", 16, 1, 17), token("other_items", 24, 1, 25),],
+                    assigned_variables: vec![],
+                },
+                targets: vec![token("item", 7, 1, 8)],
+                iterable: TagValue {
+                    token: token("(items + other_items)", 15, 1, 16),
+                    value: token("(items + other_items)", 15, 1, 16),
+                    children: vec![],
+                    kind: ValueKind::PythonExpr,
+                    spread: None,
+                    filters: vec![],
+                    used_variables: vec![token("items", 16, 1, 17), token("other_items", 24, 1, 25),],
+                    assigned_variables: vec![],
+                },
+            })
+        );
+    }
+
+    #[test]
+    fn test_for_loop_with_variable_iterable() {
+        let input = "{% for item in my_list %}";
+        let (result, _context) = plain_parse_tag_v1(input).unwrap();
+        assert_eq!(
+            result,
+            Tag::ForLoop(ForLoopTag {
+                meta: TagMeta {
+                    token: token("{% for item in my_list %}", 0, 1, 1),
+                    name: token("for", 3, 1, 4),
+                    used_variables: vec![token("my_list", 15, 1, 16)],
+                    assigned_variables: vec![],
+                },
+                targets: vec![token("item", 7, 1, 8)],
+                iterable: plain_variable_value("my_list", 15, 1, 16, None),
+            })
+        );
+    }
+
+    // ============================================
+    // Error handling tests
+    // ============================================
+
+    #[test]
+    fn test_for_loop_missing_in_keyword() {
+        // Missing "in" keyword: {% for item items %} should error
+        let input = "{% for item items %}";
+        let result = plain_parse_tag_v1(input);
+        assert!(result.is_err(), "Should error when 'in' keyword is missing");
+    }
+
+    #[test]
+    fn test_for_loop_missing_iterable() {
+        // Missing iterable: {% for item in %} should error
+        let input = "{% for item in %}";
+        let result = plain_parse_tag_v1(input);
+        assert!(result.is_err(), "Should error when iterable is missing");
+    }
+
+    #[test]
+    fn test_for_loop_missing_targets() {
+        // Missing targets: {% for in items %} should error
+        let input = "{% for in items %}";
+        let result = plain_parse_tag_v1(input);
+        assert!(
+            result.is_err(),
+            "Should error when loop variables are missing"
+        );
+    }
+
+    #[test]
+    fn test_for_loop_self_closing_error() {
+        // Self-closing for loop: {% for item in items / %} should error
+        let input = "{% for item in items / %}";
+        let result = plain_parse_tag_v1(input);
+        assert!(
+            result.is_err(),
+            "Should error when for loop is self-closing"
+        );
+    }
+
+    #[test]
+    fn test_for_loop_invalid_syntax_no_space_after_for() {
+        // Invalid syntax: no space after "for"
+        // Note: This actually parses as a generic tag with name "foritem", not an error
+        // The grammar allows this, so we test that it's not a for loop
+        let input = "{% foritem in items %}";
+        let (result, _context) = plain_parse_tag_v1(input).unwrap();
+        // This should parse as a generic tag, not a for loop
+        assert!(
+            matches!(result, Tag::Generic(_)),
+            "Should parse as a generic tag"
+        );
+    }
+
+    #[test]
+    fn test_for_loop_invalid_syntax_no_space_before_in() {
+        // Invalid syntax: no space before "in"
+        let input = "{% for itemin items %}";
+        let result = plain_parse_tag_v1(input);
+        assert!(
+            result.is_err(),
+            "Should error when there's no space before 'in'"
+        );
+    }
+
+    #[test]
+    fn test_for_loop_invalid_syntax_no_space_after_in() {
+        // Invalid syntax: no space after "in"
+        let input = "{% for item initems %}";
+        let result = plain_parse_tag_v1(input);
+        assert!(
+            result.is_err(),
+            "Should error when there's no space after 'in'"
+        );
+    }
+
+    #[test]
+    fn test_for_loop_empty_targets() {
+        // Empty targets (just comma)
+        let input = "{% for , in items %}";
+        let result = plain_parse_tag_v1(input);
+        assert!(result.is_err(), "Should error when targets are empty");
+    }
+
+    #[test]
+    fn test_for_loop_trailing_comma() {
+        // Trailing comma in targets
+        let input = "{% for x, y, in items %}";
+        let result = plain_parse_tag_v1(input);
+        assert!(
+            result.is_err(),
+            "Should error when there's a trailing comma in targets"
+        );
+    }
+}

--- a/crates/djc-template-parser/tests/tag_parser_int.rs
+++ b/crates/djc-template-parser/tests/tag_parser_int.rs
@@ -1,0 +1,810 @@
+// Each of the `tag_parser_<data_type>.rs` file tests following cases:
+//  1. as arg
+//  2. as multiple args
+//  3. as arg with filter without filter arg
+//  4. as arg with filter with filter arg
+//  5. as arg with `...` spread
+//  6. as kwarg
+//  7. as multiple kwargs
+//  8. as kwarg with filter without filter arg
+//  9. as kwarg with filter with filter arg
+// 10. as both arg and kwarg with filters
+// 11. as both arg and kwarg with filters and arg with `...` spreads
+// 12. inside list
+// 13. inside list with filter without filter arg
+// 14. inside list with filter with filter arg
+// 15. inside list with filter with filter arg and `*` spread.
+// 16. inside list with `*` spread.
+// 17. inside dict as value
+// 18. inside dict as value with filter with filter arg
+// 19. inside dict as key and value
+// 20. inside dict as key and value, both with filters, and value with filter arg.
+// 21. inside dict as neither key nor value, with `**` spread and filter without arg
+
+mod common;
+
+#[cfg(test)]
+mod tests {
+    use std::vec;
+
+    use djc_template_parser::ast::{
+        GenericTag, Tag, TagMeta, TagValue, TagValueFilter, ValueChild, ValueKind,
+    };
+
+    use super::common::{
+        int_value, plain_int_value, plain_parse_tag_v1, plain_variable_value, tag_attr, token,
+    };
+
+    #[test]
+    fn test_int_as_arg() {
+        let input = r#"{% my_tag 42 %}"#;
+        let (result, _context) = plain_parse_tag_v1(input).unwrap();
+        assert_eq!(
+            result,
+            Tag::Generic(GenericTag {
+                meta: TagMeta {
+                    token: token(r#"{% my_tag 42 %}"#, 0, 1, 1),
+                    name: token("my_tag", 3, 1, 4),
+                    used_variables: vec![],
+                    assigned_variables: vec![],
+                },
+                attrs: vec![tag_attr(
+                    None,
+                    plain_int_value("42", 10, 1, 11, None),
+                    false
+                )],
+                is_self_closing: false,
+            })
+        );
+    }
+
+    #[test]
+    fn test_int_as_multiple_args() {
+        let input = r#"{% my_tag 123 456 %}"#;
+        let (result, _context) = plain_parse_tag_v1(input).unwrap();
+        assert_eq!(
+            result,
+            Tag::Generic(GenericTag {
+                meta: TagMeta {
+                    token: token(r#"{% my_tag 123 456 %}"#, 0, 1, 1),
+                    name: token("my_tag", 3, 1, 4),
+                    used_variables: vec![],
+                    assigned_variables: vec![],
+                },
+                attrs: vec![
+                    tag_attr(None, plain_int_value("123", 10, 1, 11, None), false),
+                    tag_attr(None, plain_int_value("456", 14, 1, 15, None), false),
+                ],
+                is_self_closing: false,
+            })
+        );
+    }
+
+    #[test]
+    fn test_int_as_arg_with_filter_without_arg() {
+        let input = r#"{% my_tag 42|abs %}"#;
+        let (result, _context) = plain_parse_tag_v1(input).unwrap();
+        assert_eq!(
+            result,
+            Tag::Generic(GenericTag {
+                meta: TagMeta {
+                    token: token(r#"{% my_tag 42|abs %}"#, 0, 1, 1),
+                    name: token("my_tag", 3, 1, 4),
+                    used_variables: vec![],
+                    assigned_variables: vec![],
+                },
+                attrs: vec![tag_attr(
+                    None,
+                    int_value(
+                        token("42|abs", 10, 1, 11),
+                        token("42", 10, 1, 11),
+                        None,
+                        vec![TagValueFilter {
+                            token: token("|abs", 12, 1, 13),
+                            name: token("abs", 13, 1, 14),
+                            arg: None,
+                        }],
+                        vec![],
+                        vec![],
+                    ),
+                    false
+                )],
+                is_self_closing: false,
+            })
+        );
+    }
+
+    #[test]
+    fn test_int_as_arg_with_filter_with_arg() {
+        let input = r#"{% my_tag 42|add:5 %}"#;
+        let (result, _context) = plain_parse_tag_v1(input).unwrap();
+        assert_eq!(
+            result,
+            Tag::Generic(GenericTag {
+                meta: TagMeta {
+                    token: token(r#"{% my_tag 42|add:5 %}"#, 0, 1, 1),
+                    name: token("my_tag", 3, 1, 4),
+                    used_variables: vec![],
+                    assigned_variables: vec![],
+                },
+                attrs: vec![tag_attr(
+                    None,
+                    int_value(
+                        token("42|add:5", 10, 1, 11),
+                        token("42", 10, 1, 11),
+                        None,
+                        vec![TagValueFilter {
+                            token: token("|add:5", 12, 1, 13),
+                            name: token("add", 13, 1, 14),
+                            arg: Some(plain_int_value("5", 17, 1, 18, None)),
+                        }],
+                        vec![],
+                        vec![],
+                    ),
+                    false
+                )],
+                is_self_closing: false,
+            })
+        );
+    }
+
+    #[test]
+    fn test_int_as_arg_with_spread() {
+        let input = r#"{% my_tag ...42 %}"#;
+        let (result, _context) = plain_parse_tag_v1(input).unwrap();
+        assert_eq!(
+            result,
+            Tag::Generic(GenericTag {
+                meta: TagMeta {
+                    token: token(r#"{% my_tag ...42 %}"#, 0, 1, 1),
+                    name: token("my_tag", 3, 1, 4),
+                    used_variables: vec![],
+                    assigned_variables: vec![],
+                },
+                attrs: vec![tag_attr(
+                    None,
+                    plain_int_value("42", 10, 1, 11, Some("...")),
+                    false
+                )],
+                is_self_closing: false,
+            })
+        );
+    }
+
+    #[test]
+    fn test_int_as_kwarg() {
+        let input = r#"{% my_tag key=42 %}"#;
+        let (result, _context) = plain_parse_tag_v1(input).unwrap();
+        assert_eq!(
+            result,
+            Tag::Generic(GenericTag {
+                meta: TagMeta {
+                    token: token(r#"{% my_tag key=42 %}"#, 0, 1, 1),
+                    name: token("my_tag", 3, 1, 4),
+                    used_variables: vec![],
+                    assigned_variables: vec![],
+                },
+                attrs: vec![tag_attr(
+                    Some(token("key", 10, 1, 11)),
+                    plain_int_value("42", 14, 1, 15, None),
+                    false
+                )],
+                is_self_closing: false,
+            })
+        );
+    }
+
+    #[test]
+    fn test_int_as_multiple_kwargs() {
+        let input = r#"{% my_tag key1=123 key2=456 %}"#;
+        let (result, _context) = plain_parse_tag_v1(input).unwrap();
+        assert_eq!(
+            result,
+            Tag::Generic(GenericTag {
+                meta: TagMeta {
+                    token: token(r#"{% my_tag key1=123 key2=456 %}"#, 0, 1, 1),
+                    name: token("my_tag", 3, 1, 4),
+                    used_variables: vec![],
+                    assigned_variables: vec![],
+                },
+                attrs: vec![
+                    tag_attr(
+                        Some(token("key1", 10, 1, 11)),
+                        plain_int_value("123", 15, 1, 16, None),
+                        false
+                    ),
+                    tag_attr(
+                        Some(token("key2", 19, 1, 20)),
+                        plain_int_value("456", 24, 1, 25, None),
+                        false
+                    ),
+                ],
+                is_self_closing: false,
+            })
+        );
+    }
+
+    #[test]
+    fn test_int_as_kwarg_with_filter_without_arg() {
+        let input = r#"{% my_tag key=42|abs %}"#;
+        let (result, _context) = plain_parse_tag_v1(input).unwrap();
+        assert_eq!(
+            result,
+            Tag::Generic(GenericTag {
+                meta: TagMeta {
+                    token: token(r#"{% my_tag key=42|abs %}"#, 0, 1, 1),
+                    name: token("my_tag", 3, 1, 4),
+                    used_variables: vec![],
+                    assigned_variables: vec![],
+                },
+                attrs: vec![tag_attr(
+                    Some(token("key", 10, 1, 11)),
+                    int_value(
+                        token("42|abs", 14, 1, 15),
+                        token("42", 14, 1, 15),
+                        None,
+                        vec![TagValueFilter {
+                            token: token("|abs", 16, 1, 17),
+                            name: token("abs", 17, 1, 18),
+                            arg: None,
+                        }],
+                        vec![],
+                        vec![],
+                    ),
+                    false
+                )],
+                is_self_closing: false,
+            })
+        );
+    }
+
+    #[test]
+    fn test_int_as_kwarg_with_filter_with_arg() {
+        let input = r#"{% my_tag key=42|add:5 %}"#;
+        let (result, _context) = plain_parse_tag_v1(input).unwrap();
+        assert_eq!(
+            result,
+            Tag::Generic(GenericTag {
+                meta: TagMeta {
+                    token: token(r#"{% my_tag key=42|add:5 %}"#, 0, 1, 1),
+                    name: token("my_tag", 3, 1, 4),
+                    used_variables: vec![],
+                    assigned_variables: vec![],
+                },
+                attrs: vec![tag_attr(
+                    Some(token("key", 10, 1, 11)),
+                    int_value(
+                        token("42|add:5", 14, 1, 15),
+                        token("42", 14, 1, 15),
+                        None,
+                        vec![TagValueFilter {
+                            token: token("|add:5", 16, 1, 17),
+                            name: token("add", 17, 1, 18),
+                            arg: Some(plain_int_value("5", 21, 1, 22, None)),
+                        }],
+                        vec![],
+                        vec![],
+                    ),
+                    false
+                )],
+                is_self_closing: false,
+            })
+        );
+    }
+
+    #[test]
+    fn test_int_as_both_arg_and_kwarg_with_filters() {
+        let input = r#"{% my_tag 42|abs key=123|abs %}"#;
+        let (result, _context) = plain_parse_tag_v1(input).unwrap();
+        assert_eq!(
+            result,
+            Tag::Generic(GenericTag {
+                meta: TagMeta {
+                    token: token(r#"{% my_tag 42|abs key=123|abs %}"#, 0, 1, 1),
+                    name: token("my_tag", 3, 1, 4),
+                    used_variables: vec![],
+                    assigned_variables: vec![],
+                },
+                attrs: vec![
+                    tag_attr(
+                        None,
+                        int_value(
+                            token("42|abs", 10, 1, 11),
+                            token("42", 10, 1, 11),
+                            None,
+                            vec![TagValueFilter {
+                                token: token("|abs", 12, 1, 13),
+                                name: token("abs", 13, 1, 14),
+                                arg: None,
+                            }],
+                            vec![],
+                            vec![],
+                        ),
+                        false
+                    ),
+                    tag_attr(
+                        Some(token("key", 17, 1, 18)),
+                        int_value(
+                            token("123|abs", 21, 1, 22),
+                            token("123", 21, 1, 22),
+                            None,
+                            vec![TagValueFilter {
+                                token: token("|abs", 24, 1, 25),
+                                name: token("abs", 25, 1, 26),
+                                arg: None,
+                            }],
+                            vec![],
+                            vec![],
+                        ),
+                        false
+                    ),
+                ],
+                is_self_closing: false,
+            })
+        );
+    }
+
+    #[test]
+    fn test_int_as_both_arg_and_kwarg_with_filters_and_spread() {
+        let input = r#"{% my_tag ...42|abs key=123|abs %}"#;
+        let (result, _context) = plain_parse_tag_v1(input).unwrap();
+        assert_eq!(
+            result,
+            Tag::Generic(GenericTag {
+                meta: TagMeta {
+                    token: token(r#"{% my_tag ...42|abs key=123|abs %}"#, 0, 1, 1),
+                    name: token("my_tag", 3, 1, 4),
+                    used_variables: vec![],
+                    assigned_variables: vec![],
+                },
+                attrs: vec![
+                    tag_attr(
+                        None,
+                        int_value(
+                            token("...42|abs", 10, 1, 11),
+                            token("42", 13, 1, 14),
+                            Some("..."),
+                            vec![TagValueFilter {
+                                token: token("|abs", 15, 1, 16),
+                                name: token("abs", 16, 1, 17),
+                                arg: None,
+                            }],
+                            vec![],
+                            vec![],
+                        ),
+                        false
+                    ),
+                    tag_attr(
+                        Some(token("key", 20, 1, 21)),
+                        int_value(
+                            token("123|abs", 24, 1, 25),
+                            token("123", 24, 1, 25),
+                            None,
+                            vec![TagValueFilter {
+                                token: token("|abs", 27, 1, 28),
+                                name: token("abs", 28, 1, 29),
+                                arg: None,
+                            }],
+                            vec![],
+                            vec![],
+                        ),
+                        false
+                    ),
+                ],
+                is_self_closing: false,
+            })
+        );
+    }
+
+    #[test]
+    fn test_int_inside_list() {
+        let input = r#"{% my_tag [42] %}"#;
+        let (result, _context) = plain_parse_tag_v1(input).unwrap();
+        let list_value = TagValue {
+            token: token("[42]", 10, 1, 11),
+            value: token("[42]", 10, 1, 11),
+            children: vec![ValueChild::Value(plain_int_value("42", 11, 1, 12, None))],
+            kind: ValueKind::List,
+            spread: None,
+            filters: vec![],
+            used_variables: vec![],
+            assigned_variables: vec![],
+        };
+        assert_eq!(
+            result,
+            Tag::Generic(GenericTag {
+                meta: TagMeta {
+                    token: token(r#"{% my_tag [42] %}"#, 0, 1, 1),
+                    name: token("my_tag", 3, 1, 4),
+                    used_variables: vec![],
+                    assigned_variables: vec![],
+                },
+                attrs: vec![tag_attr(None, list_value, false)],
+                is_self_closing: false,
+            })
+        );
+    }
+
+    #[test]
+    fn test_int_inside_list_with_filter_without_arg() {
+        let input = r#"{% my_tag [42|abs] %}"#;
+        let (result, _context) = plain_parse_tag_v1(input).unwrap();
+        let list_value = TagValue {
+            token: token("[42|abs]", 10, 1, 11),
+            value: token("[42|abs]", 10, 1, 11),
+            children: vec![ValueChild::Value(int_value(
+                token("42|abs", 11, 1, 12),
+                token("42", 11, 1, 12),
+                None,
+                vec![TagValueFilter {
+                    token: token("|abs", 13, 1, 14),
+                    name: token("abs", 14, 1, 15),
+                    arg: None,
+                }],
+                vec![],
+                vec![],
+            ))],
+            kind: ValueKind::List,
+            spread: None,
+            filters: vec![],
+            used_variables: vec![],
+            assigned_variables: vec![],
+        };
+        assert_eq!(
+            result,
+            Tag::Generic(GenericTag {
+                meta: TagMeta {
+                    token: token(r#"{% my_tag [42|abs] %}"#, 0, 1, 1),
+                    name: token("my_tag", 3, 1, 4),
+                    used_variables: vec![],
+                    assigned_variables: vec![],
+                },
+                attrs: vec![tag_attr(None, list_value, false)],
+                is_self_closing: false,
+            })
+        );
+    }
+
+    #[test]
+    fn test_int_inside_list_with_filter_with_arg() {
+        let input = r#"{% my_tag [42|add:5] %}"#;
+        let (result, _context) = plain_parse_tag_v1(input).unwrap();
+        let list_value = TagValue {
+            token: token("[42|add:5]", 10, 1, 11),
+            value: token("[42|add:5]", 10, 1, 11),
+            children: vec![ValueChild::Value(int_value(
+                token("42|add:5", 11, 1, 12),
+                token("42", 11, 1, 12),
+                None,
+                vec![TagValueFilter {
+                    token: token("|add:5", 13, 1, 14),
+                    name: token("add", 14, 1, 15),
+                    arg: Some(plain_int_value("5", 18, 1, 19, None)),
+                }],
+                vec![],
+                vec![],
+            ))],
+            kind: ValueKind::List,
+            spread: None,
+            filters: vec![],
+            used_variables: vec![],
+            assigned_variables: vec![],
+        };
+        assert_eq!(
+            result,
+            Tag::Generic(GenericTag {
+                meta: TagMeta {
+                    token: token(r#"{% my_tag [42|add:5] %}"#, 0, 1, 1),
+                    name: token("my_tag", 3, 1, 4),
+                    used_variables: vec![],
+                    assigned_variables: vec![],
+                },
+                attrs: vec![tag_attr(None, list_value, false)],
+                is_self_closing: false,
+            })
+        );
+    }
+
+    #[test]
+    fn test_int_inside_list_with_filter_with_arg_and_spread() {
+        let input = r#"{% my_tag [*42|add:5] %}"#;
+        let (result, _context) = plain_parse_tag_v1(input).unwrap();
+        let list_value = TagValue {
+            token: token("[*42|add:5]", 10, 1, 11),
+            value: token("[*42|add:5]", 10, 1, 11),
+            children: vec![ValueChild::Value(int_value(
+                token("*42|add:5", 11, 1, 12),
+                token("42", 12, 1, 13),
+                Some("*"),
+                vec![TagValueFilter {
+                    token: token("|add:5", 14, 1, 15),
+                    name: token("add", 15, 1, 16),
+                    arg: Some(plain_int_value("5", 19, 1, 20, None)),
+                }],
+                vec![],
+                vec![],
+            ))],
+            kind: ValueKind::List,
+            spread: None,
+            filters: vec![],
+            used_variables: vec![],
+            assigned_variables: vec![],
+        };
+        assert_eq!(
+            result,
+            Tag::Generic(GenericTag {
+                meta: TagMeta {
+                    token: token(r#"{% my_tag [*42|add:5] %}"#, 0, 1, 1),
+                    name: token("my_tag", 3, 1, 4),
+                    used_variables: vec![],
+                    assigned_variables: vec![],
+                },
+                attrs: vec![tag_attr(None, list_value, false)],
+                is_self_closing: false,
+            })
+        );
+    }
+
+    #[test]
+    fn test_int_inside_list_with_spread() {
+        let input = r#"{% my_tag [*42] %}"#;
+        let (result, _context) = plain_parse_tag_v1(input).unwrap();
+        let list_value = TagValue {
+            token: token("[*42]", 10, 1, 11),
+            value: token("[*42]", 10, 1, 11),
+            children: vec![ValueChild::Value(plain_int_value(
+                "42",
+                11,
+                1,
+                12,
+                Some("*"),
+            ))],
+            kind: ValueKind::List,
+            spread: None,
+            filters: vec![],
+            used_variables: vec![],
+            assigned_variables: vec![],
+        };
+        assert_eq!(
+            result,
+            Tag::Generic(GenericTag {
+                meta: TagMeta {
+                    token: token(r#"{% my_tag [*42] %}"#, 0, 1, 1),
+                    name: token("my_tag", 3, 1, 4),
+                    used_variables: vec![],
+                    assigned_variables: vec![],
+                },
+                attrs: vec![tag_attr(None, list_value, false)],
+                is_self_closing: false,
+            })
+        );
+    }
+
+    #[test]
+    fn test_int_inside_dict_as_value() {
+        let input = r#"{% my_tag {key: 42} %}"#;
+        let (result, _context) = plain_parse_tag_v1(input).unwrap();
+        let dict_value = TagValue {
+            token: token("{key: 42}", 10, 1, 11),
+            value: token("{key: 42}", 10, 1, 11),
+            children: vec![
+                ValueChild::Value(plain_variable_value("key", 11, 1, 12, None)),
+                ValueChild::Value(plain_int_value("42", 16, 1, 17, None)),
+            ],
+            kind: ValueKind::Dict,
+            spread: None,
+            filters: vec![],
+            used_variables: vec![],
+            assigned_variables: vec![],
+        };
+        assert_eq!(
+            result,
+            Tag::Generic(GenericTag {
+                meta: TagMeta {
+                    token: token(r#"{% my_tag {key: 42} %}"#, 0, 1, 1),
+                    name: token("my_tag", 3, 1, 4),
+                    used_variables: vec![token("key", 11, 1, 12)],
+                    assigned_variables: vec![],
+                },
+                attrs: vec![tag_attr(None, dict_value, false)],
+                is_self_closing: false,
+            })
+        );
+    }
+
+    #[test]
+    fn test_int_inside_dict_as_value_with_filter_with_arg() {
+        let input = r#"{% my_tag {key: 42|add:5} %}"#;
+        let (result, _context) = plain_parse_tag_v1(input).unwrap();
+        let dict_value = TagValue {
+            token: token("{key: 42|add:5}", 10, 1, 11),
+            value: token("{key: 42|add:5}", 10, 1, 11),
+            children: vec![
+                ValueChild::Value(plain_variable_value("key", 11, 1, 12, None)),
+                ValueChild::Value(int_value(
+                    token("42|add:5", 16, 1, 17),
+                    token("42", 16, 1, 17),
+                    None,
+                    vec![TagValueFilter {
+                        token: token("|add:5", 18, 1, 19),
+                        name: token("add", 19, 1, 20),
+                        arg: Some(plain_int_value("5", 23, 1, 24, None)),
+                    }],
+                    vec![],
+                    vec![],
+                )),
+            ],
+            kind: ValueKind::Dict,
+            spread: None,
+            filters: vec![],
+            used_variables: vec![],
+            assigned_variables: vec![],
+        };
+        assert_eq!(
+            result,
+            Tag::Generic(GenericTag {
+                meta: TagMeta {
+                    token: token(r#"{% my_tag {key: 42|add:5} %}"#, 0, 1, 1),
+                    name: token("my_tag", 3, 1, 4),
+                    used_variables: vec![token("key", 11, 1, 12)],
+                    assigned_variables: vec![],
+                },
+                attrs: vec![tag_attr(None, dict_value, false)],
+                is_self_closing: false,
+            })
+        );
+    }
+
+    #[test]
+    fn test_int_inside_dict_as_key_and_value() {
+        let input = r#"{% my_tag {42: 123} %}"#;
+        let (result, _context) = plain_parse_tag_v1(input).unwrap();
+        let dict_value = TagValue {
+            token: token("{42: 123}", 10, 1, 11),
+            value: token("{42: 123}", 10, 1, 11),
+            children: vec![
+                ValueChild::Value(plain_int_value("42", 11, 1, 12, None)),
+                ValueChild::Value(plain_int_value("123", 15, 1, 16, None)),
+            ],
+            kind: ValueKind::Dict,
+            spread: None,
+            filters: vec![],
+            used_variables: vec![],
+            assigned_variables: vec![],
+        };
+        assert_eq!(
+            result,
+            Tag::Generic(GenericTag {
+                meta: TagMeta {
+                    token: token(r#"{% my_tag {42: 123} %}"#, 0, 1, 1),
+                    name: token("my_tag", 3, 1, 4),
+                    used_variables: vec![],
+                    assigned_variables: vec![],
+                },
+                attrs: vec![tag_attr(None, dict_value, false)],
+                is_self_closing: false,
+            })
+        );
+    }
+
+    #[test]
+    fn test_int_inside_dict_as_key_and_value_with_filters_and_arg() {
+        let input = r#"{% my_tag {42|abs: 123|add:5} %}"#;
+        let (result, _context) = plain_parse_tag_v1(input).unwrap();
+        let dict_value = TagValue {
+            token: token("{42|abs: 123|add:5}", 10, 1, 11),
+            value: token("{42|abs: 123|add:5}", 10, 1, 11),
+            children: vec![
+                ValueChild::Value(int_value(
+                    token("42|abs", 11, 1, 12),
+                    token("42", 11, 1, 12),
+                    None,
+                    vec![TagValueFilter {
+                        token: token("|abs", 13, 1, 14),
+                        name: token("abs", 14, 1, 15),
+                        arg: None,
+                    }],
+                    vec![],
+                    vec![],
+                )),
+                ValueChild::Value(int_value(
+                    token("123|add:5", 19, 1, 20),
+                    token("123", 19, 1, 20),
+                    None,
+                    vec![TagValueFilter {
+                        token: token("|add:5", 22, 1, 23),
+                        name: token("add", 23, 1, 24),
+                        arg: Some(plain_int_value("5", 27, 1, 28, None)),
+                    }],
+                    vec![],
+                    vec![],
+                )),
+            ],
+            kind: ValueKind::Dict,
+            spread: None,
+            filters: vec![],
+            used_variables: vec![],
+            assigned_variables: vec![],
+        };
+        assert_eq!(
+            result,
+            Tag::Generic(GenericTag {
+                meta: TagMeta {
+                    token: token(r#"{% my_tag {42|abs: 123|add:5} %}"#, 0, 1, 1),
+                    name: token("my_tag", 3, 1, 4),
+                    used_variables: vec![],
+                    assigned_variables: vec![],
+                },
+                attrs: vec![tag_attr(None, dict_value, false)],
+                is_self_closing: false,
+            })
+        );
+    }
+
+    #[test]
+    fn test_int_inside_dict_with_spread_and_filter() {
+        let input = r#"{% my_tag {**42|abs} %}"#;
+        let (result, _context) = plain_parse_tag_v1(input).unwrap();
+        let dict_value = TagValue {
+            token: token("{**42|abs}", 10, 1, 11),
+            value: token("{**42|abs}", 10, 1, 11),
+            children: vec![ValueChild::Value(int_value(
+                token("**42|abs", 11, 1, 12),
+                token("42", 13, 1, 14),
+                Some("**"),
+                vec![TagValueFilter {
+                    token: token("|abs", 15, 1, 16),
+                    name: token("abs", 16, 1, 17),
+                    arg: None,
+                }],
+                vec![],
+                vec![],
+            ))],
+            kind: ValueKind::Dict,
+            spread: None,
+            filters: vec![],
+            used_variables: vec![],
+            assigned_variables: vec![],
+        };
+        assert_eq!(
+            result,
+            Tag::Generic(GenericTag {
+                meta: TagMeta {
+                    token: token(r#"{% my_tag {**42|abs} %}"#, 0, 1, 1),
+                    name: token("my_tag", 3, 1, 4),
+                    used_variables: vec![],
+                    assigned_variables: vec![],
+                },
+                attrs: vec![tag_attr(None, dict_value, false)],
+                is_self_closing: false,
+            })
+        );
+    }
+
+    // #######################################
+    // INTS EDGE CASES
+    // #######################################
+
+    #[test]
+    fn test_int_leading_zeros() {
+        let input = "{% my_tag 001 %}";
+        let (result, _context) = plain_parse_tag_v1(input).unwrap();
+        assert_eq!(
+            result,
+            Tag::Generic(GenericTag {
+                meta: TagMeta {
+                    token: token("{% my_tag 001 %}", 0, 1, 1),
+                    name: token("my_tag", 3, 1, 4),
+                    used_variables: vec![],
+                    assigned_variables: vec![],
+                },
+                attrs: vec![tag_attr(
+                    None,
+                    plain_int_value("001", 10, 1, 11, None),
+                    false
+                )],
+                is_self_closing: false,
+            })
+        );
+    }
+}

--- a/crates/djc-template-parser/tests/tag_parser_list.rs
+++ b/crates/djc-template-parser/tests/tag_parser_list.rs
@@ -1,0 +1,1984 @@
+// Each of the `tag_parser_<data_type>.rs` file tests following cases:
+//  1. as arg
+//  2. as multiple args
+//  3. as arg with filter without filter arg
+//  4. as arg with filter with filter arg
+//  5. as arg with `...` spread
+//  6. as kwarg
+//  7. as multiple kwargs
+//  8. as kwarg with filter without filter arg
+//  9. as kwarg with filter with filter arg
+// 10. as both arg and kwarg with filters
+// 11. as both arg and kwarg with filters and arg with `...` spreads
+// 12. inside list
+// 13. inside list with filter without filter arg
+// 14. inside list with filter with filter arg
+// 15. inside list with filter with filter arg and `*` spread.
+// 16. inside list with `*` spread.
+// 17. inside dict as value
+// 18. inside dict as value with filter with filter arg
+// 19. inside dict as key and value
+// 20. inside dict as key and value, both with filters, and value with filter arg.
+// 21. inside dict as neither key nor value, with `**` spread and filter without arg
+
+mod common;
+
+#[cfg(test)]
+mod tests {
+    use std::vec;
+
+    use djc_template_parser::ast::{
+        GenericTag, Tag, TagMeta, TagValue, TagValueFilter, ValueChild, ValueKind,
+    };
+
+    use super::common::{
+        float_value, int_value, plain_float_value, plain_int_value, plain_parse_tag_v1,
+        plain_string_value, plain_translation_value, plain_variable_value, string_value, tag_attr,
+        template_string_value, token, translation_value, variable_value,
+    };
+
+    #[test]
+    fn test_list_as_arg() {
+        let input = r#"{% my_tag [42, 'hello', my_var] %}"#;
+        let (result, _context) = plain_parse_tag_v1(input).unwrap();
+        let list_value = TagValue {
+            token: token(r#"[42, 'hello', my_var]"#, 10, 1, 11),
+            value: token(r#"[42, 'hello', my_var]"#, 10, 1, 11),
+            children: vec![
+                ValueChild::Value(plain_int_value("42", 11, 1, 12, None)),
+                ValueChild::Value(plain_string_value(r#"'hello'"#, 15, 1, 16, None)),
+                ValueChild::Value(plain_variable_value("my_var", 24, 1, 25, None)),
+            ],
+            kind: ValueKind::List,
+            spread: None,
+            filters: vec![],
+            used_variables: vec![],
+            assigned_variables: vec![],
+        };
+        assert_eq!(
+            result,
+            Tag::Generic(GenericTag {
+                meta: TagMeta {
+                    token: token(r#"{% my_tag [42, 'hello', my_var] %}"#, 0, 1, 1),
+                    name: token("my_tag", 3, 1, 4),
+                    used_variables: vec![token("my_var", 24, 1, 25)],
+                    assigned_variables: vec![],
+                },
+                attrs: vec![tag_attr(None, list_value, false)],
+                is_self_closing: false,
+            })
+        );
+    }
+
+    #[test]
+    fn test_list_as_multiple_args() {
+        let input = r#"{% my_tag [42, 'hello', my_var] [100, 'world', other_var] %}"#;
+        let (result, _context) = plain_parse_tag_v1(input).unwrap();
+        let list_value1 = TagValue {
+            token: token(r#"[42, 'hello', my_var]"#, 10, 1, 11),
+            value: token(r#"[42, 'hello', my_var]"#, 10, 1, 11),
+            children: vec![
+                ValueChild::Value(plain_int_value("42", 11, 1, 12, None)),
+                ValueChild::Value(plain_string_value(r#"'hello'"#, 15, 1, 16, None)),
+                ValueChild::Value(plain_variable_value("my_var", 24, 1, 25, None)),
+            ],
+            kind: ValueKind::List,
+            spread: None,
+            filters: vec![],
+            used_variables: vec![],
+            assigned_variables: vec![],
+        };
+        let list_value2 = TagValue {
+            token: token(r#"[100, 'world', other_var]"#, 32, 1, 33),
+            value: token(r#"[100, 'world', other_var]"#, 32, 1, 33),
+            children: vec![
+                ValueChild::Value(plain_int_value("100", 33, 1, 34, None)),
+                ValueChild::Value(plain_string_value(r#"'world'"#, 38, 1, 39, None)),
+                ValueChild::Value(plain_variable_value("other_var", 47, 1, 48, None)),
+            ],
+            kind: ValueKind::List,
+            spread: None,
+            filters: vec![],
+            used_variables: vec![],
+            assigned_variables: vec![],
+        };
+        assert_eq!(
+            result,
+            Tag::Generic(GenericTag {
+                meta: TagMeta {
+                    token: token(
+                        r#"{% my_tag [42, 'hello', my_var] [100, 'world', other_var] %}"#,
+                        0,
+                        1,
+                        1
+                    ),
+                    name: token("my_tag", 3, 1, 4),
+                    used_variables: vec![token("my_var", 24, 1, 25), token("other_var", 47, 1, 48)],
+                    assigned_variables: vec![],
+                },
+                attrs: vec![
+                    tag_attr(None, list_value1, false),
+                    tag_attr(None, list_value2, false),
+                ],
+                is_self_closing: false,
+            })
+        );
+    }
+
+    #[test]
+    fn test_list_as_arg_with_filter_without_arg() {
+        let input = r#"{% my_tag [42, 'hello', my_var]|length %}"#;
+        let (result, _context) = plain_parse_tag_v1(input).unwrap();
+        let list_value = TagValue {
+            token: token(r#"[42, 'hello', my_var]|length"#, 10, 1, 11),
+            value: token(r#"[42, 'hello', my_var]"#, 10, 1, 11),
+            children: vec![
+                ValueChild::Value(plain_int_value("42", 11, 1, 12, None)),
+                ValueChild::Value(plain_string_value(r#"'hello'"#, 15, 1, 16, None)),
+                ValueChild::Value(plain_variable_value("my_var", 24, 1, 25, None)),
+            ],
+            kind: ValueKind::List,
+            spread: None,
+            filters: vec![TagValueFilter {
+                token: token("|length", 31, 1, 32),
+                name: token("length", 32, 1, 33),
+                arg: None,
+            }],
+            used_variables: vec![],
+            assigned_variables: vec![],
+        };
+        assert_eq!(
+            result,
+            Tag::Generic(GenericTag {
+                meta: TagMeta {
+                    token: token(r#"{% my_tag [42, 'hello', my_var]|length %}"#, 0, 1, 1),
+                    name: token("my_tag", 3, 1, 4),
+                    used_variables: vec![token("my_var", 24, 1, 25)],
+                    assigned_variables: vec![],
+                },
+                attrs: vec![tag_attr(None, list_value, false)],
+                is_self_closing: false,
+            })
+        );
+    }
+
+    #[test]
+    fn test_list_as_arg_with_filter_with_arg() {
+        let input = r#"{% my_tag [42, 'hello', my_var]|first:['a', other_var] %}"#;
+        let (result, _context) = plain_parse_tag_v1(input).unwrap();
+        let filter_arg_list = TagValue {
+            token: token(r#"['a', other_var]"#, 38, 1, 39),
+            value: token(r#"['a', other_var]"#, 38, 1, 39),
+            children: vec![
+                ValueChild::Value(plain_string_value(r#"'a'"#, 39, 1, 40, None)),
+                ValueChild::Value(plain_variable_value("other_var", 44, 1, 45, None)),
+            ],
+            kind: ValueKind::List,
+            spread: None,
+            filters: vec![],
+            used_variables: vec![],
+            assigned_variables: vec![],
+        };
+        let list_value = TagValue {
+            token: token(r#"[42, 'hello', my_var]|first:['a', other_var]"#, 10, 1, 11),
+            value: token(r#"[42, 'hello', my_var]"#, 10, 1, 11),
+            children: vec![
+                ValueChild::Value(plain_int_value("42", 11, 1, 12, None)),
+                ValueChild::Value(plain_string_value(r#"'hello'"#, 15, 1, 16, None)),
+                ValueChild::Value(plain_variable_value("my_var", 24, 1, 25, None)),
+            ],
+            kind: ValueKind::List,
+            spread: None,
+            filters: vec![TagValueFilter {
+                token: token("|first:['a', other_var]", 31, 1, 32),
+                name: token("first", 32, 1, 33),
+                arg: Some(filter_arg_list),
+            }],
+            used_variables: vec![],
+            assigned_variables: vec![],
+        };
+        assert_eq!(
+            result,
+            Tag::Generic(GenericTag {
+                meta: TagMeta {
+                    token: token(
+                        r#"{% my_tag [42, 'hello', my_var]|first:['a', other_var] %}"#,
+                        0,
+                        1,
+                        1
+                    ),
+                    name: token("my_tag", 3, 1, 4),
+                    used_variables: vec![token("my_var", 24, 1, 25), token("other_var", 44, 1, 45)],
+                    assigned_variables: vec![],
+                },
+                attrs: vec![tag_attr(None, list_value, false)],
+                is_self_closing: false,
+            })
+        );
+    }
+
+    #[test]
+    fn test_list_as_arg_with_spread() {
+        let input = r#"{% my_tag ...[42, 'hello', my_var] %}"#;
+        let (result, _context) = plain_parse_tag_v1(input).unwrap();
+        let list_value = TagValue {
+            token: token(r#"...[42, 'hello', my_var]"#, 10, 1, 11),
+            value: token(r#"[42, 'hello', my_var]"#, 13, 1, 14),
+            children: vec![
+                ValueChild::Value(plain_int_value("42", 14, 1, 15, None)),
+                ValueChild::Value(plain_string_value(r#"'hello'"#, 18, 1, 19, None)),
+                ValueChild::Value(plain_variable_value("my_var", 27, 1, 28, None)),
+            ],
+            kind: ValueKind::List,
+            spread: Some("...".to_string()),
+            filters: vec![],
+            used_variables: vec![],
+            assigned_variables: vec![],
+        };
+        assert_eq!(
+            result,
+            Tag::Generic(GenericTag {
+                meta: TagMeta {
+                    token: token(r#"{% my_tag ...[42, 'hello', my_var] %}"#, 0, 1, 1),
+                    name: token("my_tag", 3, 1, 4),
+                    used_variables: vec![token("my_var", 27, 1, 28)],
+                    assigned_variables: vec![],
+                },
+                attrs: vec![tag_attr(None, list_value, false)],
+                is_self_closing: false,
+            })
+        );
+    }
+
+    #[test]
+    fn test_list_as_kwarg() {
+        let input = r#"{% my_tag key=[42, 'hello', my_var] %}"#;
+        let (result, _context) = plain_parse_tag_v1(input).unwrap();
+        let list_value = TagValue {
+            token: token(r#"[42, 'hello', my_var]"#, 14, 1, 15),
+            value: token(r#"[42, 'hello', my_var]"#, 14, 1, 15),
+            children: vec![
+                ValueChild::Value(plain_int_value("42", 15, 1, 16, None)),
+                ValueChild::Value(plain_string_value(r#"'hello'"#, 19, 1, 20, None)),
+                ValueChild::Value(plain_variable_value("my_var", 28, 1, 29, None)),
+            ],
+            kind: ValueKind::List,
+            spread: None,
+            filters: vec![],
+            used_variables: vec![],
+            assigned_variables: vec![],
+        };
+        assert_eq!(
+            result,
+            Tag::Generic(GenericTag {
+                meta: TagMeta {
+                    token: token(r#"{% my_tag key=[42, 'hello', my_var] %}"#, 0, 1, 1),
+                    name: token("my_tag", 3, 1, 4),
+                    used_variables: vec![token("my_var", 28, 1, 29)],
+                    assigned_variables: vec![],
+                },
+                attrs: vec![tag_attr(Some(token("key", 10, 1, 11)), list_value, false)],
+                is_self_closing: false,
+            })
+        );
+    }
+
+    #[test]
+    fn test_list_as_multiple_kwargs() {
+        let input = r#"{% my_tag key1=[42, 'hello', my_var] key2=[100, 'world', other_var] %}"#;
+        let (result, _context) = plain_parse_tag_v1(input).unwrap();
+        let list_value1 = TagValue {
+            token: token(r#"[42, 'hello', my_var]"#, 15, 1, 16),
+            value: token(r#"[42, 'hello', my_var]"#, 15, 1, 16),
+            children: vec![
+                ValueChild::Value(plain_int_value("42", 16, 1, 17, None)),
+                ValueChild::Value(plain_string_value(r#"'hello'"#, 20, 1, 21, None)),
+                ValueChild::Value(plain_variable_value("my_var", 29, 1, 30, None)),
+            ],
+            kind: ValueKind::List,
+            spread: None,
+            filters: vec![],
+            used_variables: vec![],
+            assigned_variables: vec![],
+        };
+        let list_value2 = TagValue {
+            token: token(r#"[100, 'world', other_var]"#, 42, 1, 43),
+            value: token(r#"[100, 'world', other_var]"#, 42, 1, 43),
+            children: vec![
+                ValueChild::Value(plain_int_value("100", 43, 1, 44, None)),
+                ValueChild::Value(plain_string_value(r#"'world'"#, 48, 1, 49, None)),
+                ValueChild::Value(plain_variable_value("other_var", 57, 1, 58, None)),
+            ],
+            kind: ValueKind::List,
+            spread: None,
+            filters: vec![],
+            used_variables: vec![],
+            assigned_variables: vec![],
+        };
+        assert_eq!(
+            result,
+            Tag::Generic(GenericTag {
+                meta: TagMeta {
+                    token: token(
+                        r#"{% my_tag key1=[42, 'hello', my_var] key2=[100, 'world', other_var] %}"#,
+                        0,
+                        1,
+                        1
+                    ),
+                    name: token("my_tag", 3, 1, 4),
+                    used_variables: vec![token("my_var", 29, 1, 30), token("other_var", 57, 1, 58)],
+                    assigned_variables: vec![],
+                },
+                attrs: vec![
+                    tag_attr(Some(token("key1", 10, 1, 11)), list_value1, false),
+                    tag_attr(Some(token("key2", 37, 1, 38)), list_value2, false),
+                ],
+                is_self_closing: false,
+            })
+        );
+    }
+
+    #[test]
+    fn test_list_as_kwarg_with_filter_without_arg() {
+        let input = r#"{% my_tag key=[42, 'hello', my_var]|length %}"#;
+        let (result, _context) = plain_parse_tag_v1(input).unwrap();
+        let list_value = TagValue {
+            token: token(r#"[42, 'hello', my_var]|length"#, 14, 1, 15),
+            value: token(r#"[42, 'hello', my_var]"#, 14, 1, 15),
+            children: vec![
+                ValueChild::Value(plain_int_value("42", 15, 1, 16, None)),
+                ValueChild::Value(plain_string_value(r#"'hello'"#, 19, 1, 20, None)),
+                ValueChild::Value(plain_variable_value("my_var", 28, 1, 29, None)),
+            ],
+            kind: ValueKind::List,
+            spread: None,
+            filters: vec![TagValueFilter {
+                token: token("|length", 35, 1, 36),
+                name: token("length", 36, 1, 37),
+                arg: None,
+            }],
+            used_variables: vec![],
+            assigned_variables: vec![],
+        };
+        assert_eq!(
+            result,
+            Tag::Generic(GenericTag {
+                meta: TagMeta {
+                    token: token(r#"{% my_tag key=[42, 'hello', my_var]|length %}"#, 0, 1, 1),
+                    name: token("my_tag", 3, 1, 4),
+                    used_variables: vec![token("my_var", 28, 1, 29)],
+                    assigned_variables: vec![],
+                },
+                attrs: vec![tag_attr(Some(token("key", 10, 1, 11)), list_value, false)],
+                is_self_closing: false,
+            })
+        );
+    }
+
+    #[test]
+    fn test_list_as_kwarg_with_filter_with_arg() {
+        let input = r#"{% my_tag key=[42, 'hello', my_var]|first:['a', other_var] %}"#;
+        let (result, _context) = plain_parse_tag_v1(input).unwrap();
+        let filter_arg_list = TagValue {
+            token: token(r#"['a', other_var]"#, 42, 1, 43),
+            value: token(r#"['a', other_var]"#, 42, 1, 43),
+            children: vec![
+                ValueChild::Value(plain_string_value(r#"'a'"#, 43, 1, 44, None)),
+                ValueChild::Value(plain_variable_value("other_var", 48, 1, 49, None)),
+            ],
+            kind: ValueKind::List,
+            spread: None,
+            filters: vec![],
+            used_variables: vec![],
+            assigned_variables: vec![],
+        };
+        let list_value = TagValue {
+            token: token(r#"[42, 'hello', my_var]|first:['a', other_var]"#, 14, 1, 15),
+            value: token(r#"[42, 'hello', my_var]"#, 14, 1, 15),
+            children: vec![
+                ValueChild::Value(plain_int_value("42", 15, 1, 16, None)),
+                ValueChild::Value(plain_string_value(r#"'hello'"#, 19, 1, 20, None)),
+                ValueChild::Value(plain_variable_value("my_var", 28, 1, 29, None)),
+            ],
+            kind: ValueKind::List,
+            spread: None,
+            filters: vec![TagValueFilter {
+                token: token("|first:['a', other_var]", 35, 1, 36),
+                name: token("first", 36, 1, 37),
+                arg: Some(filter_arg_list),
+            }],
+            used_variables: vec![],
+            assigned_variables: vec![],
+        };
+        assert_eq!(
+            result,
+            Tag::Generic(GenericTag {
+                meta: TagMeta {
+                    token: token(
+                        r#"{% my_tag key=[42, 'hello', my_var]|first:['a', other_var] %}"#,
+                        0,
+                        1,
+                        1
+                    ),
+                    name: token("my_tag", 3, 1, 4),
+                    used_variables: vec![token("my_var", 28, 1, 29), token("other_var", 48, 1, 49)],
+                    assigned_variables: vec![],
+                },
+                attrs: vec![tag_attr(Some(token("key", 10, 1, 11)), list_value, false)],
+                is_self_closing: false,
+            })
+        );
+    }
+
+    #[test]
+    fn test_list_as_both_arg_and_kwarg_with_filters() {
+        let input = r#"{% my_tag [42, 'hello', my_var]|length key=[100, 'world', other_var]|first:['a', third_var] %}"#;
+        let (result, _context) = plain_parse_tag_v1(input).unwrap();
+        let list_value1 = TagValue {
+            token: token(r#"[42, 'hello', my_var]|length"#, 10, 1, 11),
+            value: token(r#"[42, 'hello', my_var]"#, 10, 1, 11),
+            children: vec![
+                ValueChild::Value(plain_int_value("42", 11, 1, 12, None)),
+                ValueChild::Value(plain_string_value(r#"'hello'"#, 15, 1, 16, None)),
+                ValueChild::Value(plain_variable_value("my_var", 24, 1, 25, None)),
+            ],
+            kind: ValueKind::List,
+            spread: None,
+            filters: vec![TagValueFilter {
+                token: token("|length", 31, 1, 32),
+                name: token("length", 32, 1, 33),
+                arg: None,
+            }],
+            used_variables: vec![],
+            assigned_variables: vec![],
+        };
+        let filter_arg_list2 = TagValue {
+            token: token(r#"['a', third_var]"#, 75, 1, 76),
+            value: token(r#"['a', third_var]"#, 75, 1, 76),
+            children: vec![
+                ValueChild::Value(plain_string_value(r#"'a'"#, 76, 1, 77, None)),
+                ValueChild::Value(plain_variable_value("third_var", 81, 1, 82, None)),
+            ],
+            kind: ValueKind::List,
+            spread: None,
+            filters: vec![],
+            used_variables: vec![],
+            assigned_variables: vec![],
+        };
+        let list_value2 = TagValue {
+            token: token(
+                r#"[100, 'world', other_var]|first:['a', third_var]"#,
+                43,
+                1,
+                44,
+            ),
+            value: token(r#"[100, 'world', other_var]"#, 43, 1, 44),
+            children: vec![
+                ValueChild::Value(plain_int_value("100", 44, 1, 45, None)),
+                ValueChild::Value(plain_string_value(r#"'world'"#, 49, 1, 50, None)),
+                ValueChild::Value(plain_variable_value("other_var", 58, 1, 59, None)),
+            ],
+            kind: ValueKind::List,
+            spread: None,
+            filters: vec![TagValueFilter {
+                token: token("|first:['a', third_var]", 68, 1, 69),
+                name: token("first", 69, 1, 70),
+                arg: Some(filter_arg_list2),
+            }],
+            used_variables: vec![],
+            assigned_variables: vec![],
+        };
+        assert_eq!(
+            result,
+            Tag::Generic(GenericTag {
+                meta: TagMeta {
+                    token: token(
+                        r#"{% my_tag [42, 'hello', my_var]|length key=[100, 'world', other_var]|first:['a', third_var] %}"#,
+                        0,
+                        1,
+                        1
+                    ),
+                    name: token("my_tag", 3, 1, 4),
+                    used_variables: vec![
+                        token("my_var", 24, 1, 25),
+                        token("other_var", 58, 1, 59),
+                        token("third_var", 81, 1, 82)
+                    ],
+                    assigned_variables: vec![],
+                },
+                attrs: vec![
+                    tag_attr(None, list_value1, false),
+                    tag_attr(Some(token("key", 39, 1, 40)), list_value2, false),
+                ],
+                is_self_closing: false,
+            })
+        );
+    }
+
+    #[test]
+    fn test_list_as_both_arg_and_kwarg_with_filters_and_spread() {
+        let input = r#"{% my_tag ...[42, 'hello', my_var]|length key=[100, 'world', other_var]|first:['a', third_var] %}"#;
+        let (result, _context) = plain_parse_tag_v1(input).unwrap();
+        let list_value1 = TagValue {
+            token: token(r#"...[42, 'hello', my_var]|length"#, 10, 1, 11),
+            value: token(r#"[42, 'hello', my_var]"#, 13, 1, 14),
+            children: vec![
+                ValueChild::Value(plain_int_value("42", 14, 1, 15, None)),
+                ValueChild::Value(plain_string_value(r#"'hello'"#, 18, 1, 19, None)),
+                ValueChild::Value(plain_variable_value("my_var", 27, 1, 28, None)),
+            ],
+            kind: ValueKind::List,
+            spread: Some("...".to_string()),
+            filters: vec![TagValueFilter {
+                token: token("|length", 34, 1, 35),
+                name: token("length", 35, 1, 36),
+                arg: None,
+            }],
+            used_variables: vec![],
+            assigned_variables: vec![],
+        };
+        let list_value2 = TagValue {
+            token: token(
+                r#"[100, 'world', other_var]|first:['a', third_var]"#,
+                46,
+                1,
+                47,
+            ),
+            value: token(r#"[100, 'world', other_var]"#, 46, 1, 47),
+            children: vec![
+                ValueChild::Value(plain_int_value("100", 47, 1, 48, None)),
+                ValueChild::Value(plain_string_value(r#"'world'"#, 52, 1, 53, None)),
+                ValueChild::Value(plain_variable_value("other_var", 61, 1, 62, None)),
+            ],
+            kind: ValueKind::List,
+            spread: None,
+            filters: vec![TagValueFilter {
+                token: token("|first:['a', third_var]", 71, 1, 72),
+                name: token("first", 72, 1, 73),
+                arg: Some(TagValue {
+                    token: token(r#"['a', third_var]"#, 78, 1, 79),
+                    value: token(r#"['a', third_var]"#, 78, 1, 79),
+                    children: vec![
+                        ValueChild::Value(plain_string_value(r#"'a'"#, 79, 1, 80, None)),
+                        ValueChild::Value(plain_variable_value("third_var", 84, 1, 85, None)),
+                    ],
+                    kind: ValueKind::List,
+                    spread: None,
+                    filters: vec![],
+                    used_variables: vec![],
+                    assigned_variables: vec![],
+                }),
+            }],
+            used_variables: vec![],
+            assigned_variables: vec![],
+        };
+        assert_eq!(
+            result,
+            Tag::Generic(GenericTag {
+                meta: TagMeta {
+                    token: token(
+                        r#"{% my_tag ...[42, 'hello', my_var]|length key=[100, 'world', other_var]|first:['a', third_var] %}"#,
+                        0,
+                        1,
+                        1
+                    ),
+                    name: token("my_tag", 3, 1, 4),
+                    used_variables: vec![
+                        token("my_var", 27, 1, 28),
+                        token("other_var", 61, 1, 62),
+                        token("third_var", 84, 1, 85)
+                    ],
+                    assigned_variables: vec![],
+                },
+                attrs: vec![
+                    tag_attr(None, list_value1, false),
+                    tag_attr(Some(token("key", 42, 1, 43)), list_value2, false),
+                ],
+                is_self_closing: false,
+            })
+        );
+    }
+
+    #[test]
+    fn test_list_inside_list() {
+        let input = r#"{% my_tag [[42, 'hello', my_var]] %}"#;
+        let (result, _context) = plain_parse_tag_v1(input).unwrap();
+        let inner_list = TagValue {
+            token: token(r#"[42, 'hello', my_var]"#, 11, 1, 12),
+            value: token(r#"[42, 'hello', my_var]"#, 11, 1, 12),
+            children: vec![
+                ValueChild::Value(plain_int_value("42", 12, 1, 13, None)),
+                ValueChild::Value(plain_string_value(r#"'hello'"#, 16, 1, 17, None)),
+                ValueChild::Value(plain_variable_value("my_var", 25, 1, 26, None)),
+            ],
+            kind: ValueKind::List,
+            spread: None,
+            filters: vec![],
+            used_variables: vec![],
+            assigned_variables: vec![],
+        };
+        let outer_list = TagValue {
+            token: token(r#"[[42, 'hello', my_var]]"#, 10, 1, 11),
+            value: token(r#"[[42, 'hello', my_var]]"#, 10, 1, 11),
+            children: vec![ValueChild::Value(inner_list)],
+            kind: ValueKind::List,
+            spread: None,
+            filters: vec![],
+            used_variables: vec![],
+            assigned_variables: vec![],
+        };
+        assert_eq!(
+            result,
+            Tag::Generic(GenericTag {
+                meta: TagMeta {
+                    token: token(r#"{% my_tag [[42, 'hello', my_var]] %}"#, 0, 1, 1),
+                    name: token("my_tag", 3, 1, 4),
+                    used_variables: vec![token("my_var", 25, 1, 26)],
+                    assigned_variables: vec![],
+                },
+                attrs: vec![tag_attr(None, outer_list, false)],
+                is_self_closing: false,
+            })
+        );
+    }
+
+    #[test]
+    fn test_list_inside_list_with_filter_without_arg() {
+        let input = r#"{% my_tag [[42, 'hello', my_var]|length] %}"#;
+        let (result, _context) = plain_parse_tag_v1(input).unwrap();
+        let inner_list = TagValue {
+            token: token(r#"[42, 'hello', my_var]|length"#, 11, 1, 12),
+            value: token(r#"[42, 'hello', my_var]"#, 11, 1, 12),
+            children: vec![
+                ValueChild::Value(plain_int_value("42", 12, 1, 13, None)),
+                ValueChild::Value(plain_string_value(r#"'hello'"#, 16, 1, 17, None)),
+                ValueChild::Value(plain_variable_value("my_var", 25, 1, 26, None)),
+            ],
+            kind: ValueKind::List,
+            spread: None,
+            filters: vec![TagValueFilter {
+                token: token("|length", 32, 1, 33),
+                name: token("length", 33, 1, 34),
+                arg: None,
+            }],
+            used_variables: vec![],
+            assigned_variables: vec![],
+        };
+        let outer_list = TagValue {
+            token: token(r#"[[42, 'hello', my_var]|length]"#, 10, 1, 11),
+            value: token(r#"[[42, 'hello', my_var]|length]"#, 10, 1, 11),
+            children: vec![ValueChild::Value(inner_list)],
+            kind: ValueKind::List,
+            spread: None,
+            filters: vec![],
+            used_variables: vec![],
+            assigned_variables: vec![],
+        };
+        assert_eq!(
+            result,
+            Tag::Generic(GenericTag {
+                meta: TagMeta {
+                    token: token(r#"{% my_tag [[42, 'hello', my_var]|length] %}"#, 0, 1, 1),
+                    name: token("my_tag", 3, 1, 4),
+                    used_variables: vec![token("my_var", 25, 1, 26)],
+                    assigned_variables: vec![],
+                },
+                attrs: vec![tag_attr(None, outer_list, false)],
+                is_self_closing: false,
+            })
+        );
+    }
+
+    #[test]
+    fn test_list_inside_list_with_filter_with_arg() {
+        let input = r#"{% my_tag [[42, 'hello', my_var]|first:['a', third_var]] %}"#;
+        let (result, _context) = plain_parse_tag_v1(input).unwrap();
+        let filter_arg_list = TagValue {
+            token: token(r#"['a', third_var]"#, 39, 1, 40),
+            value: token(r#"['a', third_var]"#, 39, 1, 40),
+            children: vec![
+                ValueChild::Value(plain_string_value(r#"'a'"#, 40, 1, 41, None)),
+                ValueChild::Value(plain_variable_value("third_var", 45, 1, 46, None)),
+            ],
+            kind: ValueKind::List,
+            spread: None,
+            filters: vec![],
+            used_variables: vec![],
+            assigned_variables: vec![],
+        };
+        let inner_list = TagValue {
+            token: token(r#"[42, 'hello', my_var]|first:['a', third_var]"#, 11, 1, 12),
+            value: token(r#"[42, 'hello', my_var]"#, 11, 1, 12),
+            children: vec![
+                ValueChild::Value(plain_int_value("42", 12, 1, 13, None)),
+                ValueChild::Value(plain_string_value(r#"'hello'"#, 16, 1, 17, None)),
+                ValueChild::Value(plain_variable_value("my_var", 25, 1, 26, None)),
+            ],
+            kind: ValueKind::List,
+            spread: None,
+            filters: vec![TagValueFilter {
+                token: token("|first:['a', third_var]", 32, 1, 33),
+                name: token("first", 33, 1, 34),
+                arg: Some(filter_arg_list),
+            }],
+            used_variables: vec![],
+            assigned_variables: vec![],
+        };
+        let outer_list = TagValue {
+            token: token(
+                r#"[[42, 'hello', my_var]|first:['a', third_var]]"#,
+                10,
+                1,
+                11,
+            ),
+            value: token(
+                r#"[[42, 'hello', my_var]|first:['a', third_var]]"#,
+                10,
+                1,
+                11,
+            ),
+            children: vec![ValueChild::Value(inner_list)],
+            kind: ValueKind::List,
+            spread: None,
+            filters: vec![],
+            used_variables: vec![],
+            assigned_variables: vec![],
+        };
+        assert_eq!(
+            result,
+            Tag::Generic(GenericTag {
+                meta: TagMeta {
+                    token: token(
+                        r#"{% my_tag [[42, 'hello', my_var]|first:['a', third_var]] %}"#,
+                        0,
+                        1,
+                        1
+                    ),
+                    name: token("my_tag", 3, 1, 4),
+                    used_variables: vec![token("my_var", 25, 1, 26), token("third_var", 45, 1, 46)],
+                    assigned_variables: vec![],
+                },
+                attrs: vec![tag_attr(None, outer_list, false)],
+                is_self_closing: false,
+            })
+        );
+    }
+
+    #[test]
+    fn test_list_inside_list_with_filter_with_arg_and_spread() {
+        let input = r#"{% my_tag [*[42, 'hello', my_var]|first:['a', third_var]] %}"#;
+        let (result, _context) = plain_parse_tag_v1(input).unwrap();
+        let filter_arg_list = TagValue {
+            token: token(r#"['a', third_var]"#, 40, 1, 41),
+            value: token(r#"['a', third_var]"#, 40, 1, 41),
+            children: vec![
+                ValueChild::Value(plain_string_value(r#"'a'"#, 41, 1, 42, None)),
+                ValueChild::Value(plain_variable_value("third_var", 46, 1, 47, None)),
+            ],
+            kind: ValueKind::List,
+            spread: None,
+            filters: vec![],
+            used_variables: vec![],
+            assigned_variables: vec![],
+        };
+        let inner_list = TagValue {
+            token: token(
+                r#"*[42, 'hello', my_var]|first:['a', third_var]"#,
+                11,
+                1,
+                12,
+            ),
+            value: token(r#"[42, 'hello', my_var]"#, 12, 1, 13),
+            children: vec![
+                ValueChild::Value(plain_int_value("42", 13, 1, 14, None)),
+                ValueChild::Value(plain_string_value(r#"'hello'"#, 17, 1, 18, None)),
+                ValueChild::Value(plain_variable_value("my_var", 26, 1, 27, None)),
+            ],
+            kind: ValueKind::List,
+            spread: Some("*".to_string()),
+            filters: vec![TagValueFilter {
+                token: token("|first:['a', third_var]", 33, 1, 34),
+                name: token("first", 34, 1, 35),
+                arg: Some(filter_arg_list),
+            }],
+            used_variables: vec![],
+            assigned_variables: vec![],
+        };
+        let outer_list = TagValue {
+            token: token(
+                r#"[*[42, 'hello', my_var]|first:['a', third_var]]"#,
+                10,
+                1,
+                11,
+            ),
+            value: token(
+                r#"[*[42, 'hello', my_var]|first:['a', third_var]]"#,
+                10,
+                1,
+                11,
+            ),
+            children: vec![ValueChild::Value(inner_list)],
+            kind: ValueKind::List,
+            spread: None,
+            filters: vec![],
+            used_variables: vec![],
+            assigned_variables: vec![],
+        };
+        assert_eq!(
+            result,
+            Tag::Generic(GenericTag {
+                meta: TagMeta {
+                    token: token(
+                        r#"{% my_tag [*[42, 'hello', my_var]|first:['a', third_var]] %}"#,
+                        0,
+                        1,
+                        1
+                    ),
+                    name: token("my_tag", 3, 1, 4),
+                    used_variables: vec![token("my_var", 26, 1, 27), token("third_var", 46, 1, 47)],
+                    assigned_variables: vec![],
+                },
+                attrs: vec![tag_attr(None, outer_list, false)],
+                is_self_closing: false,
+            })
+        );
+    }
+
+    #[test]
+    fn test_list_inside_list_with_spread() {
+        let input = r#"{% my_tag [*[42, 'hello', my_var]] %}"#;
+        let (result, _context) = plain_parse_tag_v1(input).unwrap();
+        let inner_list = TagValue {
+            token: token(r#"*[42, 'hello', my_var]"#, 11, 1, 12),
+            value: token(r#"[42, 'hello', my_var]"#, 12, 1, 13),
+            children: vec![
+                ValueChild::Value(plain_int_value("42", 13, 1, 14, None)),
+                ValueChild::Value(plain_string_value(r#"'hello'"#, 17, 1, 18, None)),
+                ValueChild::Value(plain_variable_value("my_var", 26, 1, 27, None)),
+            ],
+            kind: ValueKind::List,
+            spread: Some("*".to_string()),
+            filters: vec![],
+            used_variables: vec![],
+            assigned_variables: vec![],
+        };
+        let outer_list = TagValue {
+            token: token(r#"[*[42, 'hello', my_var]]"#, 10, 1, 11),
+            value: token(r#"[*[42, 'hello', my_var]]"#, 10, 1, 11),
+            children: vec![ValueChild::Value(inner_list)],
+            kind: ValueKind::List,
+            spread: None,
+            filters: vec![],
+            used_variables: vec![],
+            assigned_variables: vec![],
+        };
+        assert_eq!(
+            result,
+            Tag::Generic(GenericTag {
+                meta: TagMeta {
+                    token: token(r#"{% my_tag [*[42, 'hello', my_var]] %}"#, 0, 1, 1),
+                    name: token("my_tag", 3, 1, 4),
+                    used_variables: vec![token("my_var", 26, 1, 27)],
+                    assigned_variables: vec![],
+                },
+                attrs: vec![tag_attr(None, outer_list, false)],
+                is_self_closing: false,
+            })
+        );
+    }
+
+    #[test]
+    fn test_list_inside_dict_as_value() {
+        let input = r#"{% my_tag {key: [42, 'hello', my_var]} %}"#;
+        let (result, _context) = plain_parse_tag_v1(input).unwrap();
+        let list_value = TagValue {
+            token: token(r#"[42, 'hello', my_var]"#, 16, 1, 17),
+            value: token(r#"[42, 'hello', my_var]"#, 16, 1, 17),
+            children: vec![
+                ValueChild::Value(plain_int_value("42", 17, 1, 18, None)),
+                ValueChild::Value(plain_string_value(r#"'hello'"#, 21, 1, 22, None)),
+                ValueChild::Value(plain_variable_value("my_var", 30, 1, 31, None)),
+            ],
+            kind: ValueKind::List,
+            spread: None,
+            filters: vec![],
+            used_variables: vec![],
+            assigned_variables: vec![],
+        };
+        let dict_value = TagValue {
+            token: token(r#"{key: [42, 'hello', my_var]}"#, 10, 1, 11),
+            value: token(r#"{key: [42, 'hello', my_var]}"#, 10, 1, 11),
+            children: vec![
+                ValueChild::Value(plain_variable_value("key", 11, 1, 12, None)),
+                ValueChild::Value(list_value),
+            ],
+            kind: ValueKind::Dict,
+            spread: None,
+            filters: vec![],
+            used_variables: vec![],
+            assigned_variables: vec![],
+        };
+        assert_eq!(
+            result,
+            Tag::Generic(GenericTag {
+                meta: TagMeta {
+                    token: token(r#"{% my_tag {key: [42, 'hello', my_var]} %}"#, 0, 1, 1),
+                    name: token("my_tag", 3, 1, 4),
+                    used_variables: vec![token("key", 11, 1, 12), token("my_var", 30, 1, 31)],
+                    assigned_variables: vec![],
+                },
+                attrs: vec![tag_attr(None, dict_value, false)],
+                is_self_closing: false,
+            })
+        );
+    }
+
+    #[test]
+    fn test_list_inside_dict_as_value_with_filter_with_arg() {
+        let input = r#"{% my_tag {key: [42, 'hello', my_var]|first:['a', third_var]} %}"#;
+        let (result, _context) = plain_parse_tag_v1(input).unwrap();
+        let filter_arg_list = TagValue {
+            token: token(r#"['a', third_var]"#, 44, 1, 45),
+            value: token(r#"['a', third_var]"#, 44, 1, 45),
+            children: vec![
+                ValueChild::Value(plain_string_value(r#"'a'"#, 45, 1, 46, None)),
+                ValueChild::Value(plain_variable_value("third_var", 50, 1, 51, None)),
+            ],
+            kind: ValueKind::List,
+            spread: None,
+            filters: vec![],
+            used_variables: vec![],
+            assigned_variables: vec![],
+        };
+        let list_value = TagValue {
+            token: token(r#"[42, 'hello', my_var]|first:['a', third_var]"#, 16, 1, 17),
+            value: token(r#"[42, 'hello', my_var]"#, 16, 1, 17),
+            children: vec![
+                ValueChild::Value(plain_int_value("42", 17, 1, 18, None)),
+                ValueChild::Value(plain_string_value(r#"'hello'"#, 21, 1, 22, None)),
+                ValueChild::Value(plain_variable_value("my_var", 30, 1, 31, None)),
+            ],
+            kind: ValueKind::List,
+            spread: None,
+            filters: vec![TagValueFilter {
+                token: token("|first:['a', third_var]", 37, 1, 38),
+                name: token("first", 38, 1, 39),
+                arg: Some(filter_arg_list),
+            }],
+            used_variables: vec![],
+            assigned_variables: vec![],
+        };
+        let dict_value = TagValue {
+            token: token(
+                r#"{key: [42, 'hello', my_var]|first:['a', third_var]}"#,
+                10,
+                1,
+                11,
+            ),
+            value: token(
+                r#"{key: [42, 'hello', my_var]|first:['a', third_var]}"#,
+                10,
+                1,
+                11,
+            ),
+            children: vec![
+                ValueChild::Value(plain_variable_value("key", 11, 1, 12, None)),
+                ValueChild::Value(list_value),
+            ],
+            kind: ValueKind::Dict,
+            spread: None,
+            filters: vec![],
+            used_variables: vec![],
+            assigned_variables: vec![],
+        };
+        assert_eq!(
+            result,
+            Tag::Generic(GenericTag {
+                meta: TagMeta {
+                    token: token(
+                        r#"{% my_tag {key: [42, 'hello', my_var]|first:['a', third_var]} %}"#,
+                        0,
+                        1,
+                        1
+                    ),
+                    name: token("my_tag", 3, 1, 4),
+                    used_variables: vec![
+                        token("key", 11, 1, 12),
+                        token("my_var", 30, 1, 31),
+                        token("third_var", 50, 1, 51)
+                    ],
+                    assigned_variables: vec![],
+                },
+                attrs: vec![tag_attr(None, dict_value, false)],
+                is_self_closing: false,
+            })
+        );
+    }
+
+    #[test]
+    #[should_panic(expected = "ParsingError")]
+    fn test_list_inside_dict_as_key_and_value() {
+        // Lists cannot be used as dictionary keys - this should fail to parse
+        let input = r#"{% my_tag {[42, 'hello', my_var]: [100, 'world', other_var]} %}"#;
+        let (_result, _context) = plain_parse_tag_v1(input).unwrap();
+    }
+
+    #[test]
+    #[should_panic(expected = "ParsingError")]
+    fn test_list_inside_dict_as_key_and_value_with_filters_and_arg() {
+        // Lists cannot be used as dictionary keys - this should fail to parse
+        let input = r#"{% my_tag {[42, 'hello', my_var]|length: [100, 'world', other_var]|first:['a', third_var]} %}"#;
+        let (_result, _context) = plain_parse_tag_v1(input).unwrap();
+    }
+
+    #[test]
+    fn test_list_inside_dict_with_spread_and_filter() {
+        let input = r#"{% my_tag {**[42, 'hello', my_var]|length} %}"#;
+        let (result, _context) = plain_parse_tag_v1(input).unwrap();
+        let list_value = TagValue {
+            token: token(r#"**[42, 'hello', my_var]|length"#, 11, 1, 12),
+            value: token(r#"[42, 'hello', my_var]"#, 13, 1, 14),
+            children: vec![
+                ValueChild::Value(plain_int_value("42", 14, 1, 15, None)),
+                ValueChild::Value(plain_string_value(r#"'hello'"#, 18, 1, 19, None)),
+                ValueChild::Value(plain_variable_value("my_var", 27, 1, 28, None)),
+            ],
+            kind: ValueKind::List,
+            spread: Some("**".to_string()),
+            filters: vec![TagValueFilter {
+                token: token("|length", 34, 1, 35),
+                name: token("length", 35, 1, 36),
+                arg: None,
+            }],
+            used_variables: vec![],
+            assigned_variables: vec![],
+        };
+        let dict_value = TagValue {
+            token: token(r#"{**[42, 'hello', my_var]|length}"#, 10, 1, 11),
+            value: token(r#"{**[42, 'hello', my_var]|length}"#, 10, 1, 11),
+            children: vec![ValueChild::Value(list_value)],
+            kind: ValueKind::Dict,
+            spread: None,
+            filters: vec![],
+            used_variables: vec![],
+            assigned_variables: vec![],
+        };
+        assert_eq!(
+            result,
+            Tag::Generic(GenericTag {
+                meta: TagMeta {
+                    token: token(r#"{% my_tag {**[42, 'hello', my_var]|length} %}"#, 0, 1, 1),
+                    name: token("my_tag", 3, 1, 4),
+                    used_variables: vec![token("my_var", 27, 1, 28)],
+                    assigned_variables: vec![],
+                },
+                attrs: vec![tag_attr(None, dict_value, false)],
+                is_self_closing: false,
+            })
+        );
+    }
+
+    // #######################################
+    // LIST EDGE CASES
+    // #######################################
+
+    #[test]
+    fn test_list_empty() {
+        // Empty list
+        let input = "{% my_tag [] %}";
+        let (result, _context) = plain_parse_tag_v1(input).unwrap();
+        assert_eq!(
+            result,
+            Tag::Generic(GenericTag {
+                meta: TagMeta {
+                    token: token("{% my_tag [] %}", 0, 1, 1),
+                    name: token("my_tag", 3, 1, 4),
+                    used_variables: vec![],
+                    assigned_variables: vec![],
+                },
+                attrs: vec![tag_attr(
+                    None,
+                    TagValue {
+                        token: token("[]", 10, 1, 11),
+                        value: token("[]", 10, 1, 11),
+                        children: vec![],
+                        kind: ValueKind::List,
+                        spread: None,
+                        filters: vec![],
+                        used_variables: vec![],
+                        assigned_variables: vec![],
+                    },
+                    false,
+                )],
+                is_self_closing: false,
+            })
+        );
+    }
+
+    #[test]
+    fn test_list_mixed() {
+        // List with mixed types
+        let input = "{% my_tag [42, 'hello', my_var] %}";
+        let (result, _context) = plain_parse_tag_v1(input).unwrap();
+        assert_eq!(
+            result,
+            Tag::Generic(GenericTag {
+                meta: TagMeta {
+                    token: token("{% my_tag [42, 'hello', my_var] %}", 0, 1, 1),
+                    name: token("my_tag", 3, 1, 4),
+                    used_variables: vec![token("my_var", 24, 1, 25)],
+                    assigned_variables: vec![],
+                },
+                attrs: vec![tag_attr(
+                    None,
+                    TagValue {
+                        token: token("[42, 'hello', my_var]", 10, 1, 11),
+                        value: token("[42, 'hello', my_var]", 10, 1, 11),
+                        children: vec![
+                            ValueChild::Value(plain_int_value("42", 11, 1, 12, None)),
+                            ValueChild::Value(plain_string_value("'hello'", 15, 1, 16, None)),
+                            ValueChild::Value(plain_variable_value("my_var", 24, 1, 25, None)),
+                        ],
+                        kind: ValueKind::List,
+                        spread: None,
+                        filters: vec![],
+                        used_variables: vec![],
+                        assigned_variables: vec![],
+                    },
+                    false,
+                )],
+                is_self_closing: false,
+            })
+        );
+    }
+
+    #[test]
+    fn test_list_filter_item() {
+        // List with filters on individual items
+        let input = "{% my_tag ['hello'|upper, 'world'|title] %}";
+        let (result, _context) = plain_parse_tag_v1(input).unwrap();
+        assert_eq!(
+            result,
+            Tag::Generic(GenericTag {
+                meta: TagMeta {
+                    token: token("{% my_tag ['hello'|upper, 'world'|title] %}", 0, 1, 1),
+                    name: token("my_tag", 3, 1, 4),
+                    used_variables: vec![],
+                    assigned_variables: vec![],
+                },
+                attrs: vec![tag_attr(
+                    None,
+                    TagValue {
+                        token: token("['hello'|upper, 'world'|title]", 10, 1, 11),
+                        value: token("['hello'|upper, 'world'|title]", 10, 1, 11),
+                        children: vec![
+                            ValueChild::Value(string_value(
+                                token("'hello'|upper", 11, 1, 12),
+                                token("'hello'", 11, 1, 12),
+                                None,
+                                vec![TagValueFilter {
+                                    name: token("upper", 19, 1, 20),
+                                    token: token("|upper", 18, 1, 19),
+                                    arg: None,
+                                }],
+                                vec![],
+                                vec![],
+                            )),
+                            ValueChild::Value(string_value(
+                                token("'world'|title", 26, 1, 27),
+                                token("'world'", 26, 1, 27),
+                                None,
+                                vec![TagValueFilter {
+                                    name: token("title", 34, 1, 35),
+                                    token: token("|title", 33, 1, 34),
+                                    arg: None,
+                                }],
+                                vec![],
+                                vec![],
+                            )),
+                        ],
+                        kind: ValueKind::List,
+                        spread: None,
+                        filters: vec![],
+                        used_variables: vec![],
+                        assigned_variables: vec![],
+                    },
+                    false,
+                )],
+                is_self_closing: false,
+            })
+        );
+    }
+
+    #[test]
+    fn test_list_filter_everywhere() {
+        // List with both item filters and list filter
+        let input = "{% my_tag ['a'|upper, 'b'|upper]|join:',' %}";
+        let (result, _context) = plain_parse_tag_v1(input).unwrap();
+        assert_eq!(
+            result,
+            Tag::Generic(GenericTag {
+                meta: TagMeta {
+                    token: token("{% my_tag ['a'|upper, 'b'|upper]|join:',' %}", 0, 1, 1),
+                    name: token("my_tag", 3, 1, 4),
+                    used_variables: vec![],
+                    assigned_variables: vec![],
+                },
+                attrs: vec![tag_attr(
+                    None,
+                    TagValue {
+                        token: token("['a'|upper, 'b'|upper]|join:','", 10, 1, 11),
+                        value: token("['a'|upper, 'b'|upper]", 10, 1, 11),
+                        children: vec![
+                            ValueChild::Value(string_value(
+                                token("'a'|upper", 11, 1, 12),
+                                token("'a'", 11, 1, 12),
+                                None,
+                                vec![TagValueFilter {
+                                    name: token("upper", 15, 1, 16),
+                                    token: token("|upper", 14, 1, 15),
+                                    arg: None,
+                                }],
+                                vec![],
+                                vec![],
+                            )),
+                            ValueChild::Value(string_value(
+                                token("'b'|upper", 22, 1, 23),
+                                token("'b'", 22, 1, 23),
+                                None,
+                                vec![TagValueFilter {
+                                    name: token("upper", 26, 1, 27),
+                                    token: token("|upper", 25, 1, 26),
+                                    arg: None,
+                                }],
+                                vec![],
+                                vec![],
+                            )),
+                        ],
+                        kind: ValueKind::List,
+                        spread: None,
+                        filters: vec![TagValueFilter {
+                            name: token("join", 33, 1, 34),
+                            token: token("|join:','", 32, 1, 33),
+                            arg: Some(plain_string_value("','", 38, 1, 39, None)),
+                        }],
+                        used_variables: vec![],
+                        assigned_variables: vec![],
+                    },
+                    false,
+                )],
+                is_self_closing: false,
+            })
+        );
+    }
+
+    #[test]
+    fn test_list_nested() {
+        // Simple nested list
+        let input = "{% my_tag [1, [2, 3], 4] %}";
+        let (result, _context) = plain_parse_tag_v1(input).unwrap();
+        assert_eq!(
+            result,
+            Tag::Generic(GenericTag {
+                meta: TagMeta {
+                    token: token("{% my_tag [1, [2, 3], 4] %}", 0, 1, 1),
+                    name: token("my_tag", 3, 1, 4),
+                    used_variables: vec![],
+                    assigned_variables: vec![],
+                },
+                attrs: vec![tag_attr(
+                    None,
+                    TagValue {
+                        token: token("[1, [2, 3], 4]", 10, 1, 11),
+                        value: token("[1, [2, 3], 4]", 10, 1, 11),
+                        children: vec![
+                            ValueChild::Value(plain_int_value("1", 11, 1, 12, None)),
+                            ValueChild::Value(TagValue {
+                                token: token("[2, 3]", 14, 1, 15),
+                                value: token("[2, 3]", 14, 1, 15),
+                                children: vec![
+                                    ValueChild::Value(plain_int_value("2", 15, 1, 16, None)),
+                                    ValueChild::Value(plain_int_value("3", 18, 1, 19, None)),
+                                ],
+                                kind: ValueKind::List,
+                                spread: None,
+                                filters: vec![],
+                                used_variables: vec![],
+                                assigned_variables: vec![],
+                            }),
+                            ValueChild::Value(plain_int_value("4", 22, 1, 23, None)),
+                        ],
+                        kind: ValueKind::List,
+                        spread: None,
+                        filters: vec![],
+                        used_variables: vec![],
+                        assigned_variables: vec![],
+                    },
+                    false,
+                )],
+                is_self_closing: false,
+            })
+        );
+    }
+
+    #[test]
+    fn test_list_nested_filter() {
+        // Nested list with filters
+        let input = "{% my_tag [[1, 2]|first, [3, 4]|last]|join:',' %}";
+        let (result, _context) = plain_parse_tag_v1(input).unwrap();
+        assert_eq!(
+            result,
+            Tag::Generic(GenericTag {
+                meta: TagMeta {
+                    token: token("{% my_tag [[1, 2]|first, [3, 4]|last]|join:',' %}", 0, 1, 1),
+                    name: token("my_tag", 3, 1, 4),
+                    used_variables: vec![],
+                    assigned_variables: vec![],
+                },
+                attrs: vec![tag_attr(
+                    None,
+                    TagValue {
+                        token: token("[[1, 2]|first, [3, 4]|last]|join:','", 10, 1, 11),
+                        value: token("[[1, 2]|first, [3, 4]|last]", 10, 1, 11),
+                        children: vec![
+                            ValueChild::Value(TagValue {
+                                token: token("[1, 2]|first", 11, 1, 12),
+                                value: token("[1, 2]", 11, 1, 12),
+                                children: vec![
+                                    ValueChild::Value(plain_int_value("1", 12, 1, 13, None)),
+                                    ValueChild::Value(plain_int_value("2", 15, 1, 16, None)),
+                                ],
+                                kind: ValueKind::List,
+                                spread: None,
+                                filters: vec![TagValueFilter {
+                                    name: token("first", 18, 1, 19),
+                                    token: token("|first", 17, 1, 18),
+                                    arg: None,
+                                }],
+                                used_variables: vec![],
+                                assigned_variables: vec![],
+                            }),
+                            ValueChild::Value(TagValue {
+                                token: token("[3, 4]|last", 25, 1, 26),
+                                value: token("[3, 4]", 25, 1, 26),
+                                children: vec![
+                                    ValueChild::Value(plain_int_value("3", 26, 1, 27, None)),
+                                    ValueChild::Value(plain_int_value("4", 29, 1, 30, None)),
+                                ],
+                                kind: ValueKind::List,
+                                spread: None,
+                                filters: vec![TagValueFilter {
+                                    name: token("last", 32, 1, 33),
+                                    token: token("|last", 31, 1, 32),
+                                    arg: None,
+                                }],
+                                used_variables: vec![],
+                                assigned_variables: vec![],
+                            }),
+                        ],
+                        kind: ValueKind::List,
+                        spread: None,
+                        filters: vec![TagValueFilter {
+                            name: token("join", 38, 1, 39),
+                            token: token("|join:','", 37, 1, 38),
+                            arg: Some(plain_string_value("','", 43, 1, 44, None)),
+                        }],
+                        used_variables: vec![],
+                        assigned_variables: vec![],
+                    },
+                    false,
+                )],
+                is_self_closing: false,
+            })
+        );
+    }
+
+    #[test]
+    fn test_list_whitespace() {
+        // Test whitespace in list
+        let input = "{% my_tag [ 1 , 2 , 3 ] %}";
+        let (result, _context) = plain_parse_tag_v1(input).unwrap();
+        assert_eq!(
+            result,
+            Tag::Generic(GenericTag {
+                meta: TagMeta {
+                    token: token("{% my_tag [ 1 , 2 , 3 ] %}", 0, 1, 1),
+                    name: token("my_tag", 3, 1, 4),
+                    used_variables: vec![],
+                    assigned_variables: vec![],
+                },
+                attrs: vec![tag_attr(
+                    None,
+                    TagValue {
+                        token: token("[ 1 , 2 , 3 ]", 10, 1, 11),
+                        value: token("[ 1 , 2 , 3 ]", 10, 1, 11),
+                        children: vec![
+                            ValueChild::Value(plain_int_value("1", 12, 1, 13, None)),
+                            ValueChild::Value(plain_int_value("2", 16, 1, 17, None)),
+                            ValueChild::Value(plain_int_value("3", 20, 1, 21, None)),
+                        ],
+                        kind: ValueKind::List,
+                        spread: None,
+                        filters: vec![],
+                        used_variables: vec![],
+                        assigned_variables: vec![],
+                    },
+                    false,
+                )],
+                is_self_closing: false,
+            })
+        );
+    }
+
+    #[test]
+    fn test_list_comments() {
+        // Test comments in list
+        let input =
+            "{% my_tag {# before start #}[{# first #}1,{# second #}2,{# third #}3{# end #}]{# after end #} %}";
+        let (result, _context) = plain_parse_tag_v1(input).unwrap();
+        assert_eq!(
+            result,
+            Tag::Generic(GenericTag {
+                meta: TagMeta {
+                    token: token(
+                        "{% my_tag {# before start #}[{# first #}1,{# second #}2,{# third #}3{# end #}]{# after end #} %}",
+                        0,
+                        1,
+                        1
+                    ),
+                    name: token("my_tag", 3, 1, 4),
+                    used_variables: vec![],
+                    assigned_variables: vec![],
+                },
+                attrs: vec![tag_attr(
+                    None,
+                    TagValue {
+                        token: token(
+                            "[{# first #}1,{# second #}2,{# third #}3{# end #}]",
+                            28,
+                            1,
+                            29
+                        ),
+                        value: token(
+                            "[{# first #}1,{# second #}2,{# third #}3{# end #}]",
+                            28,
+                            1,
+                            29
+                        ),
+                        children: vec![
+                            ValueChild::Value(plain_int_value("1", 40, 1, 41, None)),
+                            ValueChild::Value(plain_int_value("2", 54, 1, 55, None)),
+                            ValueChild::Value(plain_int_value("3", 67, 1, 68, None)),
+                        ],
+                        kind: ValueKind::List,
+                        spread: None,
+                        filters: vec![],
+                        used_variables: vec![],
+                        assigned_variables: vec![],
+                    },
+                    false,
+                )],
+                is_self_closing: false,
+            })
+        );
+    }
+
+    #[test]
+    fn test_list_trailing_comma() {
+        let input = "{% my_tag [1, 2, 3,] %}";
+        let (result, _context) = plain_parse_tag_v1(input).unwrap();
+        assert_eq!(
+            result,
+            Tag::Generic(GenericTag {
+                meta: TagMeta {
+                    token: token("{% my_tag [1, 2, 3,] %}", 0, 1, 1),
+                    name: token("my_tag", 3, 1, 4),
+                    used_variables: vec![],
+                    assigned_variables: vec![],
+                },
+                attrs: vec![tag_attr(
+                    None,
+                    TagValue {
+                        token: token("[1, 2, 3,]", 10, 1, 11),
+                        value: token("[1, 2, 3,]", 10, 1, 11),
+                        children: vec![
+                            ValueChild::Value(plain_int_value("1", 11, 1, 12, None)),
+                            ValueChild::Value(plain_int_value("2", 14, 1, 15, None)),
+                            ValueChild::Value(plain_int_value("3", 17, 1, 18, None)),
+                        ],
+                        kind: ValueKind::List,
+                        spread: None,
+                        filters: vec![],
+                        used_variables: vec![],
+                        assigned_variables: vec![],
+                    },
+                    false,
+                )],
+                is_self_closing: false,
+            })
+        );
+    }
+
+    #[test]
+    fn test_list_spread() {
+        let input =
+            "{% my_tag [1, *[2, 3], *{'a': 1}, *my_list, *'xyz', *_('hello'), *'{{ var }}', *3.14, 4] %}";
+        let (result, _context) = plain_parse_tag_v1(input).unwrap();
+        assert_eq!(
+            result,
+            Tag::Generic(GenericTag {
+                meta: TagMeta {
+                    token: token(
+                        "{% my_tag [1, *[2, 3], *{'a': 1}, *my_list, *'xyz', *_('hello'), *'{{ var }}', *3.14, 4] %}",
+                        0,
+                        1,
+                        1
+                    ),
+                    name: token("my_tag", 3, 1, 4),
+                    used_variables: vec![token("my_list", 35, 1, 36)],
+                    assigned_variables: vec![],
+                },
+                attrs: vec![tag_attr(
+                    None,
+                    TagValue {
+                        token: token("[1, *[2, 3], *{'a': 1}, *my_list, *'xyz', *_('hello'), *'{{ var }}', *3.14, 4]", 10, 1, 11),
+                        value: token("[1, *[2, 3], *{'a': 1}, *my_list, *'xyz', *_('hello'), *'{{ var }}', *3.14, 4]", 10, 1, 11),
+                        children: vec![
+                            ValueChild::Value(plain_int_value("1", 11, 1, 12, None)),
+                            ValueChild::Value(TagValue {
+                                token: token("*[2, 3]", 14, 1, 15),
+                                value: token("[2, 3]", 15, 1, 16),
+                                children: vec![
+                                    ValueChild::Value(plain_int_value("2", 16, 1, 17, None)),
+                                    ValueChild::Value(plain_int_value("3", 19, 1, 20, None)),
+                                ],
+                                kind: ValueKind::List,
+                                spread: Some("*".to_string()),
+                                filters: vec![],
+                                used_variables: vec![],
+                                assigned_variables: vec![],
+                            }),
+                            ValueChild::Value(TagValue {
+                                token: token("*{'a': 1}", 23, 1, 24),
+                                value: token("{'a': 1}", 24, 1, 25),
+                                children: vec![
+                                    ValueChild::Value(plain_string_value("'a'", 25, 1, 26, None)),
+                                    ValueChild::Value(plain_int_value("1", 30, 1, 31, None)),
+                                ],
+                                kind: ValueKind::Dict,
+                                spread: Some("*".to_string()),
+                                filters: vec![],
+                                used_variables: vec![],
+                                assigned_variables: vec![],
+                            }),
+                            ValueChild::Value(plain_variable_value("my_list", 34, 1, 35, Some("*"))),
+                            ValueChild::Value(plain_string_value("'xyz'", 44, 1, 45, Some("*"))),
+                            ValueChild::Value(plain_translation_value("_('hello')", 52, 1, 53, Some("*"))),
+                            ValueChild::Value(template_string_value(
+                                token("*'{{ var }}'", 65, 1, 66),
+                                token("'{{ var }}'", 66, 1, 67),
+                                Some("*"),
+                                vec![],
+                                vec![],
+                                vec![],
+                            )),
+                            ValueChild::Value(plain_float_value("3.14", 79, 1, 80, Some("*"))),
+                            ValueChild::Value(plain_int_value("4", 86, 1, 87, None)),
+                        ],
+                        kind: ValueKind::List,
+                        spread: None,
+                        filters: vec![],
+                        used_variables: vec![],
+                        assigned_variables: vec![],
+                    },
+                    false,
+                )],
+                is_self_closing: false,
+            })
+        );
+    }
+
+    #[test]
+    fn test_list_spread_filter() {
+        let input = r#"{% my_tag [1, *[2|upper, 3|lower], *{'a': 1}|default:empty, *my_list|join:",", *'xyz'|upper, *_('hello')|escape, *'{{ var }}'|safe, *3.14|round, 4|default:0] %}"#;
+        let (result, _context) = plain_parse_tag_v1(input).unwrap();
+        assert_eq!(
+            result,
+            Tag::Generic(GenericTag {
+                meta: TagMeta {
+                    token: token(
+                        r#"{% my_tag [1, *[2|upper, 3|lower], *{'a': 1}|default:empty, *my_list|join:",", *'xyz'|upper, *_('hello')|escape, *'{{ var }}'|safe, *3.14|round, 4|default:0] %}"#,
+                        0,
+                        1,
+                        1
+                    ),
+                    name: token("my_tag", 3, 1, 4),
+                    used_variables: vec![token("empty", 53, 1, 54), token("my_list", 61, 1, 62)],
+                    assigned_variables: vec![],
+                },
+                attrs: vec![tag_attr(
+                    None,
+                    TagValue {
+                        token: token(
+                            r#"[1, *[2|upper, 3|lower], *{'a': 1}|default:empty, *my_list|join:",", *'xyz'|upper, *_('hello')|escape, *'{{ var }}'|safe, *3.14|round, 4|default:0]"#,
+                            10,
+                            1,
+                            11
+                        ),
+                        value: token(
+                            r#"[1, *[2|upper, 3|lower], *{'a': 1}|default:empty, *my_list|join:",", *'xyz'|upper, *_('hello')|escape, *'{{ var }}'|safe, *3.14|round, 4|default:0]"#,
+                            10,
+                            1,
+                            11
+                        ),
+                        children: vec![
+                            ValueChild::Value(plain_int_value("1", 11, 1, 12, None)),
+                            ValueChild::Value(TagValue {
+                                token: token("*[2|upper, 3|lower]", 14, 1, 15),
+                                value: token("[2|upper, 3|lower]", 15, 1, 16),
+                                children: vec![
+                                    ValueChild::Value(int_value(
+                                        token("2|upper", 16, 1, 17),
+                                        token("2", 16, 1, 17),
+                                        None,
+                                        vec![TagValueFilter {
+                                            name: token("upper", 18, 1, 19),
+                                            token: token("|upper", 17, 1, 18),
+                                            arg: None,
+                                        }],
+                                        vec![],
+                                        vec![],
+                                    )),
+                                    ValueChild::Value(int_value(
+                                        token("3|lower", 25, 1, 26),
+                                        token("3", 25, 1, 26),
+                                        None,
+                                        vec![TagValueFilter {
+                                            name: token("lower", 27, 1, 28),
+                                            token: token("|lower", 26, 1, 27),
+                                            arg: None,
+                                        }],
+                                        vec![],
+                                        vec![],
+                                    )),
+                                ],
+                                kind: ValueKind::List,
+                                spread: Some("*".to_string()),
+                                filters: vec![],
+                                used_variables: vec![],
+                                assigned_variables: vec![],
+                            }),
+                            ValueChild::Value(TagValue {
+                                token: token("*{'a': 1}|default:empty", 35, 1, 36),
+                                value: token("{'a': 1}", 36, 1, 37),
+                                children: vec![
+                                    ValueChild::Value(plain_string_value("'a'", 37, 1, 38, None)),
+                                    ValueChild::Value(plain_int_value("1", 42, 1, 43, None)),
+                                ],
+                                kind: ValueKind::Dict,
+                                spread: Some("*".to_string()),
+                                filters: vec![TagValueFilter {
+                                    name: token("default", 45, 1, 46),
+                                    token: token("|default:empty", 44, 1, 45),
+                                    arg: Some(plain_variable_value("empty", 53, 1, 54, None)),
+                                }],
+                                used_variables: vec![],
+                                assigned_variables: vec![],
+                            }),
+                            ValueChild::Value(variable_value(
+                                token(r#"*my_list|join:",""#, 60, 1, 61),
+                                token("my_list", 61, 1, 62),
+                                Some("*"),
+                                vec![TagValueFilter {
+                                    name: token("join", 69, 1, 70),
+                                    token: token(r#"|join:",""#, 68, 1, 69),
+                                    arg: Some(plain_string_value(r#"",""#, 74, 1, 75, None)),
+                                }],
+                                vec![],
+                                vec![],
+                            )),
+                            ValueChild::Value(string_value(
+                                token("*'xyz'|upper", 79, 1, 80),
+                                token("'xyz'", 80, 1, 81),
+                                Some("*"),
+                                vec![TagValueFilter {
+                                    name: token("upper", 86, 1, 87),
+                                    token: token("|upper", 85, 1, 86),
+                                    arg: None,
+                                }],
+                                vec![],
+                                vec![],
+                            )),
+                            ValueChild::Value(translation_value(
+                                token("*_('hello')|escape", 93, 1, 94),
+                                token("_('hello')", 94, 1, 95),
+                                Some("*"),
+                                vec![TagValueFilter {
+                                    name: token("escape", 105, 1, 106),
+                                    token: token("|escape", 104, 1, 105),
+                                    arg: None,
+                                }],
+                                vec![],
+                                vec![],
+                            )),
+                            ValueChild::Value(template_string_value(
+                                token("*'{{ var }}'|safe", 113, 1, 114),
+                                token("'{{ var }}'", 114, 1, 115),
+                                Some("*"),
+                                vec![TagValueFilter {
+                                    name: token("safe", 126, 1, 127),
+                                    token: token("|safe", 125, 1, 126),
+                                    arg: None,
+                                }],
+                                vec![],
+                                vec![],
+                            )),
+                            ValueChild::Value(float_value(
+                                token("*3.14|round", 132, 1, 133),
+                                token("3.14", 133, 1, 134),
+                                Some("*"),
+                                vec![TagValueFilter {
+                                    name: token("round", 138, 1, 139),
+                                    token: token("|round", 137, 1, 138),
+                                    arg: None,
+                                }],
+                                vec![],
+                                vec![],
+                            )),
+                            ValueChild::Value(int_value(
+                                token("4|default:0", 145, 1, 146),
+                                token("4", 145, 1, 146),
+                                None,
+                                vec![TagValueFilter {
+                                    name: token("default", 147, 1, 148),
+                                    token: token("|default:0", 146, 1, 147),
+                                    arg: Some(plain_int_value("0", 155, 1, 156, None)),
+                                }],
+                                vec![],
+                                vec![],
+                            )),
+                        ],
+                        kind: ValueKind::List,
+                        spread: None,
+                        filters: vec![],
+                        used_variables: vec![],
+                        assigned_variables: vec![],
+                    },
+                    false,
+                )],
+                is_self_closing: false,
+            })
+        );
+    }
+
+    #[test]
+    fn test_list_spread_invalid() {
+        // Test asterisk at top level as value-only
+        let input = "{% my_tag *value %}";
+        assert!(
+            plain_parse_tag_v1(input).is_err(),
+            "Should not allow asterisk operator at top level"
+        );
+
+        // Test asterisk in value position of key-value pair
+        let input = "{% my_tag key=*value %}";
+        assert!(
+            plain_parse_tag_v1(input).is_err(),
+            "Should not allow asterisk operator in value position of key-value pair"
+        );
+
+        // Test asterisk in key position
+        let input = "{% my_tag *key=value %}";
+        assert!(
+            plain_parse_tag_v1(input).is_err(),
+            "Should not allow asterisk operator in key position"
+        );
+
+        // Test asterisk with nested list at top level
+        let input = "{% my_tag *[1, 2, 3] %}";
+        assert!(
+            plain_parse_tag_v1(input).is_err(),
+            "Should not allow asterisk operator with list at top level"
+        );
+
+        // Test asterisk with nested list in key-value pair
+        let input = "{% my_tag key=*[1, 2, 3] %}";
+        assert!(
+            plain_parse_tag_v1(input).is_err(),
+            "Should not allow asterisk operator with list in key-value pair"
+        );
+
+        // Test combining spread operators
+        let input = "{% my_tag ...*[1, 2, 3] %}";
+        assert!(
+            plain_parse_tag_v1(input).is_err(),
+            "Should not allow combining spread operators"
+        );
+
+        // Test combining spread operators with variable
+        let input = "{% my_tag ...*my_list %}";
+        assert!(
+            plain_parse_tag_v1(input).is_err(),
+            "Should not allow combining spread operators with variable"
+        );
+
+        // Test combining spread operators
+        let input = "{% my_tag *...[1, 2, 3] %}";
+        assert!(
+            plain_parse_tag_v1(input).is_err(),
+            "Should not allow combining spread operators"
+        );
+    }
+
+    #[test]
+    fn test_list_spread_comments() {
+        // Test comments before / after spread
+        let input = "{% my_tag [{# ... #}*{# ... #}1,*{# ... #}2,{# ... #}3] %}";
+        let (result, _context) = plain_parse_tag_v1(input).unwrap();
+        assert_eq!(
+            result,
+            Tag::Generic(GenericTag {
+                meta: TagMeta {
+                    token: token(
+                        "{% my_tag [{# ... #}*{# ... #}1,*{# ... #}2,{# ... #}3] %}",
+                        0,
+                        1,
+                        1
+                    ),
+                    name: token("my_tag", 3, 1, 4),
+                    used_variables: vec![],
+                    assigned_variables: vec![],
+                },
+                attrs: vec![tag_attr(
+                    None,
+                    TagValue {
+                        token: token("[{# ... #}*{# ... #}1,*{# ... #}2,{# ... #}3]", 10, 1, 11),
+                        value: token("[{# ... #}*{# ... #}1,*{# ... #}2,{# ... #}3]", 10, 1, 11),
+                        children: vec![
+                            ValueChild::Value(
+                                TagValue {
+                                    token: token("*{# ... #}1", 20, 1, 21),
+                                    value: token("1", 30, 1, 31),
+                                    children: vec![],
+                                    kind: ValueKind::Int,
+                                    spread: Some("*".to_string()),
+                                    filters: vec![],
+                                    used_variables: vec![],
+                                    assigned_variables: vec![],
+                                },
+                            ),
+                            ValueChild::Value(
+                                TagValue {
+                                    token: token("*{# ... #}2", 32, 1, 33),
+                                    value: token("2", 42, 1, 43),
+                                    children: vec![],
+                                    kind: ValueKind::Int,
+                                    spread: Some("*".to_string()),
+                                    filters: vec![],
+                                    used_variables: vec![],
+                                    assigned_variables: vec![],
+                                }
+                            ),
+                            ValueChild::Value(
+                                TagValue {
+                                    token: token("3", 53, 1, 54),
+                                    value: token("3", 53, 1, 54),
+                                    children: vec![],
+                                    kind: ValueKind::Int,
+                                    spread: None,
+                                    filters: vec![],
+                                    used_variables: vec![],
+                                    assigned_variables: vec![],
+                                },
+                            ),
+                        ],
+                        kind: ValueKind::List,
+                        spread: None,
+                        filters: vec![],
+                        used_variables: vec![],
+                        assigned_variables: vec![],
+                    },
+                    false,
+                )],
+                is_self_closing: false,
+            })
+        );
+    }
+
+    #[test]
+    fn test_list_spread_nested_comments() {
+        // Test comments with nested spread
+        let input =
+            "{% my_tag {# c0 #}[1, {# c1 #}*{# c2 #}[2, {# c3 #}*{# c4 #}[3, 4]], 5]{# c5 #} %}";
+        let (result, _context) = plain_parse_tag_v1(input).unwrap();
+        assert_eq!(
+            result,
+            Tag::Generic(GenericTag {
+                meta: TagMeta {
+                    token: token(
+                        "{% my_tag {# c0 #}[1, {# c1 #}*{# c2 #}[2, {# c3 #}*{# c4 #}[3, 4]], 5]{# c5 #} %}",
+                        0,
+                        1,
+                        1
+                    ),
+                    name: token("my_tag", 3, 1, 4),
+                    used_variables: vec![],
+                    assigned_variables: vec![],
+                },
+                attrs: vec![tag_attr(
+                    None,
+                    TagValue {
+                        token: token(
+                            "[1, {# c1 #}*{# c2 #}[2, {# c3 #}*{# c4 #}[3, 4]], 5]",
+                            18,
+                            1,
+                            19
+                        ),
+                        value: token(
+                            "[1, {# c1 #}*{# c2 #}[2, {# c3 #}*{# c4 #}[3, 4]], 5]",
+                            18,
+                            1,
+                            19
+                        ),
+                        children: vec![
+                            ValueChild::Value(plain_int_value("1", 19, 1, 20, None)),
+                            ValueChild::Value(TagValue {
+                                token: token("*{# c2 #}[2, {# c3 #}*{# c4 #}[3, 4]]", 30, 1, 31),
+                                value: token("[2, {# c3 #}*{# c4 #}[3, 4]]", 39, 1, 40),
+                                children: vec![
+                                    ValueChild::Value(plain_int_value("2", 40, 1, 41, None)),
+                                    ValueChild::Value(TagValue {
+                                        token: token("*{# c4 #}[3, 4]", 51, 1, 52),
+                                        value: token("[3, 4]", 60, 1, 61),
+                                        children: vec![
+                                            ValueChild::Value(plain_int_value("3", 61, 1, 62, None)),
+                                            ValueChild::Value(plain_int_value("4", 64, 1, 65, None)),
+                                        ],
+                                        kind: ValueKind::List,
+                                        spread: Some("*".to_string()),
+                                        filters: vec![],
+                                        used_variables: vec![],
+                                        assigned_variables: vec![],
+                                    }),
+                                ],
+                                kind: ValueKind::List,
+                                spread: Some("*".to_string()),
+                                filters: vec![],
+                                used_variables: vec![],
+                                assigned_variables: vec![],
+                            }),
+                            ValueChild::Value(plain_int_value("5", 69, 1, 70, None)),
+                        ],
+                        kind: ValueKind::List,
+                        spread: None,
+                        filters: vec![],
+                        used_variables: vec![],
+                        assigned_variables: vec![],
+                    },
+                    false,
+                )],
+                is_self_closing: false,
+            })
+        );
+    }
+}

--- a/crates/djc-template-parser/tests/tag_parser_python_expr.rs
+++ b/crates/djc-template-parser/tests/tag_parser_python_expr.rs
@@ -1,0 +1,1351 @@
+// Each of the `tag_parser_<data_type>.rs` file tests following cases:
+//  1. as arg
+//  2. as multiple args
+//  3. as arg with filter without filter arg
+//  4. as arg with filter with filter arg
+//  5. as arg with `...` spread
+//  6. as kwarg
+//  7. as multiple kwargs
+//  8. as kwarg with filter without filter arg
+//  9. as kwarg with filter with filter arg
+// 10. as both arg and kwarg with filters
+// 11. as both arg and kwarg with filters and arg with `...` spreads
+// 12. inside list
+// 13. inside list with filter without filter arg
+// 14. inside list with filter with filter arg
+// 15. inside list with filter with filter arg and `*` spread.
+// 16. inside list with `*` spread.
+// 17. inside dict as value
+// 18. inside dict as value with filter with filter arg
+// 19. inside dict as key and value
+// 20. inside dict as key and value, both with filters, and value with filter arg.
+// 21. inside dict as neither key nor value, with `**` spread and filter without arg
+
+mod common;
+
+#[cfg(test)]
+mod tests {
+    use std::vec;
+
+    use djc_template_parser::ast::{
+        GenericTag, Tag, TagMeta, TagValue, TagValueFilter, ValueChild, ValueKind,
+    };
+
+    use super::common::{
+        plain_parse_tag_v1, plain_variable_value, python_expr_value, tag_attr, token,
+    };
+
+    #[test]
+    fn test_python_expr_as_arg() {
+        let input = r#"{% my_tag ( [42, (nu_var := 'hello'), my_var] ) %}"#;
+        let (result, _context) = plain_parse_tag_v1(input).unwrap();
+        assert_eq!(
+            result,
+            Tag::Generic(GenericTag {
+                meta: TagMeta {
+                    token: token(
+                        r#"{% my_tag ( [42, (nu_var := 'hello'), my_var] ) %}"#,
+                        0,
+                        1,
+                        1
+                    ),
+                    name: token("my_tag", 3, 1, 4),
+                    used_variables: vec![token("my_var", 38, 1, 39)],
+                    assigned_variables: vec![token("nu_var", 18, 1, 19)],
+                },
+                attrs: vec![tag_attr(
+                    None,
+                    python_expr_value(
+                        token(r#"( [42, (nu_var := 'hello'), my_var] )"#, 10, 1, 11),
+                        token(r#"( [42, (nu_var := 'hello'), my_var] )"#, 10, 1, 11),
+                        None,
+                        vec![],
+                        vec![token("my_var", 38, 1, 39)],
+                        vec![token("nu_var", 18, 1, 19)],
+                    ),
+                    false
+                )],
+                is_self_closing: false,
+            })
+        );
+    }
+
+    #[test]
+    fn test_python_expr_as_multiple_args() {
+        let input = r#"{% my_tag ( [1, (nu_var := 'a'), var1] ) ( [2, 'b', var2] ) %}"#;
+        let (result, _context) = plain_parse_tag_v1(input).unwrap();
+        assert_eq!(
+            result,
+            Tag::Generic(GenericTag {
+                meta: TagMeta {
+                    token: token(
+                        r#"{% my_tag ( [1, (nu_var := 'a'), var1] ) ( [2, 'b', var2] ) %}"#,
+                        0,
+                        1,
+                        1
+                    ),
+                    name: token("my_tag", 3, 1, 4),
+                    used_variables: vec![token("var1", 33, 1, 34), token("var2", 52, 1, 53)],
+                    assigned_variables: vec![token("nu_var", 17, 1, 18)],
+                },
+                attrs: vec![
+                    tag_attr(
+                        None,
+                        python_expr_value(
+                            token(r#"( [1, (nu_var := 'a'), var1] )"#, 10, 1, 11),
+                            token(r#"( [1, (nu_var := 'a'), var1] )"#, 10, 1, 11),
+                            None,
+                            vec![],
+                            vec![token("var1", 33, 1, 34)],
+                            vec![token("nu_var", 17, 1, 18)],
+                        ),
+                        false
+                    ),
+                    tag_attr(
+                        None,
+                        python_expr_value(
+                            token(r#"( [2, 'b', var2] )"#, 41, 1, 42),
+                            token(r#"( [2, 'b', var2] )"#, 41, 1, 42),
+                            None,
+                            vec![],
+                            vec![token("var2", 52, 1, 53)],
+                            vec![],
+                        ),
+                        false
+                    ),
+                ],
+                is_self_closing: false,
+            })
+        );
+    }
+
+    #[test]
+    fn test_python_expr_as_arg_with_filter_without_arg() {
+        let input = r#"{% my_tag ( [42, (nu_var := 'hello'), my_var] )|length %}"#;
+        let (result, _context) = plain_parse_tag_v1(input).unwrap();
+        assert_eq!(
+            result,
+            Tag::Generic(GenericTag {
+                meta: TagMeta {
+                    token: token(
+                        r#"{% my_tag ( [42, (nu_var := 'hello'), my_var] )|length %}"#,
+                        0,
+                        1,
+                        1
+                    ),
+                    name: token("my_tag", 3, 1, 4),
+                    used_variables: vec![token("my_var", 38, 1, 39)],
+                    assigned_variables: vec![token("nu_var", 18, 1, 19)],
+                },
+                attrs: vec![tag_attr(
+                    None,
+                    python_expr_value(
+                        token(r#"( [42, (nu_var := 'hello'), my_var] )|length"#, 10, 1, 11),
+                        token(r#"( [42, (nu_var := 'hello'), my_var] )"#, 10, 1, 11),
+                        None,
+                        vec![TagValueFilter {
+                            token: token("|length", 47, 1, 48),
+                            name: token("length", 48, 1, 49),
+                            arg: None,
+                        }],
+                        vec![token("my_var", 38, 1, 39)],
+                        vec![token("nu_var", 18, 1, 19)],
+                    ),
+                    false
+                )],
+                is_self_closing: false,
+            })
+        );
+    }
+
+    #[test]
+    fn test_python_expr_as_arg_with_filter_with_arg() {
+        let input = r#"{% my_tag ( [42, (nu_var := 'hello'), my_var] )|first:( [(nu2_var := 2), x_var] ) %}"#;
+        let (result, _context) = plain_parse_tag_v1(input).unwrap();
+        assert_eq!(
+            result,
+            Tag::Generic(GenericTag {
+                meta: TagMeta {
+                    token: token(
+                        r#"{% my_tag ( [42, (nu_var := 'hello'), my_var] )|first:( [(nu2_var := 2), x_var] ) %}"#,
+                        0,
+                        1,
+                        1
+                    ),
+                    name: token("my_tag", 3, 1, 4),
+                    used_variables: vec![token("my_var", 38, 1, 39), token("x_var", 73, 1, 74)],
+                    assigned_variables: vec![
+                        token("nu_var", 18, 1, 19),
+                        token("nu2_var", 58, 1, 59)
+                    ],
+                },
+                attrs: vec![tag_attr(
+                    None,
+                    python_expr_value(
+                        token(
+                            r#"( [42, (nu_var := 'hello'), my_var] )|first:( [(nu2_var := 2), x_var] )"#,
+                            10,
+                            1,
+                            11
+                        ),
+                        token(r#"( [42, (nu_var := 'hello'), my_var] )"#, 10, 1, 11),
+                        None,
+                        vec![TagValueFilter {
+                            token: token("|first:( [(nu2_var := 2), x_var] )", 47, 1, 48),
+                            name: token("first", 48, 1, 49),
+                            arg: Some(python_expr_value(
+                                token(r#"( [(nu2_var := 2), x_var] )"#, 54, 1, 55),
+                                token(r#"( [(nu2_var := 2), x_var] )"#, 54, 1, 55),
+                                None,
+                                vec![],
+                                vec![token("x_var", 73, 1, 74)],
+                                vec![token("nu2_var", 58, 1, 59)],
+                            )),
+                        }],
+                        vec![token("my_var", 38, 1, 39)],
+                        vec![token("nu_var", 18, 1, 19)],
+                    ),
+                    false
+                )],
+                is_self_closing: false,
+            })
+        );
+    }
+
+    #[test]
+    fn test_python_expr_as_arg_with_spread() {
+        let input = r#"{% my_tag ...( [42, (nu_var := 'hello'), my_var] ) %}"#;
+        let (result, _context) = plain_parse_tag_v1(input).unwrap();
+        assert_eq!(
+            result,
+            Tag::Generic(GenericTag {
+                meta: TagMeta {
+                    token: token(
+                        r#"{% my_tag ...( [42, (nu_var := 'hello'), my_var] ) %}"#,
+                        0,
+                        1,
+                        1
+                    ),
+                    name: token("my_tag", 3, 1, 4),
+                    used_variables: vec![token("my_var", 41, 1, 42)],
+                    assigned_variables: vec![token("nu_var", 21, 1, 22)],
+                },
+                attrs: vec![tag_attr(
+                    None,
+                    python_expr_value(
+                        token(r#"...( [42, (nu_var := 'hello'), my_var] )"#, 10, 1, 11),
+                        token(r#"( [42, (nu_var := 'hello'), my_var] )"#, 13, 1, 14),
+                        Some("..."),
+                        vec![],
+                        vec![token("my_var", 41, 1, 42)],
+                        vec![token("nu_var", 21, 1, 22)],
+                    ),
+                    false
+                )],
+                is_self_closing: false,
+            })
+        );
+    }
+
+    #[test]
+    fn test_python_expr_as_kwarg() {
+        let input = r#"{% my_tag key=( [42, (nu_var := 'hello'), my_var] ) %}"#;
+        let (result, _context) = plain_parse_tag_v1(input).unwrap();
+        assert_eq!(
+            result,
+            Tag::Generic(GenericTag {
+                meta: TagMeta {
+                    token: token(
+                        r#"{% my_tag key=( [42, (nu_var := 'hello'), my_var] ) %}"#,
+                        0,
+                        1,
+                        1
+                    ),
+                    name: token("my_tag", 3, 1, 4),
+                    used_variables: vec![token("my_var", 42, 1, 43)],
+                    assigned_variables: vec![token("nu_var", 22, 1, 23)],
+                },
+                attrs: vec![tag_attr(
+                    Some(token("key", 10, 1, 11)),
+                    python_expr_value(
+                        token(r#"( [42, (nu_var := 'hello'), my_var] )"#, 14, 1, 15),
+                        token(r#"( [42, (nu_var := 'hello'), my_var] )"#, 14, 1, 15),
+                        None,
+                        vec![],
+                        vec![token("my_var", 42, 1, 43)],
+                        vec![token("nu_var", 22, 1, 23)],
+                    ),
+                    false
+                )],
+                is_self_closing: false,
+            })
+        );
+    }
+
+    #[test]
+    fn test_python_expr_as_multiple_kwargs() {
+        let input = r#"{% my_tag key1=( [1, (nu_var := 'a'), var1] ) key2=( [2, 'b', var2] ) %}"#;
+        let (result, _context) = plain_parse_tag_v1(input).unwrap();
+        assert_eq!(
+            result,
+            Tag::Generic(GenericTag {
+                meta: TagMeta {
+                    token: token(
+                        r#"{% my_tag key1=( [1, (nu_var := 'a'), var1] ) key2=( [2, 'b', var2] ) %}"#,
+                        0,
+                        1,
+                        1
+                    ),
+                    name: token("my_tag", 3, 1, 4),
+                    used_variables: vec![token("var1", 38, 1, 39), token("var2", 62, 1, 63)],
+                    assigned_variables: vec![token("nu_var", 22, 1, 23)],
+                },
+                attrs: vec![
+                    tag_attr(
+                        Some(token("key1", 10, 1, 11)),
+                        python_expr_value(
+                            token(r#"( [1, (nu_var := 'a'), var1] )"#, 15, 1, 16),
+                            token(r#"( [1, (nu_var := 'a'), var1] )"#, 15, 1, 16),
+                            None,
+                            vec![],
+                            vec![token("var1", 38, 1, 39)],
+                            vec![token("nu_var", 22, 1, 23)],
+                        ),
+                        false
+                    ),
+                    tag_attr(
+                        Some(token("key2", 46, 1, 47)),
+                        python_expr_value(
+                            token(r#"( [2, 'b', var2] )"#, 51, 1, 52),
+                            token(r#"( [2, 'b', var2] )"#, 51, 1, 52),
+                            None,
+                            vec![],
+                            vec![token("var2", 62, 1, 63)],
+                            vec![],
+                        ),
+                        false
+                    ),
+                ],
+                is_self_closing: false,
+            })
+        );
+    }
+
+    #[test]
+    fn test_python_expr_as_kwarg_with_filter_without_arg() {
+        let input = r#"{% my_tag key=( [42, (nu_var := 'hello'), my_var] )|length %}"#;
+        let (result, _context) = plain_parse_tag_v1(input).unwrap();
+        assert_eq!(
+            result,
+            Tag::Generic(GenericTag {
+                meta: TagMeta {
+                    token: token(
+                        r#"{% my_tag key=( [42, (nu_var := 'hello'), my_var] )|length %}"#,
+                        0,
+                        1,
+                        1
+                    ),
+                    name: token("my_tag", 3, 1, 4),
+                    used_variables: vec![token("my_var", 42, 1, 43)],
+                    assigned_variables: vec![token("nu_var", 22, 1, 23)],
+                },
+                attrs: vec![tag_attr(
+                    Some(token("key", 10, 1, 11)),
+                    python_expr_value(
+                        token(r#"( [42, (nu_var := 'hello'), my_var] )|length"#, 14, 1, 15),
+                        token(r#"( [42, (nu_var := 'hello'), my_var] )"#, 14, 1, 15),
+                        None,
+                        vec![TagValueFilter {
+                            token: token("|length", 51, 1, 52),
+                            name: token("length", 52, 1, 53),
+                            arg: None,
+                        }],
+                        vec![token("my_var", 42, 1, 43)],
+                        vec![token("nu_var", 22, 1, 23)],
+                    ),
+                    false
+                )],
+                is_self_closing: false,
+            })
+        );
+    }
+
+    #[test]
+    fn test_python_expr_as_kwarg_with_filter_with_arg() {
+        let input = r#"{% my_tag key=( [42, (nu_var := 'hello'), my_var] )|first:( [(nu2_var := 2), x_var] ) %}"#;
+        let (result, _context) = plain_parse_tag_v1(input).unwrap();
+        assert_eq!(
+            result,
+            Tag::Generic(GenericTag {
+                meta: TagMeta {
+                    token: token(
+                        r#"{% my_tag key=( [42, (nu_var := 'hello'), my_var] )|first:( [(nu2_var := 2), x_var] ) %}"#,
+                        0,
+                        1,
+                        1
+                    ),
+                    name: token("my_tag", 3, 1, 4),
+                    used_variables: vec![token("my_var", 42, 1, 43), token("x_var", 77, 1, 78)],
+                    assigned_variables: vec![
+                        token("nu_var", 22, 1, 23),
+                        token("nu2_var", 62, 1, 63)
+                    ],
+                },
+                attrs: vec![tag_attr(
+                    Some(token("key", 10, 1, 11)),
+                    python_expr_value(
+                        token(
+                            r#"( [42, (nu_var := 'hello'), my_var] )|first:( [(nu2_var := 2), x_var] )"#,
+                            14,
+                            1,
+                            15
+                        ),
+                        token(r#"( [42, (nu_var := 'hello'), my_var] )"#, 14, 1, 15),
+                        None,
+                        vec![TagValueFilter {
+                            token: token("|first:( [(nu2_var := 2), x_var] )", 51, 1, 52),
+                            name: token("first", 52, 1, 53),
+                            arg: Some(python_expr_value(
+                                token(r#"( [(nu2_var := 2), x_var] )"#, 58, 1, 59),
+                                token(r#"( [(nu2_var := 2), x_var] )"#, 58, 1, 59),
+                                None,
+                                vec![],
+                                vec![token("x_var", 77, 1, 78)],
+                                vec![token("nu2_var", 62, 1, 63)],
+                            )),
+                        }],
+                        vec![token("my_var", 42, 1, 43)],
+                        vec![token("nu_var", 22, 1, 23)],
+                    ),
+                    false
+                )],
+                is_self_closing: false,
+            })
+        );
+    }
+
+    #[test]
+    fn test_python_expr_as_both_arg_and_kwarg_with_filters() {
+        let input = r#"{% my_tag ( [42, (nu_var := 'hello'), my_var] )|length key=( [1, (nu_var := 'a'), var1] )|first:( [(nu2_var := 2), x_var] ) %}"#;
+        let (result, _context) = plain_parse_tag_v1(input).unwrap();
+        assert_eq!(
+            result,
+            Tag::Generic(GenericTag {
+                meta: TagMeta {
+                    token: token(
+                        r#"{% my_tag ( [42, (nu_var := 'hello'), my_var] )|length key=( [1, (nu_var := 'a'), var1] )|first:( [(nu2_var := 2), x_var] ) %}"#,
+                        0,
+                        1,
+                        1
+                    ),
+                    name: token("my_tag", 3, 1, 4),
+                    used_variables: vec![
+                        token("my_var", 38, 1, 39),
+                        token("var1", 82, 1, 83),
+                        token("x_var", 115, 1, 116)
+                    ],
+                    assigned_variables: vec![
+                        token("nu_var", 18, 1, 19),
+                        token("nu_var", 66, 1, 67),
+                        token("nu2_var", 100, 1, 101)
+                    ],
+                },
+                attrs: vec![
+                    tag_attr(
+                        None,
+                        python_expr_value(
+                            token(r#"( [42, (nu_var := 'hello'), my_var] )|length"#, 10, 1, 11),
+                            token(r#"( [42, (nu_var := 'hello'), my_var] )"#, 10, 1, 11),
+                            None,
+                            vec![TagValueFilter {
+                                token: token("|length", 47, 1, 48),
+                                name: token("length", 48, 1, 49),
+                                arg: None,
+                            }],
+                            vec![token("my_var", 38, 1, 39)],
+                            vec![token("nu_var", 18, 1, 19)],
+                        ),
+                        false
+                    ),
+                    tag_attr(
+                        Some(token("key", 55, 1, 56)),
+                        python_expr_value(
+                            token(
+                                r#"( [1, (nu_var := 'a'), var1] )|first:( [(nu2_var := 2), x_var] )"#,
+                                59,
+                                1,
+                                60
+                            ),
+                            token(r#"( [1, (nu_var := 'a'), var1] )"#, 59, 1, 60),
+                            None,
+                            vec![TagValueFilter {
+                                token: token("|first:( [(nu2_var := 2), x_var] )", 89, 1, 90),
+                                name: token("first", 90, 1, 91),
+                                arg: Some(python_expr_value(
+                                    token(r#"( [(nu2_var := 2), x_var] )"#, 96, 1, 97),
+                                    token(r#"( [(nu2_var := 2), x_var] )"#, 96, 1, 97),
+                                    None,
+                                    vec![],
+                                    vec![token("x_var", 115, 1, 116)],
+                                    vec![token("nu2_var", 100, 1, 101)],
+                                )),
+                            }],
+                            vec![token("var1", 82, 1, 83)],
+                            vec![token("nu_var", 66, 1, 67)],
+                        ),
+                        false
+                    ),
+                ],
+                is_self_closing: false,
+            })
+        );
+    }
+
+    #[test]
+    fn test_python_expr_as_both_arg_and_kwarg_with_filters_and_spread() {
+        let input = r#"{% my_tag ...( [42, (nu_var := 'hello'), my_var] )|length key=( [1, (nu_var := 'a'), var1] )|first:( [(nu2_var := 2), x_var] ) %}"#;
+        let (result, _context) = plain_parse_tag_v1(input).unwrap();
+        assert_eq!(
+            result,
+            Tag::Generic(GenericTag {
+                meta: TagMeta {
+                    token: token(
+                        r#"{% my_tag ...( [42, (nu_var := 'hello'), my_var] )|length key=( [1, (nu_var := 'a'), var1] )|first:( [(nu2_var := 2), x_var] ) %}"#,
+                        0,
+                        1,
+                        1
+                    ),
+                    name: token("my_tag", 3, 1, 4),
+                    used_variables: vec![
+                        token("my_var", 41, 1, 42),
+                        token("var1", 85, 1, 86),
+                        token("x_var", 118, 1, 119)
+                    ],
+                    assigned_variables: vec![
+                        token("nu_var", 21, 1, 22),
+                        token("nu_var", 69, 1, 70),
+                        token("nu2_var", 103, 1, 104)
+                    ],
+                },
+                attrs: vec![
+                    tag_attr(
+                        None,
+                        python_expr_value(
+                            token(
+                                r#"...( [42, (nu_var := 'hello'), my_var] )|length"#,
+                                10,
+                                1,
+                                11
+                            ),
+                            token(r#"( [42, (nu_var := 'hello'), my_var] )"#, 13, 1, 14),
+                            Some("..."),
+                            vec![TagValueFilter {
+                                token: token("|length", 50, 1, 51),
+                                name: token("length", 51, 1, 52),
+                                arg: None,
+                            }],
+                            vec![token("my_var", 41, 1, 42)],
+                            vec![token("nu_var", 21, 1, 22)],
+                        ),
+                        false
+                    ),
+                    tag_attr(
+                        Some(token("key", 58, 1, 59)),
+                        python_expr_value(
+                            token(
+                                r#"( [1, (nu_var := 'a'), var1] )|first:( [(nu2_var := 2), x_var] )"#,
+                                62,
+                                1,
+                                63
+                            ),
+                            token(r#"( [1, (nu_var := 'a'), var1] )"#, 62, 1, 63),
+                            None,
+                            vec![TagValueFilter {
+                                token: token("|first:( [(nu2_var := 2), x_var] )", 92, 1, 93),
+                                name: token("first", 93, 1, 94),
+                                arg: Some(python_expr_value(
+                                    token(r#"( [(nu2_var := 2), x_var] )"#, 99, 1, 100),
+                                    token(r#"( [(nu2_var := 2), x_var] )"#, 99, 1, 100),
+                                    None,
+                                    vec![],
+                                    vec![token("x_var", 118, 1, 119)],
+                                    vec![token("nu2_var", 103, 1, 104)],
+                                )),
+                            }],
+                            vec![token("var1", 85, 1, 86)],
+                            vec![token("nu_var", 69, 1, 70)],
+                        ),
+                        false
+                    ),
+                ],
+                is_self_closing: false,
+            })
+        );
+    }
+
+    #[test]
+    fn test_python_expr_inside_list() {
+        let input = r#"{% my_tag [( [42, (nu_var := 'hello'), my_var] )] %}"#;
+        let (result, _context) = plain_parse_tag_v1(input).unwrap();
+        let list_value = TagValue {
+            token: token(r#"[( [42, (nu_var := 'hello'), my_var] )]"#, 10, 1, 11),
+            value: token(r#"[( [42, (nu_var := 'hello'), my_var] )]"#, 10, 1, 11),
+            children: vec![ValueChild::Value(python_expr_value(
+                token(r#"( [42, (nu_var := 'hello'), my_var] )"#, 11, 1, 12),
+                token(r#"( [42, (nu_var := 'hello'), my_var] )"#, 11, 1, 12),
+                None,
+                vec![],
+                vec![token("my_var", 39, 1, 40)],
+                vec![token("nu_var", 19, 1, 20)],
+            ))],
+            kind: ValueKind::List,
+            spread: None,
+            filters: vec![],
+            used_variables: vec![],
+            assigned_variables: vec![],
+        };
+        assert_eq!(
+            result,
+            Tag::Generic(GenericTag {
+                meta: TagMeta {
+                    token: token(
+                        r#"{% my_tag [( [42, (nu_var := 'hello'), my_var] )] %}"#,
+                        0,
+                        1,
+                        1
+                    ),
+                    name: token("my_tag", 3, 1, 4),
+                    used_variables: vec![token("my_var", 39, 1, 40)],
+                    assigned_variables: vec![token("nu_var", 19, 1, 20)],
+                },
+                attrs: vec![tag_attr(None, list_value, false)],
+                is_self_closing: false,
+            })
+        );
+    }
+
+    #[test]
+    fn test_python_expr_inside_list_with_filter_without_arg() {
+        let input = r#"{% my_tag [( [42, (nu_var := 'hello'), my_var] )|length] %}"#;
+        let (result, _context) = plain_parse_tag_v1(input).unwrap();
+        let list_value = TagValue {
+            token: token(
+                r#"[( [42, (nu_var := 'hello'), my_var] )|length]"#,
+                10,
+                1,
+                11,
+            ),
+            value: token(
+                r#"[( [42, (nu_var := 'hello'), my_var] )|length]"#,
+                10,
+                1,
+                11,
+            ),
+            children: vec![ValueChild::Value(python_expr_value(
+                token(r#"( [42, (nu_var := 'hello'), my_var] )|length"#, 11, 1, 12),
+                token(r#"( [42, (nu_var := 'hello'), my_var] )"#, 11, 1, 12),
+                None,
+                vec![TagValueFilter {
+                    token: token("|length", 48, 1, 49),
+                    name: token("length", 49, 1, 50),
+                    arg: None,
+                }],
+                vec![token("my_var", 39, 1, 40)],
+                vec![token("nu_var", 19, 1, 20)],
+            ))],
+            kind: ValueKind::List,
+            spread: None,
+            filters: vec![],
+            used_variables: vec![],
+            assigned_variables: vec![],
+        };
+        assert_eq!(
+            result,
+            Tag::Generic(GenericTag {
+                meta: TagMeta {
+                    token: token(
+                        r#"{% my_tag [( [42, (nu_var := 'hello'), my_var] )|length] %}"#,
+                        0,
+                        1,
+                        1
+                    ),
+                    name: token("my_tag", 3, 1, 4),
+                    used_variables: vec![token("my_var", 39, 1, 40)],
+                    assigned_variables: vec![token("nu_var", 19, 1, 20)],
+                },
+                attrs: vec![tag_attr(None, list_value, false)],
+                is_self_closing: false,
+            })
+        );
+    }
+
+    #[test]
+    fn test_python_expr_inside_list_with_filter_with_arg() {
+        let input = r#"{% my_tag [( [42, (nu_var := 'hello'), my_var] )|first:( [(nu2_var := 2), x_var] )] %}"#;
+        let (result, _context) = plain_parse_tag_v1(input).unwrap();
+        let list_value = TagValue {
+            token: token(
+                r#"[( [42, (nu_var := 'hello'), my_var] )|first:( [(nu2_var := 2), x_var] )]"#,
+                10,
+                1,
+                11,
+            ),
+            value: token(
+                r#"[( [42, (nu_var := 'hello'), my_var] )|first:( [(nu2_var := 2), x_var] )]"#,
+                10,
+                1,
+                11,
+            ),
+            children: vec![ValueChild::Value(python_expr_value(
+                token(
+                    r#"( [42, (nu_var := 'hello'), my_var] )|first:( [(nu2_var := 2), x_var] )"#,
+                    11,
+                    1,
+                    12,
+                ),
+                token(r#"( [42, (nu_var := 'hello'), my_var] )"#, 11, 1, 12),
+                None,
+                vec![TagValueFilter {
+                    token: token("|first:( [(nu2_var := 2), x_var] )", 48, 1, 49),
+                    name: token("first", 49, 1, 50),
+
+                    arg: Some(python_expr_value(
+                        token(r#"( [(nu2_var := 2), x_var] )"#, 55, 1, 56),
+                        token(r#"( [(nu2_var := 2), x_var] )"#, 55, 1, 56),
+                        None,
+                        vec![],
+                        vec![token("x_var", 74, 1, 75)],
+                        vec![token("nu2_var", 59, 1, 60)],
+                    )),
+                }],
+                vec![token("my_var", 39, 1, 40)],
+                vec![token("nu_var", 19, 1, 20)],
+            ))],
+            kind: ValueKind::List,
+            spread: None,
+            filters: vec![],
+            used_variables: vec![],
+            assigned_variables: vec![],
+        };
+        assert_eq!(
+            result,
+            Tag::Generic(GenericTag {
+                meta: TagMeta {
+                    token: token(
+                        r#"{% my_tag [( [42, (nu_var := 'hello'), my_var] )|first:( [(nu2_var := 2), x_var] )] %}"#,
+                        0,
+                        1,
+                        1
+                    ),
+                    name: token("my_tag", 3, 1, 4),
+                    used_variables: vec![token("my_var", 39, 1, 40), token("x_var", 74, 1, 75)],
+                    assigned_variables: vec![
+                        token("nu_var", 19, 1, 20),
+                        token("nu2_var", 59, 1, 60)
+                    ],
+                },
+                attrs: vec![tag_attr(None, list_value, false)],
+                is_self_closing: false,
+            })
+        );
+    }
+
+    #[test]
+    fn test_python_expr_inside_list_with_filter_with_arg_and_spread() {
+        let input = r#"{% my_tag [*( [42, (nu_var := 'hello'), my_var] )|first:( [(nu2_var := 2), x_var] )] %}"#;
+        let (result, _context) = plain_parse_tag_v1(input).unwrap();
+        let list_value = TagValue {
+            token: token(
+                r#"[*( [42, (nu_var := 'hello'), my_var] )|first:( [(nu2_var := 2), x_var] )]"#,
+                10,
+                1,
+                11,
+            ),
+            value: token(
+                r#"[*( [42, (nu_var := 'hello'), my_var] )|first:( [(nu2_var := 2), x_var] )]"#,
+                10,
+                1,
+                11,
+            ),
+            children: vec![ValueChild::Value(python_expr_value(
+                token(
+                    r#"*( [42, (nu_var := 'hello'), my_var] )|first:( [(nu2_var := 2), x_var] )"#,
+                    11,
+                    1,
+                    12,
+                ),
+                token(r#"( [42, (nu_var := 'hello'), my_var] )"#, 12, 1, 13),
+                Some("*"),
+                vec![TagValueFilter {
+                    token: token("|first:( [(nu2_var := 2), x_var] )", 49, 1, 50),
+                    name: token("first", 50, 1, 51),
+                    arg: Some(python_expr_value(
+                        token(r#"( [(nu2_var := 2), x_var] )"#, 56, 1, 57),
+                        token(r#"( [(nu2_var := 2), x_var] )"#, 56, 1, 57),
+                        None,
+                        vec![],
+                        vec![token("x_var", 75, 1, 76)],
+                        vec![token("nu2_var", 60, 1, 61)],
+                    )),
+                }],
+                vec![token("my_var", 40, 1, 41)],
+                vec![token("nu_var", 20, 1, 21)],
+            ))],
+            kind: ValueKind::List,
+            spread: None,
+            filters: vec![],
+            used_variables: vec![],
+            assigned_variables: vec![],
+        };
+        assert_eq!(
+            result,
+            Tag::Generic(GenericTag {
+                meta: TagMeta {
+                    token: token(
+                        r#"{% my_tag [*( [42, (nu_var := 'hello'), my_var] )|first:( [(nu2_var := 2), x_var] )] %}"#,
+                        0,
+                        1,
+                        1
+                    ),
+                    name: token("my_tag", 3, 1, 4),
+                    used_variables: vec![token("my_var", 40, 1, 41), token("x_var", 75, 1, 76)],
+                    assigned_variables: vec![
+                        token("nu_var", 20, 1, 21),
+                        token("nu2_var", 60, 1, 61)
+                    ],
+                },
+                attrs: vec![tag_attr(None, list_value, false)],
+                is_self_closing: false,
+            })
+        );
+    }
+
+    #[test]
+    fn test_python_expr_inside_list_with_spread() {
+        let input = r#"{% my_tag [*( [42, (nu_var := 'hello'), my_var] )] %}"#;
+        let (result, _context) = plain_parse_tag_v1(input).unwrap();
+        let list_value = TagValue {
+            token: token(r#"[*( [42, (nu_var := 'hello'), my_var] )]"#, 10, 1, 11),
+            value: token(r#"[*( [42, (nu_var := 'hello'), my_var] )]"#, 10, 1, 11),
+            children: vec![ValueChild::Value(python_expr_value(
+                token(r#"*( [42, (nu_var := 'hello'), my_var] )"#, 11, 1, 12),
+                token(r#"( [42, (nu_var := 'hello'), my_var] )"#, 12, 1, 13),
+                Some("*"),
+                vec![],
+                vec![token("my_var", 40, 1, 41)],
+                vec![token("nu_var", 20, 1, 21)],
+            ))],
+            kind: ValueKind::List,
+            spread: None,
+            filters: vec![],
+            used_variables: vec![],
+            assigned_variables: vec![],
+        };
+        assert_eq!(
+            result,
+            Tag::Generic(GenericTag {
+                meta: TagMeta {
+                    token: token(
+                        r#"{% my_tag [*( [42, (nu_var := 'hello'), my_var] )] %}"#,
+                        0,
+                        1,
+                        1
+                    ),
+                    name: token("my_tag", 3, 1, 4),
+                    used_variables: vec![token("my_var", 40, 1, 41)],
+                    assigned_variables: vec![token("nu_var", 20, 1, 21)],
+                },
+                attrs: vec![tag_attr(None, list_value, false)],
+                is_self_closing: false,
+            })
+        );
+    }
+
+    #[test]
+    fn test_python_expr_inside_dict_as_value() {
+        let input = r#"{% my_tag {key: ( [42, (nu_var := 'hello'), my_var] )} %}"#;
+        let (result, _context) = plain_parse_tag_v1(input).unwrap();
+        let dict_value = TagValue {
+            token: token(r#"{key: ( [42, (nu_var := 'hello'), my_var] )}"#, 10, 1, 11),
+            value: token(r#"{key: ( [42, (nu_var := 'hello'), my_var] )}"#, 10, 1, 11),
+            children: vec![
+                ValueChild::Value(plain_variable_value("key", 11, 1, 12, None)),
+                ValueChild::Value(python_expr_value(
+                    token(r#"( [42, (nu_var := 'hello'), my_var] )"#, 16, 1, 17),
+                    token(r#"( [42, (nu_var := 'hello'), my_var] )"#, 16, 1, 17),
+                    None,
+                    vec![],
+                    vec![token("my_var", 44, 1, 45)],
+                    vec![token("nu_var", 24, 1, 25)],
+                )),
+            ],
+            kind: ValueKind::Dict,
+            spread: None,
+            filters: vec![],
+            used_variables: vec![],
+            assigned_variables: vec![],
+        };
+        assert_eq!(
+            result,
+            Tag::Generic(GenericTag {
+                meta: TagMeta {
+                    token: token(
+                        r#"{% my_tag {key: ( [42, (nu_var := 'hello'), my_var] )} %}"#,
+                        0,
+                        1,
+                        1
+                    ),
+                    name: token("my_tag", 3, 1, 4),
+                    used_variables: vec![token("key", 11, 1, 12), token("my_var", 44, 1, 45)],
+                    assigned_variables: vec![token("nu_var", 24, 1, 25)],
+                },
+                attrs: vec![tag_attr(None, dict_value, false)],
+                is_self_closing: false,
+            })
+        );
+    }
+
+    #[test]
+    fn test_python_expr_inside_dict_as_value_with_filter_with_arg() {
+        let input = r#"{% my_tag {key: ( [42, (nu_var := 'hello'), my_var] )|first:( [(nu2_var := 2), x_var] )} %}"#;
+        let (result, _context) = plain_parse_tag_v1(input).unwrap();
+        let dict_value = TagValue {
+            token: token(
+                r#"{key: ( [42, (nu_var := 'hello'), my_var] )|first:( [(nu2_var := 2), x_var] )}"#,
+                10,
+                1,
+                11,
+            ),
+            value: token(
+                r#"{key: ( [42, (nu_var := 'hello'), my_var] )|first:( [(nu2_var := 2), x_var] )}"#,
+                10,
+                1,
+                11,
+            ),
+            children: vec![
+                ValueChild::Value(plain_variable_value("key", 11, 1, 12, None)),
+                ValueChild::Value(python_expr_value(
+                    token(
+                        r#"( [42, (nu_var := 'hello'), my_var] )|first:( [(nu2_var := 2), x_var] )"#,
+                        16,
+                        1,
+                        17,
+                    ),
+                    token(r#"( [42, (nu_var := 'hello'), my_var] )"#, 16, 1, 17),
+                    None,
+                    vec![TagValueFilter {
+                        token: token("|first:( [(nu2_var := 2), x_var] )", 53, 1, 54),
+                        name: token("first", 54, 1, 55),
+                        arg: Some(python_expr_value(
+                            token(r#"( [(nu2_var := 2), x_var] )"#, 60, 1, 61),
+                            token(r#"( [(nu2_var := 2), x_var] )"#, 60, 1, 61),
+                            None,
+                            vec![],
+                            vec![token("x_var", 79, 1, 80)],
+                            vec![token("nu2_var", 64, 1, 65)],
+                        )),
+                    }],
+                    vec![token("my_var", 44, 1, 45)],
+                    vec![token("nu_var", 24, 1, 25)],
+                )),
+            ],
+            kind: ValueKind::Dict,
+            spread: None,
+            filters: vec![],
+            used_variables: vec![],
+            assigned_variables: vec![],
+        };
+        assert_eq!(
+            result,
+            Tag::Generic(GenericTag {
+                meta: TagMeta {
+                    token: token(
+                        r#"{% my_tag {key: ( [42, (nu_var := 'hello'), my_var] )|first:( [(nu2_var := 2), x_var] )} %}"#,
+                        0,
+                        1,
+                        1
+                    ),
+                    name: token("my_tag", 3, 1, 4),
+                    used_variables: vec![
+                        token("key", 11, 1, 12),
+                        token("my_var", 44, 1, 45),
+                        token("x_var", 79, 1, 80)
+                    ],
+                    assigned_variables: vec![
+                        token("nu_var", 24, 1, 25),
+                        token("nu2_var", 64, 1, 65)
+                    ],
+                },
+                attrs: vec![tag_attr(None, dict_value, false)],
+                is_self_closing: false,
+            })
+        );
+    }
+
+    #[test]
+    fn test_python_expr_inside_dict_as_key_and_value() {
+        let input = r#"{% my_tag {( [1, (nu_var := 'a'), var1] ): ( [42, (nu_var := 'hello'), my_var] )} %}"#;
+        let (result, _context) = plain_parse_tag_v1(input).unwrap();
+        let dict_value = TagValue {
+            token: token(
+                r#"{( [1, (nu_var := 'a'), var1] ): ( [42, (nu_var := 'hello'), my_var] )}"#,
+                10,
+                1,
+                11,
+            ),
+            value: token(
+                r#"{( [1, (nu_var := 'a'), var1] ): ( [42, (nu_var := 'hello'), my_var] )}"#,
+                10,
+                1,
+                11,
+            ),
+            children: vec![
+                ValueChild::Value(python_expr_value(
+                    token(r#"( [1, (nu_var := 'a'), var1] )"#, 11, 1, 12),
+                    token(r#"( [1, (nu_var := 'a'), var1] )"#, 11, 1, 12),
+                    None,
+                    vec![],
+                    vec![token("var1", 34, 1, 35)],
+                    vec![token("nu_var", 18, 1, 19)],
+                )),
+                ValueChild::Value(python_expr_value(
+                    token(r#"( [42, (nu_var := 'hello'), my_var] )"#, 43, 1, 44),
+                    token(r#"( [42, (nu_var := 'hello'), my_var] )"#, 43, 1, 44),
+                    None,
+                    vec![],
+                    vec![token("my_var", 71, 1, 72)],
+                    vec![token("nu_var", 51, 1, 52)],
+                )),
+            ],
+            kind: ValueKind::Dict,
+            spread: None,
+            filters: vec![],
+            used_variables: vec![],
+            assigned_variables: vec![],
+        };
+        assert_eq!(
+            result,
+            Tag::Generic(GenericTag {
+                meta: TagMeta {
+                    token: token(
+                        r#"{% my_tag {( [1, (nu_var := 'a'), var1] ): ( [42, (nu_var := 'hello'), my_var] )} %}"#,
+                        0,
+                        1,
+                        1
+                    ),
+                    name: token("my_tag", 3, 1, 4),
+                    used_variables: vec![token("var1", 34, 1, 35), token("my_var", 71, 1, 72)],
+                    assigned_variables: vec![
+                        token("nu_var", 18, 1, 19),
+                        token("nu_var", 51, 1, 52)
+                    ],
+                },
+                attrs: vec![tag_attr(None, dict_value, false)],
+                is_self_closing: false,
+            })
+        );
+    }
+
+    #[test]
+    fn test_python_expr_inside_dict_as_key_and_value_with_filters_and_arg() {
+        let input = r#"{% my_tag {( [1, (nu_var := 'a'), var1] )|length: ( [42, (nu_var := 'hello'), my_var] )|first:( [(nu2_var := 2), x_var] )} %}"#;
+        let (result, _context) = plain_parse_tag_v1(input).unwrap();
+        let dict_value = TagValue {
+            token: token(
+                r#"{( [1, (nu_var := 'a'), var1] )|length: ( [42, (nu_var := 'hello'), my_var] )|first:( [(nu2_var := 2), x_var] )}"#,
+                10,
+                1,
+                11,
+            ),
+            value: token(
+                r#"{( [1, (nu_var := 'a'), var1] )|length: ( [42, (nu_var := 'hello'), my_var] )|first:( [(nu2_var := 2), x_var] )}"#,
+                10,
+                1,
+                11,
+            ),
+            children: vec![
+                ValueChild::Value(python_expr_value(
+                    token(r#"( [1, (nu_var := 'a'), var1] )|length"#, 11, 1, 12),
+                    token(r#"( [1, (nu_var := 'a'), var1] )"#, 11, 1, 12),
+                    None,
+                    vec![TagValueFilter {
+                        token: token("|length", 41, 1, 42),
+                        name: token("length", 42, 1, 43),
+                        arg: None,
+                    }],
+                    vec![token("var1", 34, 1, 35)],
+                    vec![token("nu_var", 18, 1, 19)],
+                )),
+                ValueChild::Value(python_expr_value(
+                    token(
+                        r#"( [42, (nu_var := 'hello'), my_var] )|first:( [(nu2_var := 2), x_var] )"#,
+                        50,
+                        1,
+                        51,
+                    ),
+                    token(r#"( [42, (nu_var := 'hello'), my_var] )"#, 50, 1, 51),
+                    None,
+                    vec![TagValueFilter {
+                        token: token("|first:( [(nu2_var := 2), x_var] )", 87, 1, 88),
+                        name: token("first", 88, 1, 89),
+                        arg: Some(python_expr_value(
+                            token(r#"( [(nu2_var := 2), x_var] )"#, 94, 1, 95),
+                            token(r#"( [(nu2_var := 2), x_var] )"#, 94, 1, 95),
+                            None,
+                            vec![],
+                            vec![token("x_var", 113, 1, 114)],
+                            vec![token("nu2_var", 98, 1, 99)],
+                        )),
+                    }],
+                    vec![token("my_var", 78, 1, 79)],
+                    vec![token("nu_var", 58, 1, 59)],
+                )),
+            ],
+            kind: ValueKind::Dict,
+            spread: None,
+            filters: vec![],
+            used_variables: vec![],
+            assigned_variables: vec![],
+        };
+        assert_eq!(
+            result,
+            Tag::Generic(GenericTag {
+                meta: TagMeta {
+                    token: token(
+                        r#"{% my_tag {( [1, (nu_var := 'a'), var1] )|length: ( [42, (nu_var := 'hello'), my_var] )|first:( [(nu2_var := 2), x_var] )} %}"#,
+                        0,
+                        1,
+                        1
+                    ),
+                    name: token("my_tag", 3, 1, 4),
+                    used_variables: vec![
+                        token("var1", 34, 1, 35),
+                        token("my_var", 78, 1, 79),
+                        token("x_var", 113, 1, 114)
+                    ],
+                    assigned_variables: vec![
+                        token("nu_var", 18, 1, 19),
+                        token("nu_var", 58, 1, 59),
+                        token("nu2_var", 98, 1, 99)
+                    ],
+                },
+                attrs: vec![tag_attr(None, dict_value, false)],
+                is_self_closing: false,
+            })
+        );
+    }
+
+    #[test]
+    fn test_python_expr_inside_dict_with_spread_and_filter() {
+        let input = r#"{% my_tag {**( [42, (nu_var := 'hello'), my_var] )|length} %}"#;
+        let (result, _context) = plain_parse_tag_v1(input).unwrap();
+        let dict_value = TagValue {
+            token: token(
+                r#"{**( [42, (nu_var := 'hello'), my_var] )|length}"#,
+                10,
+                1,
+                11,
+            ),
+            value: token(
+                r#"{**( [42, (nu_var := 'hello'), my_var] )|length}"#,
+                10,
+                1,
+                11,
+            ),
+            children: vec![ValueChild::Value(python_expr_value(
+                token(
+                    r#"**( [42, (nu_var := 'hello'), my_var] )|length"#,
+                    11,
+                    1,
+                    12,
+                ),
+                token(r#"( [42, (nu_var := 'hello'), my_var] )"#, 13, 1, 14),
+                Some("**"),
+                vec![TagValueFilter {
+                    token: token("|length", 50, 1, 51),
+                    name: token("length", 51, 1, 52),
+                    arg: None,
+                }],
+                vec![token("my_var", 41, 1, 42)],
+                vec![token("nu_var", 21, 1, 22)],
+            ))],
+            kind: ValueKind::Dict,
+            spread: None,
+            filters: vec![],
+            used_variables: vec![],
+            assigned_variables: vec![],
+        };
+        assert_eq!(
+            result,
+            Tag::Generic(GenericTag {
+                meta: TagMeta {
+                    token: token(
+                        r#"{% my_tag {**( [42, (nu_var := 'hello'), my_var] )|length} %}"#,
+                        0,
+                        1,
+                        1
+                    ),
+                    name: token("my_tag", 3, 1, 4),
+                    used_variables: vec![token("my_var", 41, 1, 42)],
+                    assigned_variables: vec![token("nu_var", 21, 1, 22)],
+                },
+                attrs: vec![tag_attr(None, dict_value, false)],
+                is_self_closing: false,
+            })
+        );
+    }
+
+    // #######################################
+    // PYTHON EXPRESSIONS EDGE CASES
+    // #######################################
+
+    #[test]
+    fn test_python_expr_conditional_expression() {
+        let input = r#"{% my_tag ("YES" if condition else "NO") %}"#;
+        let (result, _context) = plain_parse_tag_v1(input).unwrap();
+        assert_eq!(
+            result,
+            Tag::Generic(GenericTag {
+                meta: TagMeta {
+                    token: token(r#"{% my_tag ("YES" if condition else "NO") %}"#, 0, 1, 1),
+                    name: token("my_tag", 3, 1, 4),
+                    used_variables: vec![token("condition", 20, 1, 21)],
+                    assigned_variables: vec![],
+                },
+                attrs: vec![tag_attr(
+                    None,
+                    python_expr_value(
+                        token(r#"("YES" if condition else "NO")"#, 10, 1, 11),
+                        token(r#"("YES" if condition else "NO")"#, 10, 1, 11),
+                        None,
+                        vec![],
+                        vec![token("condition", 20, 1, 21)],
+                        vec![],
+                    ),
+                    false
+                )],
+                is_self_closing: false,
+            })
+        );
+    }
+
+    #[test]
+    fn test_python_expr_complex_expression() {
+        let input = r#"{% my_tag (my_item[0].name.upper()[:2]) %}"#;
+        let (result, _context) = plain_parse_tag_v1(input).unwrap();
+        assert_eq!(
+            result,
+            Tag::Generic(GenericTag {
+                meta: TagMeta {
+                    token: token(r#"{% my_tag (my_item[0].name.upper()[:2]) %}"#, 0, 1, 1),
+                    name: token("my_tag", 3, 1, 4),
+                    used_variables: vec![token("my_item", 11, 1, 12)],
+                    assigned_variables: vec![],
+                },
+                attrs: vec![tag_attr(
+                    None,
+                    python_expr_value(
+                        token(r#"(my_item[0].name.upper()[:2])"#, 10, 1, 11),
+                        token(r#"(my_item[0].name.upper()[:2])"#, 10, 1, 11),
+                        None,
+                        vec![],
+                        vec![token("my_item", 11, 1, 12)],
+                        vec![],
+                    ),
+                    false
+                )],
+                is_self_closing: false,
+            })
+        );
+    }
+
+    #[test]
+    fn test_python_expr_walrus_operator_in_list_comp() {
+        let input = r#"{% my_tag ( [(x := y) for y in items] ) %}"#;
+        let (result, _context) = plain_parse_tag_v1(input).unwrap();
+        assert_eq!(
+            result,
+            Tag::Generic(GenericTag {
+                meta: TagMeta {
+                    token: token(r#"{% my_tag ( [(x := y) for y in items] ) %}"#, 0, 1, 1),
+                    name: token("my_tag", 3, 1, 4),
+                    used_variables: vec![token("items", 31, 1, 32)],
+                    assigned_variables: vec![token("x", 14, 1, 15)],
+                },
+                attrs: vec![tag_attr(
+                    None,
+                    python_expr_value(
+                        token(r#"( [(x := y) for y in items] )"#, 10, 1, 11),
+                        token(r#"( [(x := y) for y in items] )"#, 10, 1, 11),
+                        None,
+                        vec![],
+                        vec![token("items", 31, 1, 32)],
+                        vec![token("x", 14, 1, 15)],
+                    ),
+                    false
+                )],
+                is_self_closing: false,
+            })
+        );
+    }
+
+    #[test]
+    fn test_python_expr_walrus_operator_in_lambda() {
+        let input = r#"{% my_tag ( lambda y: (x := y) ) %}"#;
+        let (result, _context) = plain_parse_tag_v1(input).unwrap();
+        assert_eq!(
+            result,
+            Tag::Generic(GenericTag {
+                meta: TagMeta {
+                    token: token(r#"{% my_tag ( lambda y: (x := y) ) %}"#, 0, 1, 1),
+                    name: token("my_tag", 3, 1, 4),
+                    used_variables: vec![],
+                    assigned_variables: vec![token("x", 23, 1, 24)],
+                },
+                attrs: vec![tag_attr(
+                    None,
+                    python_expr_value(
+                        token(r#"( lambda y: (x := y) )"#, 10, 1, 11),
+                        token(r#"( lambda y: (x := y) )"#, 10, 1, 11),
+                        None,
+                        vec![],
+                        vec![],
+                        vec![token("x", 23, 1, 24)],
+                    ),
+                    false
+                )],
+                is_self_closing: false,
+            })
+        );
+    }
+
+    #[test]
+    fn test_python_expr_multiline() {
+        let input = "{% my_tag ( [1, \n\nb, \n(c := 3)] ) %}";
+        let (result, _context) = plain_parse_tag_v1(input).unwrap();
+        assert_eq!(
+            result,
+            Tag::Generic(GenericTag {
+                meta: TagMeta {
+                    token: token("{% my_tag ( [1, \n\nb, \n(c := 3)] ) %}", 0, 1, 1),
+                    name: token("my_tag", 3, 1, 4),
+                    used_variables: vec![token("b", 18, 3, 1)],
+                    assigned_variables: vec![token("c", 23, 4, 2)],
+                },
+                attrs: vec![tag_attr(
+                    None,
+                    python_expr_value(
+                        token("( [1, \n\nb, \n(c := 3)] )", 10, 1, 11),
+                        token("( [1, \n\nb, \n(c := 3)] )", 10, 1, 11),
+                        None,
+                        vec![],
+                        vec![token("b", 18, 3, 1)],
+                        vec![token("c", 23, 4, 2)],
+                    ),
+                    false,
+                )],
+                is_self_closing: false
+            })
+        );
+    }
+}

--- a/crates/djc-template-parser/tests/tag_parser_string.rs
+++ b/crates/djc-template-parser/tests/tag_parser_string.rs
@@ -1,0 +1,834 @@
+// Each of the `tag_parser_<data_type>.rs` file tests following cases:
+//  1. as arg
+//  2. as multiple args
+//  3. as arg with filter without filter arg
+//  4. as arg with filter with filter arg
+//  5. as arg with `...` spread
+//  6. as kwarg
+//  7. as multiple kwargs
+//  8. as kwarg with filter without filter arg
+//  9. as kwarg with filter with filter arg
+// 10. as both arg and kwarg with filters
+// 11. as both arg and kwarg with filters and arg with `...` spreads
+// 12. inside list
+// 13. inside list with filter without filter arg
+// 14. inside list with filter with filter arg
+// 15. inside list with filter with filter arg and `*` spread.
+// 16. inside list with `*` spread.
+// 17. inside dict as value
+// 18. inside dict as value with filter with filter arg
+// 19. inside dict as key and value
+// 20. inside dict as key and value, both with filters, and value with filter arg.
+// 21. inside dict as neither key nor value, with `**` spread and filter without arg
+
+mod common;
+
+#[cfg(test)]
+mod tests {
+    use std::vec;
+
+    use djc_template_parser::ast::{
+        GenericTag, Tag, TagMeta, TagValue, TagValueFilter, ValueChild, ValueKind,
+    };
+
+    use super::common::{
+        plain_parse_tag_v1, plain_string_value, plain_variable_value, string_value, tag_attr, token,
+    };
+
+    #[test]
+    fn test_string_as_arg() {
+        let input = r#"{% my_tag "hello" %}"#;
+        let (result, _context) = plain_parse_tag_v1(input).unwrap();
+        assert_eq!(
+            result,
+            Tag::Generic(GenericTag {
+                meta: TagMeta {
+                    token: token(r#"{% my_tag "hello" %}"#, 0, 1, 1),
+                    name: token("my_tag", 3, 1, 4),
+                    used_variables: vec![],
+                    assigned_variables: vec![],
+                },
+                attrs: vec![tag_attr(
+                    None,
+                    plain_string_value(r#""hello""#, 10, 1, 11, None),
+                    false
+                )],
+                is_self_closing: false,
+            })
+        );
+    }
+
+    #[test]
+    fn test_string_as_multiple_args() {
+        let input = r#"{% my_tag "value1" "value2" %}"#;
+        let (result, _context) = plain_parse_tag_v1(input).unwrap();
+        assert_eq!(
+            result,
+            Tag::Generic(GenericTag {
+                meta: TagMeta {
+                    token: token(r#"{% my_tag "value1" "value2" %}"#, 0, 1, 1),
+                    name: token("my_tag", 3, 1, 4),
+                    used_variables: vec![],
+                    assigned_variables: vec![],
+                },
+                attrs: vec![
+                    tag_attr(
+                        None,
+                        plain_string_value(r#""value1""#, 10, 1, 11, None),
+                        false
+                    ),
+                    tag_attr(
+                        None,
+                        plain_string_value(r#""value2""#, 19, 1, 20, None),
+                        false
+                    ),
+                ],
+                is_self_closing: false,
+            })
+        );
+    }
+
+    #[test]
+    fn test_string_as_arg_with_filter_without_arg() {
+        let input = r#"{% my_tag "hello"|lower %}"#;
+        let (result, _context) = plain_parse_tag_v1(input).unwrap();
+        assert_eq!(
+            result,
+            Tag::Generic(GenericTag {
+                meta: TagMeta {
+                    token: token(r#"{% my_tag "hello"|lower %}"#, 0, 1, 1),
+                    name: token("my_tag", 3, 1, 4),
+                    used_variables: vec![],
+                    assigned_variables: vec![],
+                },
+                attrs: vec![tag_attr(
+                    None,
+                    string_value(
+                        token(r#""hello"|lower"#, 10, 1, 11),
+                        token(r#""hello""#, 10, 1, 11),
+                        None,
+                        vec![TagValueFilter {
+                            token: token("|lower", 17, 1, 18),
+                            name: token("lower", 18, 1, 19),
+                            arg: None,
+                        }],
+                        vec![],
+                        vec![],
+                    ),
+                    false
+                )],
+                is_self_closing: false,
+            })
+        );
+    }
+
+    #[test]
+    fn test_string_as_arg_with_filter_with_arg() {
+        let input = r#"{% my_tag "hello"|select:"world" %}"#;
+        let (result, _context) = plain_parse_tag_v1(input).unwrap();
+        assert_eq!(
+            result,
+            Tag::Generic(GenericTag {
+                meta: TagMeta {
+                    token: token(r#"{% my_tag "hello"|select:"world" %}"#, 0, 1, 1),
+                    name: token("my_tag", 3, 1, 4),
+                    used_variables: vec![],
+                    assigned_variables: vec![],
+                },
+                attrs: vec![tag_attr(
+                    None,
+                    string_value(
+                        token(r#""hello"|select:"world""#, 10, 1, 11),
+                        token(r#""hello""#, 10, 1, 11),
+                        None,
+                        vec![TagValueFilter {
+                            token: token(r#"|select:"world""#, 17, 1, 18),
+                            name: token("select", 18, 1, 19),
+                            arg: Some(plain_string_value(r#""world""#, 25, 1, 26, None)),
+                        }],
+                        vec![],
+                        vec![],
+                    ),
+                    false
+                )],
+                is_self_closing: false,
+            })
+        );
+    }
+
+    #[test]
+    fn test_string_as_arg_with_spread() {
+        let input = r#"{% my_tag ..."hello" %}"#;
+        let (result, _context) = plain_parse_tag_v1(input).unwrap();
+        assert_eq!(
+            result,
+            Tag::Generic(GenericTag {
+                meta: TagMeta {
+                    token: token(r#"{% my_tag ..."hello" %}"#, 0, 1, 1),
+                    name: token("my_tag", 3, 1, 4),
+                    used_variables: vec![],
+                    assigned_variables: vec![],
+                },
+                attrs: vec![tag_attr(
+                    None,
+                    plain_string_value(r#""hello""#, 10, 1, 11, Some("...")),
+                    false
+                )],
+                is_self_closing: false,
+            })
+        );
+    }
+
+    #[test]
+    fn test_string_as_kwarg() {
+        let input = r#"{% my_tag key="hello" %}"#;
+        let (result, _context) = plain_parse_tag_v1(input).unwrap();
+        assert_eq!(
+            result,
+            Tag::Generic(GenericTag {
+                meta: TagMeta {
+                    token: token(r#"{% my_tag key="hello" %}"#, 0, 1, 1),
+                    name: token("my_tag", 3, 1, 4),
+                    used_variables: vec![],
+                    assigned_variables: vec![],
+                },
+                attrs: vec![tag_attr(
+                    Some(token("key", 10, 1, 11)),
+                    plain_string_value(r#""hello""#, 14, 1, 15, None),
+                    false
+                )],
+                is_self_closing: false,
+            })
+        );
+    }
+
+    #[test]
+    fn test_string_as_multiple_kwargs() {
+        let input = r#"{% my_tag key1="value1" key2="value2" %}"#;
+        let (result, _context) = plain_parse_tag_v1(input).unwrap();
+        assert_eq!(
+            result,
+            Tag::Generic(GenericTag {
+                meta: TagMeta {
+                    token: token(r#"{% my_tag key1="value1" key2="value2" %}"#, 0, 1, 1),
+                    name: token("my_tag", 3, 1, 4),
+                    used_variables: vec![],
+                    assigned_variables: vec![],
+                },
+                attrs: vec![
+                    tag_attr(
+                        Some(token("key1", 10, 1, 11)),
+                        plain_string_value(r#""value1""#, 15, 1, 16, None),
+                        false
+                    ),
+                    tag_attr(
+                        Some(token("key2", 24, 1, 25)),
+                        plain_string_value(r#""value2""#, 29, 1, 30, None),
+                        false
+                    ),
+                ],
+                is_self_closing: false,
+            })
+        );
+    }
+
+    #[test]
+    fn test_string_as_kwarg_with_filter_without_arg() {
+        let input = r#"{% my_tag key="hello"|upper %}"#;
+        let (result, _context) = plain_parse_tag_v1(input).unwrap();
+        assert_eq!(
+            result,
+            Tag::Generic(GenericTag {
+                meta: TagMeta {
+                    token: token(r#"{% my_tag key="hello"|upper %}"#, 0, 1, 1),
+                    name: token("my_tag", 3, 1, 4),
+                    used_variables: vec![],
+                    assigned_variables: vec![],
+                },
+                attrs: vec![tag_attr(
+                    Some(token("key", 10, 1, 11)),
+                    string_value(
+                        token(r#""hello"|upper"#, 14, 1, 15),
+                        token(r#""hello""#, 14, 1, 15),
+                        None,
+                        vec![TagValueFilter {
+                            token: token("|upper", 21, 1, 22),
+                            name: token("upper", 22, 1, 23),
+                            arg: None,
+                        }],
+                        vec![],
+                        vec![],
+                    ),
+                    false
+                )],
+                is_self_closing: false,
+            })
+        );
+    }
+
+    #[test]
+    fn test_string_as_kwarg_with_filter_with_arg() {
+        let input = r#"{% my_tag key="hello"|select:"world" %}"#;
+        let (result, _context) = plain_parse_tag_v1(input).unwrap();
+        assert_eq!(
+            result,
+            Tag::Generic(GenericTag {
+                meta: TagMeta {
+                    token: token(r#"{% my_tag key="hello"|select:"world" %}"#, 0, 1, 1),
+                    name: token("my_tag", 3, 1, 4),
+                    used_variables: vec![],
+                    assigned_variables: vec![],
+                },
+                attrs: vec![tag_attr(
+                    Some(token("key", 10, 1, 11)),
+                    string_value(
+                        token(r#""hello"|select:"world""#, 14, 1, 15),
+                        token(r#""hello""#, 14, 1, 15),
+                        None,
+                        vec![TagValueFilter {
+                            token: token(r#"|select:"world""#, 21, 1, 22),
+                            name: token("select", 22, 1, 23),
+                            arg: Some(plain_string_value(r#""world""#, 29, 1, 30, None)),
+                        }],
+                        vec![],
+                        vec![],
+                    ),
+                    false
+                )],
+                is_self_closing: false,
+            })
+        );
+    }
+
+    #[test]
+    fn test_string_as_both_arg_and_kwarg_with_filters() {
+        let input = r#"{% my_tag "hello"|lower key="world"|upper %}"#;
+        let (result, _context) = plain_parse_tag_v1(input).unwrap();
+        assert_eq!(
+            result,
+            Tag::Generic(GenericTag {
+                meta: TagMeta {
+                    token: token(r#"{% my_tag "hello"|lower key="world"|upper %}"#, 0, 1, 1),
+                    name: token("my_tag", 3, 1, 4),
+                    used_variables: vec![],
+                    assigned_variables: vec![],
+                },
+                attrs: vec![
+                    tag_attr(
+                        None,
+                        string_value(
+                            token(r#""hello"|lower"#, 10, 1, 11),
+                            token(r#""hello""#, 10, 1, 11),
+                            None,
+                            vec![TagValueFilter {
+                                token: token("|lower", 17, 1, 18),
+                                name: token("lower", 18, 1, 19),
+                                arg: None,
+                            }],
+                            vec![],
+                            vec![],
+                        ),
+                        false
+                    ),
+                    tag_attr(
+                        Some(token("key", 24, 1, 25)),
+                        string_value(
+                            token(r#""world"|upper"#, 28, 1, 29),
+                            token(r#""world""#, 28, 1, 29),
+                            None,
+                            vec![TagValueFilter {
+                                token: token("|upper", 35, 1, 36),
+                                name: token("upper", 36, 1, 37),
+                                arg: None,
+                            }],
+                            vec![],
+                            vec![],
+                        ),
+                        false
+                    ),
+                ],
+                is_self_closing: false,
+            })
+        );
+    }
+
+    #[test]
+    fn test_string_as_both_arg_and_kwarg_with_filters_and_spread() {
+        let input = r#"{% my_tag ..."hello"|lower key="world"|upper %}"#;
+        let (result, _context) = plain_parse_tag_v1(input).unwrap();
+        assert_eq!(
+            result,
+            Tag::Generic(GenericTag {
+                meta: TagMeta {
+                    token: token(
+                        r#"{% my_tag ..."hello"|lower key="world"|upper %}"#,
+                        0,
+                        1,
+                        1
+                    ),
+                    name: token("my_tag", 3, 1, 4),
+                    used_variables: vec![],
+                    assigned_variables: vec![],
+                },
+                attrs: vec![
+                    tag_attr(
+                        None,
+                        string_value(
+                            token(r#"..."hello"|lower"#, 10, 1, 11),
+                            token(r#""hello""#, 13, 1, 14),
+                            Some("..."),
+                            vec![TagValueFilter {
+                                token: token("|lower", 20, 1, 21),
+                                name: token("lower", 21, 1, 22),
+                                arg: None,
+                            }],
+                            vec![],
+                            vec![],
+                        ),
+                        false
+                    ),
+                    tag_attr(
+                        Some(token("key", 27, 1, 28)),
+                        string_value(
+                            token(r#""world"|upper"#, 31, 1, 32),
+                            token(r#""world""#, 31, 1, 32),
+                            None,
+                            vec![TagValueFilter {
+                                token: token("|upper", 38, 1, 39),
+                                name: token("upper", 39, 1, 40),
+                                arg: None,
+                            }],
+                            vec![],
+                            vec![],
+                        ),
+                        false
+                    ),
+                ],
+                is_self_closing: false,
+            })
+        );
+    }
+
+    #[test]
+    fn test_string_inside_list() {
+        let input = r#"{% my_tag ["hello"] %}"#;
+        let (result, _context) = plain_parse_tag_v1(input).unwrap();
+        let list_value = TagValue {
+            token: token(r#"["hello"]"#, 10, 1, 11),
+            value: token(r#"["hello"]"#, 10, 1, 11),
+            children: vec![ValueChild::Value(plain_string_value(
+                r#""hello""#,
+                11,
+                1,
+                12,
+                None,
+            ))],
+            kind: ValueKind::List,
+            spread: None,
+            filters: vec![],
+            used_variables: vec![],
+            assigned_variables: vec![],
+        };
+        assert_eq!(
+            result,
+            Tag::Generic(GenericTag {
+                meta: TagMeta {
+                    token: token(r#"{% my_tag ["hello"] %}"#, 0, 1, 1),
+                    name: token("my_tag", 3, 1, 4),
+                    used_variables: vec![],
+                    assigned_variables: vec![],
+                },
+                attrs: vec![tag_attr(None, list_value, false)],
+                is_self_closing: false,
+            })
+        );
+    }
+
+    #[test]
+    fn test_string_inside_list_with_filter_without_arg() {
+        let input = r#"{% my_tag ["hello"|lower] %}"#;
+        let (result, _context) = plain_parse_tag_v1(input).unwrap();
+        let list_value = TagValue {
+            token: token(r#"["hello"|lower]"#, 10, 1, 11),
+            value: token(r#"["hello"|lower]"#, 10, 1, 11),
+            children: vec![ValueChild::Value(string_value(
+                token(r#""hello"|lower"#, 11, 1, 12),
+                token(r#""hello""#, 11, 1, 12),
+                None,
+                vec![TagValueFilter {
+                    token: token("|lower", 18, 1, 19),
+                    name: token("lower", 19, 1, 20),
+                    arg: None,
+                }],
+                vec![],
+                vec![],
+            ))],
+            kind: ValueKind::List,
+            spread: None,
+            filters: vec![],
+            used_variables: vec![],
+            assigned_variables: vec![],
+        };
+        assert_eq!(
+            result,
+            Tag::Generic(GenericTag {
+                meta: TagMeta {
+                    token: token(r#"{% my_tag ["hello"|lower] %}"#, 0, 1, 1),
+                    name: token("my_tag", 3, 1, 4),
+                    used_variables: vec![],
+                    assigned_variables: vec![],
+                },
+                attrs: vec![tag_attr(None, list_value, false)],
+                is_self_closing: false,
+            })
+        );
+    }
+
+    #[test]
+    fn test_string_inside_list_with_filter_with_arg() {
+        let input = r#"{% my_tag ["hello"|select:"world"] %}"#;
+        let (result, _context) = plain_parse_tag_v1(input).unwrap();
+        let list_value = TagValue {
+            token: token(r#"["hello"|select:"world"]"#, 10, 1, 11),
+            value: token(r#"["hello"|select:"world"]"#, 10, 1, 11),
+            children: vec![ValueChild::Value(string_value(
+                token(r#""hello"|select:"world""#, 11, 1, 12),
+                token(r#""hello""#, 11, 1, 12),
+                None,
+                vec![TagValueFilter {
+                    token: token(r#"|select:"world""#, 18, 1, 19),
+                    name: token("select", 19, 1, 20),
+                    arg: Some(plain_string_value(r#""world""#, 26, 1, 27, None)),
+                }],
+                vec![],
+                vec![],
+            ))],
+            kind: ValueKind::List,
+            spread: None,
+            filters: vec![],
+            used_variables: vec![],
+            assigned_variables: vec![],
+        };
+        assert_eq!(
+            result,
+            Tag::Generic(GenericTag {
+                meta: TagMeta {
+                    token: token(r#"{% my_tag ["hello"|select:"world"] %}"#, 0, 1, 1),
+                    name: token("my_tag", 3, 1, 4),
+                    used_variables: vec![],
+                    assigned_variables: vec![],
+                },
+                attrs: vec![tag_attr(None, list_value, false)],
+                is_self_closing: false,
+            })
+        );
+    }
+
+    #[test]
+    fn test_string_inside_list_with_filter_with_arg_and_spread() {
+        let input = r#"{% my_tag [*"hello"|select:"world"] %}"#;
+        let (result, _context) = plain_parse_tag_v1(input).unwrap();
+        let list_value = TagValue {
+            token: token(r#"[*"hello"|select:"world"]"#, 10, 1, 11),
+            value: token(r#"[*"hello"|select:"world"]"#, 10, 1, 11),
+            children: vec![ValueChild::Value(string_value(
+                token(r#"*"hello"|select:"world""#, 11, 1, 12),
+                token(r#""hello""#, 12, 1, 13),
+                Some("*"),
+                vec![TagValueFilter {
+                    token: token(r#"|select:"world""#, 19, 1, 20),
+                    name: token("select", 20, 1, 21),
+                    arg: Some(plain_string_value(r#""world""#, 27, 1, 28, None)),
+                }],
+                vec![],
+                vec![],
+            ))],
+            kind: ValueKind::List,
+            spread: None,
+            filters: vec![],
+            used_variables: vec![],
+            assigned_variables: vec![],
+        };
+        assert_eq!(
+            result,
+            Tag::Generic(GenericTag {
+                meta: TagMeta {
+                    token: token(r#"{% my_tag [*"hello"|select:"world"] %}"#, 0, 1, 1),
+                    name: token("my_tag", 3, 1, 4),
+                    used_variables: vec![],
+                    assigned_variables: vec![],
+                },
+                attrs: vec![tag_attr(None, list_value, false)],
+                is_self_closing: false,
+            })
+        );
+    }
+
+    #[test]
+    fn test_string_inside_list_with_spread() {
+        let input = r#"{% my_tag [*"hello"] %}"#;
+        let (result, _context) = plain_parse_tag_v1(input).unwrap();
+        let list_value = TagValue {
+            token: token(r#"[*"hello"]"#, 10, 1, 11),
+            value: token(r#"[*"hello"]"#, 10, 1, 11),
+            children: vec![ValueChild::Value(plain_string_value(
+                r#""hello""#,
+                11,
+                1,
+                12,
+                Some("*"),
+            ))],
+            kind: ValueKind::List,
+            spread: None,
+            filters: vec![],
+            used_variables: vec![],
+            assigned_variables: vec![],
+        };
+        assert_eq!(
+            result,
+            Tag::Generic(GenericTag {
+                meta: TagMeta {
+                    token: token(r#"{% my_tag [*"hello"] %}"#, 0, 1, 1),
+                    name: token("my_tag", 3, 1, 4),
+                    used_variables: vec![],
+                    assigned_variables: vec![],
+                },
+                attrs: vec![tag_attr(None, list_value, false)],
+                is_self_closing: false,
+            })
+        );
+    }
+
+    #[test]
+    fn test_string_inside_dict_as_value() {
+        let input = r#"{% my_tag {key: "hello"} %}"#;
+        let (result, _context) = plain_parse_tag_v1(input).unwrap();
+        let dict_value = TagValue {
+            token: token(r#"{key: "hello"}"#, 10, 1, 11),
+            value: token(r#"{key: "hello"}"#, 10, 1, 11),
+            children: vec![
+                ValueChild::Value(plain_variable_value("key", 11, 1, 12, None)),
+                ValueChild::Value(plain_string_value(r#""hello""#, 16, 1, 17, None)),
+            ],
+            kind: ValueKind::Dict,
+            spread: None,
+            filters: vec![],
+            used_variables: vec![],
+            assigned_variables: vec![],
+        };
+        assert_eq!(
+            result,
+            Tag::Generic(GenericTag {
+                meta: TagMeta {
+                    token: token(r#"{% my_tag {key: "hello"} %}"#, 0, 1, 1),
+                    name: token("my_tag", 3, 1, 4),
+                    used_variables: vec![token("key", 11, 1, 12)],
+                    assigned_variables: vec![],
+                },
+                attrs: vec![tag_attr(None, dict_value, false)],
+                is_self_closing: false,
+            })
+        );
+    }
+
+    #[test]
+    fn test_string_inside_dict_as_value_with_filter_with_arg() {
+        let input = r#"{% my_tag {key: "hello"|select:"world"} %}"#;
+        let (result, _context) = plain_parse_tag_v1(input).unwrap();
+        let dict_value = TagValue {
+            token: token(r#"{key: "hello"|select:"world"}"#, 10, 1, 11),
+            value: token(r#"{key: "hello"|select:"world"}"#, 10, 1, 11),
+            children: vec![
+                ValueChild::Value(plain_variable_value("key", 11, 1, 12, None)),
+                ValueChild::Value(string_value(
+                    token(r#""hello"|select:"world""#, 16, 1, 17),
+                    token(r#""hello""#, 16, 1, 17),
+                    None,
+                    vec![TagValueFilter {
+                        token: token(r#"|select:"world""#, 23, 1, 24),
+                        name: token("select", 24, 1, 25),
+                        arg: Some(plain_string_value(r#""world""#, 31, 1, 32, None)),
+                    }],
+                    vec![],
+                    vec![],
+                )),
+            ],
+            kind: ValueKind::Dict,
+            spread: None,
+            filters: vec![],
+            used_variables: vec![],
+            assigned_variables: vec![],
+        };
+        assert_eq!(
+            result,
+            Tag::Generic(GenericTag {
+                meta: TagMeta {
+                    token: token(r#"{% my_tag {key: "hello"|select:"world"} %}"#, 0, 1, 1),
+                    name: token("my_tag", 3, 1, 4),
+                    used_variables: vec![token("key", 11, 1, 12)],
+                    assigned_variables: vec![],
+                },
+                attrs: vec![tag_attr(None, dict_value, false)],
+                is_self_closing: false,
+            })
+        );
+    }
+
+    #[test]
+    fn test_string_inside_dict_as_key_and_value() {
+        let input = r#"{% my_tag {"my_key": "hello"} %}"#;
+        let (result, _context) = plain_parse_tag_v1(input).unwrap();
+        let dict_value = TagValue {
+            token: token(r#"{"my_key": "hello"}"#, 10, 1, 11),
+            value: token(r#"{"my_key": "hello"}"#, 10, 1, 11),
+            children: vec![
+                ValueChild::Value(plain_string_value(r#""my_key""#, 11, 1, 12, None)),
+                ValueChild::Value(plain_string_value(r#""hello""#, 21, 1, 22, None)),
+            ],
+            kind: ValueKind::Dict,
+            spread: None,
+            filters: vec![],
+            used_variables: vec![],
+            assigned_variables: vec![],
+        };
+        assert_eq!(
+            result,
+            Tag::Generic(GenericTag {
+                meta: TagMeta {
+                    token: token(r#"{% my_tag {"my_key": "hello"} %}"#, 0, 1, 1),
+                    name: token("my_tag", 3, 1, 4),
+                    used_variables: vec![],
+                    assigned_variables: vec![],
+                },
+                attrs: vec![tag_attr(None, dict_value, false)],
+                is_self_closing: false,
+            })
+        );
+    }
+
+    #[test]
+    fn test_string_inside_dict_as_key_and_value_with_filters_and_arg() {
+        let input = r#"{% my_tag {"my_key"|lower: "hello"|select:"world"} %}"#;
+        let (result, _context) = plain_parse_tag_v1(input).unwrap();
+        let dict_value = TagValue {
+            token: token(r#"{"my_key"|lower: "hello"|select:"world"}"#, 10, 1, 11),
+            value: token(r#"{"my_key"|lower: "hello"|select:"world"}"#, 10, 1, 11),
+            children: vec![
+                ValueChild::Value(string_value(
+                    token(r#""my_key"|lower"#, 11, 1, 12),
+                    token(r#""my_key""#, 11, 1, 12),
+                    None,
+                    vec![TagValueFilter {
+                        token: token("|lower", 19, 1, 20),
+                        name: token("lower", 20, 1, 21),
+                        arg: None,
+                    }],
+                    vec![],
+                    vec![],
+                )),
+                ValueChild::Value(string_value(
+                    token(r#""hello"|select:"world""#, 27, 1, 28),
+                    token(r#""hello""#, 27, 1, 28),
+                    None,
+                    vec![TagValueFilter {
+                        token: token(r#"|select:"world""#, 34, 1, 35),
+                        name: token("select", 35, 1, 36),
+                        arg: Some(plain_string_value(r#""world""#, 42, 1, 43, None)),
+                    }],
+                    vec![],
+                    vec![],
+                )),
+            ],
+            kind: ValueKind::Dict,
+            spread: None,
+            filters: vec![],
+            used_variables: vec![],
+            assigned_variables: vec![],
+        };
+        assert_eq!(
+            result,
+            Tag::Generic(GenericTag {
+                meta: TagMeta {
+                    token: token(
+                        r#"{% my_tag {"my_key"|lower: "hello"|select:"world"} %}"#,
+                        0,
+                        1,
+                        1
+                    ),
+                    name: token("my_tag", 3, 1, 4),
+                    used_variables: vec![],
+                    assigned_variables: vec![],
+                },
+                attrs: vec![tag_attr(None, dict_value, false)],
+                is_self_closing: false,
+            })
+        );
+    }
+
+    #[test]
+    fn test_string_inside_dict_with_spread_and_filter() {
+        let input = r#"{% my_tag {**"hello"|upper} %}"#;
+        let (result, _context) = plain_parse_tag_v1(input).unwrap();
+        let dict_value = TagValue {
+            token: token(r#"{**"hello"|upper}"#, 10, 1, 11),
+            value: token(r#"{**"hello"|upper}"#, 10, 1, 11),
+            children: vec![ValueChild::Value(string_value(
+                token(r#"**"hello"|upper"#, 11, 1, 12),
+                token(r#""hello""#, 13, 1, 14),
+                Some("**"),
+                vec![TagValueFilter {
+                    token: token("|upper", 20, 1, 21),
+                    name: token("upper", 21, 1, 22),
+                    arg: None,
+                }],
+                vec![],
+                vec![],
+            ))],
+            kind: ValueKind::Dict,
+            spread: None,
+            filters: vec![],
+            used_variables: vec![],
+            assigned_variables: vec![],
+        };
+        assert_eq!(
+            result,
+            Tag::Generic(GenericTag {
+                meta: TagMeta {
+                    token: token(r#"{% my_tag {**"hello"|upper} %}"#, 0, 1, 1),
+                    name: token("my_tag", 3, 1, 4),
+                    used_variables: vec![],
+                    assigned_variables: vec![],
+                },
+                attrs: vec![tag_attr(None, dict_value, false)],
+                is_self_closing: false,
+            })
+        );
+    }
+
+    // #######################################
+    // STRINGS EDGE CASES
+    // #######################################
+
+    #[test]
+    fn test_string_single_quoted() {
+        let input = r#"{% my_tag 'hello world' %}"#;
+        let (result, _context) = plain_parse_tag_v1(input).unwrap();
+        assert_eq!(
+            result,
+            Tag::Generic(GenericTag {
+                meta: TagMeta {
+                    token: token("{% my_tag 'hello world' %}", 0, 1, 1),
+                    name: token("my_tag", 3, 1, 4),
+                    used_variables: vec![],
+                    assigned_variables: vec![],
+                },
+                attrs: vec![tag_attr(
+                    None,
+                    plain_string_value("'hello world'", 10, 1, 11, None),
+                    false
+                )],
+                is_self_closing: false,
+            })
+        );
+    }
+}

--- a/crates/djc-template-parser/tests/tag_parser_template_string.rs
+++ b/crates/djc-template-parser/tests/tag_parser_template_string.rs
@@ -1,0 +1,1154 @@
+// Each of the `tag_parser_<data_type>.rs` file tests following cases:
+//  1. as arg
+//  2. as multiple args
+//  3. as arg with filter without filter arg
+//  4. as arg with filter with filter arg
+//  5. as arg with `...` spread
+//  6. as kwarg
+//  7. as multiple kwargs
+//  8. as kwarg with filter without filter arg
+//  9. as kwarg with filter with filter arg
+// 10. as both arg and kwarg with filters
+// 11. as both arg and kwarg with filters and arg with `...` spreads
+// 12. inside list
+// 13. inside list with filter without filter arg
+// 14. inside list with filter with filter arg
+// 15. inside list with filter with filter arg and `*` spread.
+// 16. inside list with `*` spread.
+// 17. inside dict as value
+// 18. inside dict as value with filter with filter arg
+// 19. inside dict as key and value
+// 20. inside dict as key and value, both with filters, and value with filter arg.
+// 21. inside dict as neither key nor value, with `**` spread and filter without arg
+
+mod common;
+
+#[cfg(test)]
+mod tests {
+    use std::vec;
+
+    use djc_template_parser::ast::{
+        GenericTag, Tag, TagMeta, TagValue, TagValueFilter, ValueChild, ValueKind,
+    };
+
+    use super::common::{
+        plain_parse_tag_v1, plain_string_value, plain_template_string_value,
+        plain_translation_value, plain_variable_value, tag_attr, template_string_value, token,
+    };
+
+    #[test]
+    fn test_template_string_as_arg() {
+        let input = r#"{% my_tag "Hello {{ name }} {% tag %}" %}"#;
+        let (result, _context) = plain_parse_tag_v1(input).unwrap();
+        assert_eq!(
+            result,
+            Tag::Generic(GenericTag {
+                meta: TagMeta {
+                    token: token(r#"{% my_tag "Hello {{ name }} {% tag %}" %}"#, 0, 1, 1),
+                    name: token("my_tag", 3, 1, 4),
+                    used_variables: vec![],
+                    assigned_variables: vec![],
+                },
+                attrs: vec![tag_attr(
+                    None,
+                    plain_template_string_value(r#""Hello {{ name }} {% tag %}""#, 10, 1, 11, None),
+                    false
+                )],
+                is_self_closing: false,
+            })
+        );
+    }
+
+    #[test]
+    fn test_template_string_as_multiple_args() {
+        let input = r#"{% my_tag "Hello {{ var1 }}" "World {% tag2 %}" %}"#;
+        let (result, _context) = plain_parse_tag_v1(input).unwrap();
+        assert_eq!(
+            result,
+            Tag::Generic(GenericTag {
+                meta: TagMeta {
+                    token: token(
+                        r#"{% my_tag "Hello {{ var1 }}" "World {% tag2 %}" %}"#,
+                        0,
+                        1,
+                        1
+                    ),
+                    name: token("my_tag", 3, 1, 4),
+                    used_variables: vec![],
+                    assigned_variables: vec![],
+                },
+                attrs: vec![
+                    tag_attr(
+                        None,
+                        plain_template_string_value(r#""Hello {{ var1 }}""#, 10, 1, 11, None),
+                        false
+                    ),
+                    tag_attr(
+                        None,
+                        plain_template_string_value(r#""World {% tag2 %}""#, 29, 1, 30, None),
+                        false
+                    ),
+                ],
+                is_self_closing: false,
+            })
+        );
+    }
+
+    #[test]
+    fn test_template_string_as_arg_with_filter_without_arg() {
+        let input = r#"{% my_tag "Hello {{ name }} {% tag %}"|lower %}"#;
+        let (result, _context) = plain_parse_tag_v1(input).unwrap();
+        assert_eq!(
+            result,
+            Tag::Generic(GenericTag {
+                meta: TagMeta {
+                    token: token(
+                        r#"{% my_tag "Hello {{ name }} {% tag %}"|lower %}"#,
+                        0,
+                        1,
+                        1
+                    ),
+                    name: token("my_tag", 3, 1, 4),
+                    used_variables: vec![],
+                    assigned_variables: vec![],
+                },
+                attrs: vec![tag_attr(
+                    None,
+                    template_string_value(
+                        token(r#""Hello {{ name }} {% tag %}"|lower"#, 10, 1, 11),
+                        token(r#""Hello {{ name }} {% tag %}""#, 10, 1, 11),
+                        None,
+                        vec![TagValueFilter {
+                            token: token("|lower", 38, 1, 39),
+                            name: token("lower", 39, 1, 40),
+                            arg: None,
+                        }],
+                        vec![],
+                        vec![],
+                    ),
+                    false
+                )],
+                is_self_closing: false,
+            })
+        );
+    }
+
+    #[test]
+    fn test_template_string_as_arg_with_filter_with_arg() {
+        let input = r#"{% my_tag "Hello {{ name }} {% tag %}"|select:"World {{ key }}" %}"#;
+        let (result, _context) = plain_parse_tag_v1(input).unwrap();
+        assert_eq!(
+            result,
+            Tag::Generic(GenericTag {
+                meta: TagMeta {
+                    token: token(
+                        r#"{% my_tag "Hello {{ name }} {% tag %}"|select:"World {{ key }}" %}"#,
+                        0,
+                        1,
+                        1
+                    ),
+                    name: token("my_tag", 3, 1, 4),
+                    used_variables: vec![],
+                    assigned_variables: vec![],
+                },
+                attrs: vec![tag_attr(
+                    None,
+                    template_string_value(
+                        token(
+                            r#""Hello {{ name }} {% tag %}"|select:"World {{ key }}""#,
+                            10,
+                            1,
+                            11
+                        ),
+                        token(r#""Hello {{ name }} {% tag %}""#, 10, 1, 11),
+                        None,
+                        vec![TagValueFilter {
+                            token: token(r#"|select:"World {{ key }}""#, 38, 1, 39),
+                            name: token("select", 39, 1, 40),
+                            arg: Some(plain_template_string_value(
+                                r#""World {{ key }}""#,
+                                46,
+                                1,
+                                47,
+                                None
+                            )),
+                        }],
+                        vec![],
+                        vec![],
+                    ),
+                    false
+                )],
+                is_self_closing: false,
+            })
+        );
+    }
+
+    #[test]
+    fn test_template_string_as_arg_with_spread() {
+        let input = r#"{% my_tag ..."Hello {{ name }} {% tag %}" %}"#;
+        let (result, _context) = plain_parse_tag_v1(input).unwrap();
+        assert_eq!(
+            result,
+            Tag::Generic(GenericTag {
+                meta: TagMeta {
+                    token: token(r#"{% my_tag ..."Hello {{ name }} {% tag %}" %}"#, 0, 1, 1),
+                    name: token("my_tag", 3, 1, 4),
+                    used_variables: vec![],
+                    assigned_variables: vec![],
+                },
+                attrs: vec![tag_attr(
+                    None,
+                    plain_template_string_value(
+                        r#""Hello {{ name }} {% tag %}""#,
+                        10,
+                        1,
+                        11,
+                        Some("...")
+                    ),
+                    false
+                )],
+                is_self_closing: false,
+            })
+        );
+    }
+
+    #[test]
+    fn test_template_string_as_kwarg() {
+        let input = r#"{% my_tag key="Hello {{ name }} {% tag %}" %}"#;
+        let (result, _context) = plain_parse_tag_v1(input).unwrap();
+        assert_eq!(
+            result,
+            Tag::Generic(GenericTag {
+                meta: TagMeta {
+                    token: token(r#"{% my_tag key="Hello {{ name }} {% tag %}" %}"#, 0, 1, 1),
+                    name: token("my_tag", 3, 1, 4),
+                    used_variables: vec![],
+                    assigned_variables: vec![],
+                },
+                attrs: vec![tag_attr(
+                    Some(token("key", 10, 1, 11)),
+                    plain_template_string_value(r#""Hello {{ name }} {% tag %}""#, 14, 1, 15, None),
+                    false
+                )],
+                is_self_closing: false,
+            })
+        );
+    }
+
+    #[test]
+    fn test_template_string_as_multiple_kwargs() {
+        let input = r#"{% my_tag key1="Hello {{ var1 }}" key2="World {% tag2 %}" %}"#;
+        let (result, _context) = plain_parse_tag_v1(input).unwrap();
+        assert_eq!(
+            result,
+            Tag::Generic(GenericTag {
+                meta: TagMeta {
+                    token: token(
+                        r#"{% my_tag key1="Hello {{ var1 }}" key2="World {% tag2 %}" %}"#,
+                        0,
+                        1,
+                        1
+                    ),
+                    name: token("my_tag", 3, 1, 4),
+                    used_variables: vec![],
+                    assigned_variables: vec![],
+                },
+                attrs: vec![
+                    tag_attr(
+                        Some(token("key1", 10, 1, 11)),
+                        plain_template_string_value(r#""Hello {{ var1 }}""#, 15, 1, 16, None),
+                        false
+                    ),
+                    tag_attr(
+                        Some(token("key2", 34, 1, 35)),
+                        plain_template_string_value(r#""World {% tag2 %}""#, 39, 1, 40, None),
+                        false
+                    ),
+                ],
+                is_self_closing: false,
+            })
+        );
+    }
+
+    #[test]
+    fn test_template_string_as_kwarg_with_filter_without_arg() {
+        let input = r#"{% my_tag key="Hello {{ name }} {% tag %}"|upper %}"#;
+        let (result, _context) = plain_parse_tag_v1(input).unwrap();
+        assert_eq!(
+            result,
+            Tag::Generic(GenericTag {
+                meta: TagMeta {
+                    token: token(
+                        r#"{% my_tag key="Hello {{ name }} {% tag %}"|upper %}"#,
+                        0,
+                        1,
+                        1
+                    ),
+                    name: token("my_tag", 3, 1, 4),
+                    used_variables: vec![],
+                    assigned_variables: vec![],
+                },
+                attrs: vec![tag_attr(
+                    Some(token("key", 10, 1, 11)),
+                    template_string_value(
+                        token(r#""Hello {{ name }} {% tag %}"|upper"#, 14, 1, 15),
+                        token(r#""Hello {{ name }} {% tag %}""#, 14, 1, 15),
+                        None,
+                        vec![TagValueFilter {
+                            token: token("|upper", 42, 1, 43),
+                            name: token("upper", 43, 1, 44),
+                            arg: None,
+                        }],
+                        vec![],
+                        vec![],
+                    ),
+                    false
+                )],
+                is_self_closing: false,
+            })
+        );
+    }
+
+    #[test]
+    fn test_template_string_as_kwarg_with_filter_with_arg() {
+        let input =
+            r#"{% my_tag key="Hello {{ name }} {% tag %}"|select:"world is {{ my_var }}" %}"#;
+        let (result, _context) = plain_parse_tag_v1(input).unwrap();
+        assert_eq!(
+            result,
+            Tag::Generic(GenericTag {
+                meta: TagMeta {
+                    token: token(
+                        r#"{% my_tag key="Hello {{ name }} {% tag %}"|select:"world is {{ my_var }}" %}"#,
+                        0,
+                        1,
+                        1
+                    ),
+                    name: token("my_tag", 3, 1, 4),
+                    used_variables: vec![],
+                    assigned_variables: vec![],
+                },
+                attrs: vec![tag_attr(
+                    Some(token("key", 10, 1, 11)),
+                    template_string_value(
+                        token(
+                            r#""Hello {{ name }} {% tag %}"|select:"world is {{ my_var }}""#,
+                            14,
+                            1,
+                            15
+                        ),
+                        token(r#""Hello {{ name }} {% tag %}""#, 14, 1, 15),
+                        None,
+                        vec![TagValueFilter {
+                            token: token(r#"|select:"world is {{ my_var }}""#, 42, 1, 43),
+                            name: token("select", 43, 1, 44),
+                            arg: Some(plain_template_string_value(
+                                r#""world is {{ my_var }}""#,
+                                50,
+                                1,
+                                51,
+                                None
+                            )),
+                        }],
+                        vec![],
+                        vec![],
+                    ),
+                    false
+                )],
+                is_self_closing: false,
+            })
+        );
+    }
+
+    #[test]
+    fn test_template_string_as_both_arg_and_kwarg_with_filters() {
+        let input = r#"{% my_tag "Hello {{ name }}"|lower key="World {% tag %}"|upper %}"#;
+        let (result, _context) = plain_parse_tag_v1(input).unwrap();
+        assert_eq!(
+            result,
+            Tag::Generic(GenericTag {
+                meta: TagMeta {
+                    token: token(
+                        r#"{% my_tag "Hello {{ name }}"|lower key="World {% tag %}"|upper %}"#,
+                        0,
+                        1,
+                        1
+                    ),
+                    name: token("my_tag", 3, 1, 4),
+                    used_variables: vec![],
+                    assigned_variables: vec![],
+                },
+                attrs: vec![
+                    tag_attr(
+                        None,
+                        template_string_value(
+                            token(r#""Hello {{ name }}"|lower"#, 10, 1, 11),
+                            token(r#""Hello {{ name }}""#, 10, 1, 11),
+                            None,
+                            vec![TagValueFilter {
+                                token: token("|lower", 28, 1, 29),
+                                name: token("lower", 29, 1, 30),
+                                arg: None,
+                            }],
+                            vec![],
+                            vec![],
+                        ),
+                        false
+                    ),
+                    tag_attr(
+                        Some(token("key", 35, 1, 36)),
+                        template_string_value(
+                            token(r#""World {% tag %}"|upper"#, 39, 1, 40),
+                            token(r#""World {% tag %}""#, 39, 1, 40),
+                            None,
+                            vec![TagValueFilter {
+                                token: token("|upper", 56, 1, 57),
+                                name: token("upper", 57, 1, 58),
+                                arg: None,
+                            }],
+                            vec![],
+                            vec![],
+                        ),
+                        false
+                    ),
+                ],
+                is_self_closing: false,
+            })
+        );
+    }
+
+    #[test]
+    fn test_template_string_as_both_arg_and_kwarg_with_filters_and_spread() {
+        let input = r#"{% my_tag ..."Hello {{ name }}"|lower key="World {% tag %}"|upper %}"#;
+        let (result, _context) = plain_parse_tag_v1(input).unwrap();
+        assert_eq!(
+            result,
+            Tag::Generic(GenericTag {
+                meta: TagMeta {
+                    token: token(
+                        r#"{% my_tag ..."Hello {{ name }}"|lower key="World {% tag %}"|upper %}"#,
+                        0,
+                        1,
+                        1
+                    ),
+                    name: token("my_tag", 3, 1, 4),
+                    used_variables: vec![],
+                    assigned_variables: vec![],
+                },
+                attrs: vec![
+                    tag_attr(
+                        None,
+                        template_string_value(
+                            token(r#"..."Hello {{ name }}"|lower"#, 10, 1, 11),
+                            token(r#""Hello {{ name }}""#, 13, 1, 14),
+                            Some("..."),
+                            vec![TagValueFilter {
+                                token: token("|lower", 31, 1, 32),
+                                name: token("lower", 32, 1, 33),
+                                arg: None,
+                            }],
+                            vec![],
+                            vec![],
+                        ),
+                        false
+                    ),
+                    tag_attr(
+                        Some(token("key", 38, 1, 39)),
+                        template_string_value(
+                            token(r#""World {% tag %}"|upper"#, 42, 1, 43),
+                            token(r#""World {% tag %}""#, 42, 1, 43),
+                            None,
+                            vec![TagValueFilter {
+                                token: token("|upper", 59, 1, 60),
+                                name: token("upper", 60, 1, 61),
+                                arg: None,
+                            }],
+                            vec![],
+                            vec![],
+                        ),
+                        false
+                    ),
+                ],
+                is_self_closing: false,
+            })
+        );
+    }
+
+    #[test]
+    fn test_template_string_inside_list() {
+        let input = r#"{% my_tag ["Hello {{ name }} {% tag %}"] %}"#;
+        let (result, _context) = plain_parse_tag_v1(input).unwrap();
+        let list_value = TagValue {
+            token: token(r#"["Hello {{ name }} {% tag %}"]"#, 10, 1, 11),
+            value: token(r#"["Hello {{ name }} {% tag %}"]"#, 10, 1, 11),
+            children: vec![ValueChild::Value(plain_template_string_value(
+                r#""Hello {{ name }} {% tag %}""#,
+                11,
+                1,
+                12,
+                None,
+            ))],
+            kind: ValueKind::List,
+            spread: None,
+            filters: vec![],
+            used_variables: vec![],
+            assigned_variables: vec![],
+        };
+        assert_eq!(
+            result,
+            Tag::Generic(GenericTag {
+                meta: TagMeta {
+                    token: token(r#"{% my_tag ["Hello {{ name }} {% tag %}"] %}"#, 0, 1, 1),
+                    name: token("my_tag", 3, 1, 4),
+                    used_variables: vec![],
+                    assigned_variables: vec![],
+                },
+                attrs: vec![tag_attr(None, list_value, false)],
+                is_self_closing: false,
+            })
+        );
+    }
+
+    #[test]
+    fn test_template_string_inside_list_with_filter_without_arg() {
+        let input = r#"{% my_tag ["Hello {{ name }} {% tag %}"|lower] %}"#;
+        let (result, _context) = plain_parse_tag_v1(input).unwrap();
+        let list_value = TagValue {
+            token: token(r#"["Hello {{ name }} {% tag %}"|lower]"#, 10, 1, 11),
+            value: token(r#"["Hello {{ name }} {% tag %}"|lower]"#, 10, 1, 11),
+            children: vec![ValueChild::Value(template_string_value(
+                token(r#""Hello {{ name }} {% tag %}"|lower"#, 11, 1, 12),
+                token(r#""Hello {{ name }} {% tag %}""#, 11, 1, 12),
+                None,
+                vec![TagValueFilter {
+                    token: token("|lower", 39, 1, 40),
+                    name: token("lower", 40, 1, 41),
+                    arg: None,
+                }],
+                vec![],
+                vec![],
+            ))],
+            kind: ValueKind::List,
+            spread: None,
+            filters: vec![],
+            used_variables: vec![],
+            assigned_variables: vec![],
+        };
+        assert_eq!(
+            result,
+            Tag::Generic(GenericTag {
+                meta: TagMeta {
+                    token: token(
+                        r#"{% my_tag ["Hello {{ name }} {% tag %}"|lower] %}"#,
+                        0,
+                        1,
+                        1
+                    ),
+                    name: token("my_tag", 3, 1, 4),
+                    used_variables: vec![],
+                    assigned_variables: vec![],
+                },
+                attrs: vec![tag_attr(None, list_value, false)],
+                is_self_closing: false,
+            })
+        );
+    }
+
+    #[test]
+    fn test_template_string_inside_list_with_filter_with_arg() {
+        let input = r#"{% my_tag ["Hello {{ name }} {% tag %}"|select:"world is {{ my_var }}"] %}"#;
+        let (result, _context) = plain_parse_tag_v1(input).unwrap();
+        let list_value = TagValue {
+            token: token(
+                r#"["Hello {{ name }} {% tag %}"|select:"world is {{ my_var }}"]"#,
+                10,
+                1,
+                11,
+            ),
+            value: token(
+                r#"["Hello {{ name }} {% tag %}"|select:"world is {{ my_var }}"]"#,
+                10,
+                1,
+                11,
+            ),
+            children: vec![ValueChild::Value(template_string_value(
+                token(
+                    r#""Hello {{ name }} {% tag %}"|select:"world is {{ my_var }}""#,
+                    11,
+                    1,
+                    12,
+                ),
+                token(r#""Hello {{ name }} {% tag %}""#, 11, 1, 12),
+                None,
+                vec![TagValueFilter {
+                    token: token(r#"|select:"world is {{ my_var }}""#, 39, 1, 40),
+                    name: token("select", 40, 1, 41),
+                    arg: Some(plain_template_string_value(
+                        r#""world is {{ my_var }}""#,
+                        47,
+                        1,
+                        48,
+                        None,
+                    )),
+                }],
+                vec![],
+                vec![],
+            ))],
+            kind: ValueKind::List,
+            spread: None,
+            filters: vec![],
+            used_variables: vec![],
+            assigned_variables: vec![],
+        };
+        assert_eq!(
+            result,
+            Tag::Generic(GenericTag {
+                meta: TagMeta {
+                    token: token(
+                        r#"{% my_tag ["Hello {{ name }} {% tag %}"|select:"world is {{ my_var }}"] %}"#,
+                        0,
+                        1,
+                        1
+                    ),
+                    name: token("my_tag", 3, 1, 4),
+                    used_variables: vec![],
+                    assigned_variables: vec![],
+                },
+                attrs: vec![tag_attr(None, list_value, false)],
+                is_self_closing: false,
+            })
+        );
+    }
+
+    #[test]
+    fn test_template_string_inside_list_with_filter_with_arg_and_spread() {
+        let input =
+            r#"{% my_tag [*"Hello {{ name }} {% tag %}"|select:"world is {{ my_var }}"] %}"#;
+        let (result, _context) = plain_parse_tag_v1(input).unwrap();
+        let list_value = TagValue {
+            token: token(
+                r#"[*"Hello {{ name }} {% tag %}"|select:"world is {{ my_var }}"]"#,
+                10,
+                1,
+                11,
+            ),
+            value: token(
+                r#"[*"Hello {{ name }} {% tag %}"|select:"world is {{ my_var }}"]"#,
+                10,
+                1,
+                11,
+            ),
+            children: vec![ValueChild::Value(template_string_value(
+                token(
+                    r#"*"Hello {{ name }} {% tag %}"|select:"world is {{ my_var }}""#,
+                    11,
+                    1,
+                    12,
+                ),
+                token(r#""Hello {{ name }} {% tag %}""#, 12, 1, 13),
+                Some("*"),
+                vec![TagValueFilter {
+                    token: token(r#"|select:"world is {{ my_var }}""#, 40, 1, 41),
+                    name: token("select", 41, 1, 42),
+                    arg: Some(plain_template_string_value(
+                        r#""world is {{ my_var }}""#,
+                        48,
+                        1,
+                        49,
+                        None,
+                    )),
+                }],
+                vec![],
+                vec![],
+            ))],
+            kind: ValueKind::List,
+            spread: None,
+            filters: vec![],
+            used_variables: vec![],
+            assigned_variables: vec![],
+        };
+        assert_eq!(
+            result,
+            Tag::Generic(GenericTag {
+                meta: TagMeta {
+                    token: token(
+                        r#"{% my_tag [*"Hello {{ name }} {% tag %}"|select:"world is {{ my_var }}"] %}"#,
+                        0,
+                        1,
+                        1
+                    ),
+                    name: token("my_tag", 3, 1, 4),
+                    used_variables: vec![],
+                    assigned_variables: vec![],
+                },
+                attrs: vec![tag_attr(None, list_value, false)],
+                is_self_closing: false,
+            })
+        );
+    }
+
+    #[test]
+    fn test_template_string_inside_list_with_spread() {
+        let input = r#"{% my_tag [*"Hello {{ name }} {% tag %}"] %}"#;
+        let (result, _context) = plain_parse_tag_v1(input).unwrap();
+        let list_value = TagValue {
+            token: token(r#"[*"Hello {{ name }} {% tag %}"]"#, 10, 1, 11),
+            value: token(r#"[*"Hello {{ name }} {% tag %}"]"#, 10, 1, 11),
+            children: vec![ValueChild::Value(plain_template_string_value(
+                r#""Hello {{ name }} {% tag %}""#,
+                11,
+                1,
+                12,
+                Some("*"),
+            ))],
+            kind: ValueKind::List,
+            spread: None,
+            filters: vec![],
+            used_variables: vec![],
+            assigned_variables: vec![],
+        };
+        assert_eq!(
+            result,
+            Tag::Generic(GenericTag {
+                meta: TagMeta {
+                    token: token(r#"{% my_tag [*"Hello {{ name }} {% tag %}"] %}"#, 0, 1, 1),
+                    name: token("my_tag", 3, 1, 4),
+                    used_variables: vec![],
+                    assigned_variables: vec![],
+                },
+                attrs: vec![tag_attr(None, list_value, false)],
+                is_self_closing: false,
+            })
+        );
+    }
+
+    #[test]
+    fn test_template_string_inside_dict_as_value() {
+        let input = r#"{% my_tag {key: "Hello {{ name }} {% tag %}"} %}"#;
+        let (result, _context) = plain_parse_tag_v1(input).unwrap();
+        let dict_value = TagValue {
+            token: token(r#"{key: "Hello {{ name }} {% tag %}"}"#, 10, 1, 11),
+            value: token(r#"{key: "Hello {{ name }} {% tag %}"}"#, 10, 1, 11),
+            children: vec![
+                ValueChild::Value(plain_variable_value("key", 11, 1, 12, None)),
+                ValueChild::Value(plain_template_string_value(
+                    r#""Hello {{ name }} {% tag %}""#,
+                    16,
+                    1,
+                    17,
+                    None,
+                )),
+            ],
+            kind: ValueKind::Dict,
+            spread: None,
+            filters: vec![],
+            used_variables: vec![],
+            assigned_variables: vec![],
+        };
+        assert_eq!(
+            result,
+            Tag::Generic(GenericTag {
+                meta: TagMeta {
+                    token: token(
+                        r#"{% my_tag {key: "Hello {{ name }} {% tag %}"} %}"#,
+                        0,
+                        1,
+                        1
+                    ),
+                    name: token("my_tag", 3, 1, 4),
+                    used_variables: vec![token("key", 11, 1, 12)],
+                    assigned_variables: vec![],
+                },
+                attrs: vec![tag_attr(None, dict_value, false)],
+                is_self_closing: false,
+            })
+        );
+    }
+
+    #[test]
+    fn test_template_string_inside_dict_as_value_with_filter_with_arg() {
+        let input =
+            r#"{% my_tag {key: "Hello {{ name }} {% tag %}"|select:"world is {{ my_var }}"} %}"#;
+        let (result, _context) = plain_parse_tag_v1(input).unwrap();
+        let dict_value = TagValue {
+            token: token(
+                r#"{key: "Hello {{ name }} {% tag %}"|select:"world is {{ my_var }}"}"#,
+                10,
+                1,
+                11,
+            ),
+            value: token(
+                r#"{key: "Hello {{ name }} {% tag %}"|select:"world is {{ my_var }}"}"#,
+                10,
+                1,
+                11,
+            ),
+            children: vec![
+                ValueChild::Value(plain_variable_value("key", 11, 1, 12, None)),
+                ValueChild::Value(template_string_value(
+                    token(
+                        r#""Hello {{ name }} {% tag %}"|select:"world is {{ my_var }}""#,
+                        16,
+                        1,
+                        17,
+                    ),
+                    token(r#""Hello {{ name }} {% tag %}""#, 16, 1, 17),
+                    None,
+                    vec![TagValueFilter {
+                        token: token(r#"|select:"world is {{ my_var }}""#, 44, 1, 45),
+                        name: token("select", 45, 1, 46),
+                        arg: Some(plain_template_string_value(
+                            r#""world is {{ my_var }}""#,
+                            52,
+                            1,
+                            53,
+                            None,
+                        )),
+                    }],
+                    vec![],
+                    vec![],
+                )),
+            ],
+            kind: ValueKind::Dict,
+            spread: None,
+            filters: vec![],
+            used_variables: vec![],
+            assigned_variables: vec![],
+        };
+        assert_eq!(
+            result,
+            Tag::Generic(GenericTag {
+                meta: TagMeta {
+                    token: token(
+                        r#"{% my_tag {key: "Hello {{ name }} {% tag %}"|select:"world is {{ my_var }}"} %}"#,
+                        0,
+                        1,
+                        1
+                    ),
+                    name: token("my_tag", 3, 1, 4),
+                    used_variables: vec![token("key", 11, 1, 12)],
+                    assigned_variables: vec![],
+                },
+                attrs: vec![tag_attr(None, dict_value, false)],
+                is_self_closing: false,
+            })
+        );
+    }
+
+    #[test]
+    fn test_template_string_inside_dict_as_key_and_value() {
+        let input = r#"{% my_tag {"Hello {{ key }}": "World {% tag %}"} %}"#;
+        let (result, _context) = plain_parse_tag_v1(input).unwrap();
+        let dict_value = TagValue {
+            token: token(r#"{"Hello {{ key }}": "World {% tag %}"}"#, 10, 1, 11),
+            value: token(r#"{"Hello {{ key }}": "World {% tag %}"}"#, 10, 1, 11),
+            children: vec![
+                ValueChild::Value(plain_template_string_value(
+                    r#""Hello {{ key }}""#,
+                    11,
+                    1,
+                    12,
+                    None,
+                )),
+                ValueChild::Value(plain_template_string_value(
+                    r#""World {% tag %}""#,
+                    30,
+                    1,
+                    31,
+                    None,
+                )),
+            ],
+            kind: ValueKind::Dict,
+            spread: None,
+            filters: vec![],
+            used_variables: vec![],
+            assigned_variables: vec![],
+        };
+        assert_eq!(
+            result,
+            Tag::Generic(GenericTag {
+                meta: TagMeta {
+                    token: token(
+                        r#"{% my_tag {"Hello {{ key }}": "World {% tag %}"} %}"#,
+                        0,
+                        1,
+                        1
+                    ),
+                    name: token("my_tag", 3, 1, 4),
+                    used_variables: vec![],
+                    assigned_variables: vec![],
+                },
+                attrs: vec![tag_attr(None, dict_value, false)],
+                is_self_closing: false,
+            })
+        );
+    }
+
+    #[test]
+    fn test_template_string_inside_dict_as_key_and_value_with_filters_and_arg() {
+        let input = r#"{% my_tag {"Hello {{ key }}"|lower: "World {% tag %}"|select:"world is {{ my_var }}"} %}"#;
+        let (result, _context) = plain_parse_tag_v1(input).unwrap();
+        let dict_value = TagValue {
+            token: token(
+                r#"{"Hello {{ key }}"|lower: "World {% tag %}"|select:"world is {{ my_var }}"}"#,
+                10,
+                1,
+                11,
+            ),
+            value: token(
+                r#"{"Hello {{ key }}"|lower: "World {% tag %}"|select:"world is {{ my_var }}"}"#,
+                10,
+                1,
+                11,
+            ),
+            children: vec![
+                ValueChild::Value(template_string_value(
+                    token(r#""Hello {{ key }}"|lower"#, 11, 1, 12),
+                    token(r#""Hello {{ key }}""#, 11, 1, 12),
+                    None,
+                    vec![TagValueFilter {
+                        token: token("|lower", 28, 1, 29),
+                        name: token("lower", 29, 1, 30),
+                        arg: None,
+                    }],
+                    vec![],
+                    vec![],
+                )),
+                ValueChild::Value(template_string_value(
+                    token(
+                        r#""World {% tag %}"|select:"world is {{ my_var }}""#,
+                        36,
+                        1,
+                        37,
+                    ),
+                    token(r#""World {% tag %}""#, 36, 1, 37),
+                    None,
+                    vec![TagValueFilter {
+                        token: token(r#"|select:"world is {{ my_var }}""#, 53, 1, 54),
+                        name: token("select", 54, 1, 55),
+                        arg: Some(plain_template_string_value(
+                            r#""world is {{ my_var }}""#,
+                            61,
+                            1,
+                            62,
+                            None,
+                        )),
+                    }],
+                    vec![],
+                    vec![],
+                )),
+            ],
+            kind: ValueKind::Dict,
+            spread: None,
+            filters: vec![],
+            used_variables: vec![],
+            assigned_variables: vec![],
+        };
+        assert_eq!(
+            result,
+            Tag::Generic(GenericTag {
+                meta: TagMeta {
+                    token: token(
+                        r#"{% my_tag {"Hello {{ key }}"|lower: "World {% tag %}"|select:"world is {{ my_var }}"} %}"#,
+                        0,
+                        1,
+                        1
+                    ),
+                    name: token("my_tag", 3, 1, 4),
+                    used_variables: vec![],
+                    assigned_variables: vec![],
+                },
+                attrs: vec![tag_attr(None, dict_value, false)],
+                is_self_closing: false,
+            })
+        );
+    }
+
+    #[test]
+    fn test_template_string_inside_dict_with_spread_and_filter() {
+        let input = r#"{% my_tag {**"Hello {{ name }} {% tag %}"|upper} %}"#;
+        let (result, _context) = plain_parse_tag_v1(input).unwrap();
+        let dict_value = TagValue {
+            token: token(r#"{**"Hello {{ name }} {% tag %}"|upper}"#, 10, 1, 11),
+            value: token(r#"{**"Hello {{ name }} {% tag %}"|upper}"#, 10, 1, 11),
+            children: vec![ValueChild::Value(template_string_value(
+                token(r#"**"Hello {{ name }} {% tag %}"|upper"#, 11, 1, 12),
+                token(r#""Hello {{ name }} {% tag %}""#, 13, 1, 14),
+                Some("**"),
+                vec![TagValueFilter {
+                    token: token("|upper", 41, 1, 42),
+                    name: token("upper", 42, 1, 43),
+                    arg: None,
+                }],
+                vec![],
+                vec![],
+            ))],
+            kind: ValueKind::Dict,
+            spread: None,
+            filters: vec![],
+            used_variables: vec![],
+            assigned_variables: vec![],
+        };
+        assert_eq!(
+            result,
+            Tag::Generic(GenericTag {
+                meta: TagMeta {
+                    token: token(
+                        r#"{% my_tag {**"Hello {{ name }} {% tag %}"|upper} %}"#,
+                        0,
+                        1,
+                        1
+                    ),
+                    name: token("my_tag", 3, 1, 4),
+                    used_variables: vec![],
+                    assigned_variables: vec![],
+                },
+                attrs: vec![tag_attr(None, dict_value, false)],
+                is_self_closing: false,
+            })
+        );
+    }
+
+    // #######################################
+    // TEMPLATE STRING EDGE CASES
+    // #######################################
+
+    #[test]
+    fn test_template_string_comment() {
+        let input = r#"{% my_tag "Hello {# TODO #}" %}"#;
+        let (result, _context) = plain_parse_tag_v1(input).unwrap();
+        assert_eq!(
+            result,
+            Tag::Generic(GenericTag {
+                meta: TagMeta {
+                    token: token(r#"{% my_tag "Hello {# TODO #}" %}"#, 0, 1, 1),
+                    name: token("my_tag", 3, 1, 4),
+                    used_variables: vec![],
+                    assigned_variables: vec![],
+                },
+                attrs: vec![tag_attr(
+                    None,
+                    template_string_value(
+                        token(r#""Hello {# TODO #}""#, 10, 1, 11),
+                        token(r#""Hello {# TODO #}""#, 10, 1, 11),
+                        None,
+                        vec![],
+                        vec![],
+                        vec![],
+                    ),
+                    false,
+                )],
+                is_self_closing: false,
+            }),
+        );
+    }
+
+    #[test]
+    fn test_template_string_mixed() {
+        // Test string with multiple template tags
+        let input = r#"{% my_tag "Hello {{ first_name }} {% lorem 1 w %} {# TODO #}" %}"#;
+        let (result, _context) = plain_parse_tag_v1(input).unwrap();
+        assert_eq!(
+            result,
+            Tag::Generic(GenericTag {
+                meta: TagMeta {
+                    token: token(
+                        r#"{% my_tag "Hello {{ first_name }} {% lorem 1 w %} {# TODO #}" %}"#,
+                        0,
+                        1,
+                        1
+                    ),
+                    name: token("my_tag", 3, 1, 4),
+                    used_variables: vec![],
+                    assigned_variables: vec![],
+                },
+                attrs: vec![tag_attr(
+                    None,
+                    template_string_value(
+                        token(
+                            r#""Hello {{ first_name }} {% lorem 1 w %} {# TODO #}""#,
+                            10,
+                            1,
+                            11
+                        ),
+                        token(
+                            r#""Hello {{ first_name }} {% lorem 1 w %} {# TODO #}""#,
+                            10,
+                            1,
+                            11
+                        ),
+                        None,
+                        vec![],
+                        vec![],
+                        vec![],
+                    ),
+                    false,
+                )],
+                is_self_closing: false,
+            }),
+        );
+    }
+
+    #[test]
+    fn test_template_string_invalid() {
+        // Test incomplete template tags (should not be marked as template_string)
+        let inputs = vec![
+            r#"{% my_tag "Hello {{ first_name" %}"#,
+            r#"{% my_tag "Hello {% first_name" %}"#,
+            r#"{% my_tag "Hello {# first_name" %}"#,
+            r#"{% my_tag "Hello {{ first_name %}" %}"#,
+            r#"{% my_tag "Hello first_name }}" %}"#,
+            r#"{% my_tag "Hello }} first_name {{" %}"#,
+        ];
+        for input in inputs {
+            let (result, _context) = plain_parse_tag_v1(input).unwrap();
+
+            // Extract the string value from the input (between quotes)
+            let string_start = input.find('"').unwrap() + 1;
+            let string_end = input.rfind('"').unwrap();
+            let string_value = &input[string_start..string_end];
+
+            assert_eq!(
+                result,
+                Tag::Generic(GenericTag {
+                    meta: TagMeta {
+                        token: token(input, 0, 1, 1),
+                        name: token("my_tag", 3, 1, 4),
+                        used_variables: vec![],
+                        assigned_variables: vec![],
+                    },
+                    attrs: vec![tag_attr(
+                        None,
+                        plain_string_value(&format!(r#""{}""#, string_value), 10, 1, 11, None),
+                        false,
+                    )],
+                    is_self_closing: false,
+                }),
+            );
+        }
+    }
+
+    #[test]
+    fn test_template_string_translation() {
+        // Test that template strings are not detected in translation strings
+        let input = r#"{% my_tag _("{{ var }}") %}"#;
+        let (result, _context) = plain_parse_tag_v1(input).unwrap();
+        assert_eq!(
+            result,
+            Tag::Generic(GenericTag {
+                meta: TagMeta {
+                    token: token(r#"{% my_tag _("{{ var }}") %}"#, 0, 1, 1),
+                    name: token("my_tag", 3, 1, 4),
+                    used_variables: vec![],
+                    assigned_variables: vec![],
+                },
+                attrs: vec![tag_attr(
+                    None,
+                    plain_translation_value(r#"_("{{ var }}")"#, 10, 1, 11, None),
+                    false
+                )],
+                is_self_closing: false,
+            })
+        );
+    }
+}

--- a/crates/djc-template-parser/tests/tag_parser_translation.rs
+++ b/crates/djc-template-parser/tests/tag_parser_translation.rs
@@ -1,0 +1,901 @@
+// Each of the `tag_parser_<data_type>.rs` file tests following cases:
+//  1. as arg
+//  2. as multiple args
+//  3. as arg with filter without filter arg
+//  4. as arg with filter with filter arg
+//  5. as arg with `...` spread
+//  6. as kwarg
+//  7. as multiple kwargs
+//  8. as kwarg with filter without filter arg
+//  9. as kwarg with filter with filter arg
+// 10. as both arg and kwarg with filters
+// 11. as both arg and kwarg with filters and arg with `...` spreads
+// 12. inside list
+// 13. inside list with filter without filter arg
+// 14. inside list with filter with filter arg
+// 15. inside list with filter with filter arg and `*` spread.
+// 16. inside list with `*` spread.
+// 17. inside dict as value
+// 18. inside dict as value with filter with filter arg
+// 19. inside dict as key and value
+// 20. inside dict as key and value, both with filters, and value with filter arg.
+// 21. inside dict as neither key nor value, with `**` spread and filter without arg
+
+mod common;
+
+#[cfg(test)]
+mod tests {
+    use std::vec;
+
+    use djc_template_parser::ast::{
+        GenericTag, Tag, TagMeta, TagValue, TagValueFilter, Token, ValueChild, ValueKind,
+    };
+
+    use super::common::{
+        plain_parse_tag_v1, plain_translation_value, plain_variable_value, tag_attr, token,
+        translation_value, variable_value,
+    };
+
+    #[test]
+    fn test_translation_as_arg() {
+        let input = r#"{% my_tag _("hello") %}"#;
+        let (result, _context) = plain_parse_tag_v1(input).unwrap();
+        assert_eq!(
+            result,
+            Tag::Generic(GenericTag {
+                meta: TagMeta {
+                    token: token(r#"{% my_tag _("hello") %}"#, 0, 1, 1),
+                    name: token("my_tag", 3, 1, 4),
+                    used_variables: vec![],
+                    assigned_variables: vec![],
+                },
+                attrs: vec![tag_attr(
+                    None,
+                    plain_translation_value(r#"_("hello")"#, 10, 1, 11, None),
+                    false
+                )],
+                is_self_closing: false,
+            })
+        );
+    }
+
+    #[test]
+    fn test_translation_as_multiple_args() {
+        let input = r#"{% my_tag _("hello") _("world") %}"#;
+        let (result, _context) = plain_parse_tag_v1(input).unwrap();
+        assert_eq!(
+            result,
+            Tag::Generic(GenericTag {
+                meta: TagMeta {
+                    token: token(r#"{% my_tag _("hello") _("world") %}"#, 0, 1, 1),
+                    name: token("my_tag", 3, 1, 4),
+                    used_variables: vec![],
+                    assigned_variables: vec![],
+                },
+                attrs: vec![
+                    tag_attr(
+                        None,
+                        plain_translation_value(r#"_("hello")"#, 10, 1, 11, None),
+                        false
+                    ),
+                    tag_attr(
+                        None,
+                        plain_translation_value(r#"_("world")"#, 21, 1, 22, None),
+                        false
+                    ),
+                ],
+                is_self_closing: false,
+            })
+        );
+    }
+
+    #[test]
+    fn test_translation_as_arg_with_filter_without_arg() {
+        let input = r#"{% my_tag _("hello")|lower %}"#;
+        let (result, _context) = plain_parse_tag_v1(input).unwrap();
+        assert_eq!(
+            result,
+            Tag::Generic(GenericTag {
+                meta: TagMeta {
+                    token: token(r#"{% my_tag _("hello")|lower %}"#, 0, 1, 1),
+                    name: token("my_tag", 3, 1, 4),
+                    used_variables: vec![],
+                    assigned_variables: vec![],
+                },
+                attrs: vec![tag_attr(
+                    None,
+                    translation_value(
+                        token(r#"_("hello")|lower"#, 10, 1, 11),
+                        token(r#"_("hello")"#, 10, 1, 11),
+                        None,
+                        vec![TagValueFilter {
+                            token: token("|lower", 20, 1, 21),
+                            name: token("lower", 21, 1, 22),
+                            arg: None,
+                        }],
+                        vec![],
+                        vec![],
+                    ),
+                    false
+                )],
+                is_self_closing: false,
+            })
+        );
+    }
+
+    #[test]
+    fn test_translation_as_arg_with_filter_with_arg() {
+        let input = r#"{% my_tag _("hello")|select:_("world") %}"#;
+        let (result, _context) = plain_parse_tag_v1(input).unwrap();
+        assert_eq!(
+            result,
+            Tag::Generic(GenericTag {
+                meta: TagMeta {
+                    token: token(r#"{% my_tag _("hello")|select:_("world") %}"#, 0, 1, 1),
+                    name: token("my_tag", 3, 1, 4),
+                    used_variables: vec![],
+                    assigned_variables: vec![],
+                },
+                attrs: vec![tag_attr(
+                    None,
+                    translation_value(
+                        token(r#"_("hello")|select:_("world")"#, 10, 1, 11),
+                        token(r#"_("hello")"#, 10, 1, 11),
+                        None,
+                        vec![TagValueFilter {
+                            token: token(r#"|select:_("world")"#, 20, 1, 21),
+                            name: token("select", 21, 1, 22),
+                            arg: Some(plain_translation_value(r#"_("world")"#, 28, 1, 29, None)),
+                        }],
+                        vec![],
+                        vec![],
+                    ),
+                    false
+                )],
+                is_self_closing: false,
+            })
+        );
+    }
+
+    #[test]
+    fn test_translation_as_arg_with_spread() {
+        let input = r#"{% my_tag ..._("hello") %}"#;
+        let (result, _context) = plain_parse_tag_v1(input).unwrap();
+        assert_eq!(
+            result,
+            Tag::Generic(GenericTag {
+                meta: TagMeta {
+                    token: token(r#"{% my_tag ..._("hello") %}"#, 0, 1, 1),
+                    name: token("my_tag", 3, 1, 4),
+                    used_variables: vec![],
+                    assigned_variables: vec![],
+                },
+                attrs: vec![tag_attr(
+                    None,
+                    plain_translation_value(r#"_("hello")"#, 10, 1, 11, Some("...")),
+                    false
+                )],
+                is_self_closing: false,
+            })
+        );
+    }
+
+    #[test]
+    fn test_translation_as_kwarg() {
+        let input = r#"{% my_tag key=_("hello") %}"#;
+        let (result, _context) = plain_parse_tag_v1(input).unwrap();
+        assert_eq!(
+            result,
+            Tag::Generic(GenericTag {
+                meta: TagMeta {
+                    token: token(r#"{% my_tag key=_("hello") %}"#, 0, 1, 1),
+                    name: token("my_tag", 3, 1, 4),
+                    used_variables: vec![],
+                    assigned_variables: vec![],
+                },
+                attrs: vec![tag_attr(
+                    Some(token("key", 10, 1, 11)),
+                    plain_translation_value(r#"_("hello")"#, 14, 1, 15, None),
+                    false
+                )],
+                is_self_closing: false,
+            })
+        );
+    }
+
+    #[test]
+    fn test_translation_as_multiple_kwargs() {
+        let input = r#"{% my_tag key1=_("hello") key2=_("world") %}"#;
+        let (result, _context) = plain_parse_tag_v1(input).unwrap();
+        assert_eq!(
+            result,
+            Tag::Generic(GenericTag {
+                meta: TagMeta {
+                    token: token(r#"{% my_tag key1=_("hello") key2=_("world") %}"#, 0, 1, 1),
+                    name: token("my_tag", 3, 1, 4),
+                    used_variables: vec![],
+                    assigned_variables: vec![],
+                },
+                attrs: vec![
+                    tag_attr(
+                        Some(token("key1", 10, 1, 11)),
+                        plain_translation_value(r#"_("hello")"#, 15, 1, 16, None),
+                        false
+                    ),
+                    tag_attr(
+                        Some(token("key2", 26, 1, 27)),
+                        plain_translation_value(r#"_("world")"#, 31, 1, 32, None),
+                        false
+                    ),
+                ],
+                is_self_closing: false,
+            })
+        );
+    }
+
+    #[test]
+    fn test_translation_as_kwarg_with_filter_without_arg() {
+        let input = r#"{% my_tag key=_("hello")|upper %}"#;
+        let (result, _context) = plain_parse_tag_v1(input).unwrap();
+        assert_eq!(
+            result,
+            Tag::Generic(GenericTag {
+                meta: TagMeta {
+                    token: token(r#"{% my_tag key=_("hello")|upper %}"#, 0, 1, 1),
+                    name: token("my_tag", 3, 1, 4),
+                    used_variables: vec![],
+                    assigned_variables: vec![],
+                },
+                attrs: vec![tag_attr(
+                    Some(token("key", 10, 1, 11)),
+                    translation_value(
+                        token(r#"_("hello")|upper"#, 14, 1, 15),
+                        token(r#"_("hello")"#, 14, 1, 15),
+                        None,
+                        vec![TagValueFilter {
+                            token: token("|upper", 24, 1, 25),
+                            name: token("upper", 25, 1, 26),
+                            arg: None,
+                        }],
+                        vec![],
+                        vec![],
+                    ),
+                    false
+                )],
+                is_self_closing: false,
+            })
+        );
+    }
+
+    #[test]
+    fn test_translation_as_kwarg_with_filter_with_arg() {
+        let input = r#"{% my_tag key=_("hello")|select:_("world") %}"#;
+        let (result, _context) = plain_parse_tag_v1(input).unwrap();
+        assert_eq!(
+            result,
+            Tag::Generic(GenericTag {
+                meta: TagMeta {
+                    token: token(r#"{% my_tag key=_("hello")|select:_("world") %}"#, 0, 1, 1),
+                    name: token("my_tag", 3, 1, 4),
+                    used_variables: vec![],
+                    assigned_variables: vec![],
+                },
+                attrs: vec![tag_attr(
+                    Some(token("key", 10, 1, 11)),
+                    translation_value(
+                        token(r#"_("hello")|select:_("world")"#, 14, 1, 15),
+                        token(r#"_("hello")"#, 14, 1, 15),
+                        None,
+                        vec![TagValueFilter {
+                            token: token(r#"|select:_("world")"#, 24, 1, 25),
+                            name: token("select", 25, 1, 26),
+                            arg: Some(plain_translation_value(r#"_("world")"#, 32, 1, 33, None)),
+                        }],
+                        vec![],
+                        vec![],
+                    ),
+                    false
+                )],
+                is_self_closing: false,
+            })
+        );
+    }
+
+    #[test]
+    fn test_translation_as_both_arg_and_kwarg_with_filters() {
+        let input = r#"{% my_tag _("hello")|lower key=_("world")|upper %}"#;
+        let (result, _context) = plain_parse_tag_v1(input).unwrap();
+        assert_eq!(
+            result,
+            Tag::Generic(GenericTag {
+                meta: TagMeta {
+                    token: token(
+                        r#"{% my_tag _("hello")|lower key=_("world")|upper %}"#,
+                        0,
+                        1,
+                        1
+                    ),
+                    name: token("my_tag", 3, 1, 4),
+                    used_variables: vec![],
+                    assigned_variables: vec![],
+                },
+                attrs: vec![
+                    tag_attr(
+                        None,
+                        translation_value(
+                            token(r#"_("hello")|lower"#, 10, 1, 11),
+                            token(r#"_("hello")"#, 10, 1, 11),
+                            None,
+                            vec![TagValueFilter {
+                                token: token("|lower", 20, 1, 21),
+                                name: token("lower", 21, 1, 22),
+                                arg: None,
+                            }],
+                            vec![],
+                            vec![],
+                        ),
+                        false
+                    ),
+                    tag_attr(
+                        Some(token("key", 27, 1, 28)),
+                        translation_value(
+                            token(r#"_("world")|upper"#, 31, 1, 32),
+                            token(r#"_("world")"#, 31, 1, 32),
+                            None,
+                            vec![TagValueFilter {
+                                token: token("|upper", 41, 1, 42),
+                                name: token("upper", 42, 1, 43),
+                                arg: None,
+                            }],
+                            vec![],
+                            vec![],
+                        ),
+                        false
+                    ),
+                ],
+                is_self_closing: false,
+            })
+        );
+    }
+
+    #[test]
+    fn test_translation_as_both_arg_and_kwarg_with_filters_and_spread() {
+        let input = r#"{% my_tag ..._("hello")|lower key=_("world")|upper %}"#;
+        let (result, _context) = plain_parse_tag_v1(input).unwrap();
+        assert_eq!(
+            result,
+            Tag::Generic(GenericTag {
+                meta: TagMeta {
+                    token: token(
+                        r#"{% my_tag ..._("hello")|lower key=_("world")|upper %}"#,
+                        0,
+                        1,
+                        1
+                    ),
+                    name: token("my_tag", 3, 1, 4),
+                    used_variables: vec![],
+                    assigned_variables: vec![],
+                },
+                attrs: vec![
+                    tag_attr(
+                        None,
+                        translation_value(
+                            token(r#"..._("hello")|lower"#, 10, 1, 11),
+                            token(r#"_("hello")"#, 13, 1, 14),
+                            Some("..."),
+                            vec![TagValueFilter {
+                                token: token("|lower", 23, 1, 24),
+                                name: token("lower", 24, 1, 25),
+                                arg: None,
+                            }],
+                            vec![],
+                            vec![],
+                        ),
+                        false
+                    ),
+                    tag_attr(
+                        Some(token("key", 30, 1, 31)),
+                        translation_value(
+                            token(r#"_("world")|upper"#, 34, 1, 35),
+                            token(r#"_("world")"#, 34, 1, 35),
+                            None,
+                            vec![TagValueFilter {
+                                token: token("|upper", 44, 1, 45),
+                                name: token("upper", 45, 1, 46),
+                                arg: None,
+                            }],
+                            vec![],
+                            vec![],
+                        ),
+                        false
+                    ),
+                ],
+                is_self_closing: false,
+            })
+        );
+    }
+
+    #[test]
+    fn test_translation_inside_list() {
+        let input = r#"{% my_tag [_("hello")] %}"#;
+        let (result, _context) = plain_parse_tag_v1(input).unwrap();
+        let list_value = TagValue {
+            token: token(r#"[_("hello")]"#, 10, 1, 11),
+            value: token(r#"[_("hello")]"#, 10, 1, 11),
+            children: vec![ValueChild::Value(plain_translation_value(
+                r#"_("hello")"#,
+                11,
+                1,
+                12,
+                None,
+            ))],
+            kind: ValueKind::List,
+            spread: None,
+            filters: vec![],
+            used_variables: vec![],
+            assigned_variables: vec![],
+        };
+        assert_eq!(
+            result,
+            Tag::Generic(GenericTag {
+                meta: TagMeta {
+                    token: token(r#"{% my_tag [_("hello")] %}"#, 0, 1, 1),
+                    name: token("my_tag", 3, 1, 4),
+                    used_variables: vec![],
+                    assigned_variables: vec![],
+                },
+                attrs: vec![tag_attr(None, list_value, false)],
+                is_self_closing: false,
+            })
+        );
+    }
+
+    #[test]
+    fn test_translation_inside_list_with_filter_without_arg() {
+        let input = r#"{% my_tag [_("hello")|lower] %}"#;
+        let (result, _context) = plain_parse_tag_v1(input).unwrap();
+        let list_value = TagValue {
+            token: token(r#"[_("hello")|lower]"#, 10, 1, 11),
+            value: token(r#"[_("hello")|lower]"#, 10, 1, 11),
+            children: vec![ValueChild::Value(translation_value(
+                token(r#"_("hello")|lower"#, 11, 1, 12),
+                token(r#"_("hello")"#, 11, 1, 12),
+                None,
+                vec![TagValueFilter {
+                    token: token("|lower", 21, 1, 22),
+                    name: token("lower", 22, 1, 23),
+                    arg: None,
+                }],
+                vec![],
+                vec![],
+            ))],
+            kind: ValueKind::List,
+            spread: None,
+            filters: vec![],
+            used_variables: vec![],
+            assigned_variables: vec![],
+        };
+        assert_eq!(
+            result,
+            Tag::Generic(GenericTag {
+                meta: TagMeta {
+                    token: token(r#"{% my_tag [_("hello")|lower] %}"#, 0, 1, 1),
+                    name: token("my_tag", 3, 1, 4),
+                    used_variables: vec![],
+                    assigned_variables: vec![],
+                },
+                attrs: vec![tag_attr(None, list_value, false)],
+                is_self_closing: false,
+            })
+        );
+    }
+
+    #[test]
+    fn test_translation_inside_list_with_filter_with_arg() {
+        let input = r#"{% my_tag [_("hello")|select:_("world")] %}"#;
+        let (result, _context) = plain_parse_tag_v1(input).unwrap();
+        let list_value = TagValue {
+            token: token(r#"[_("hello")|select:_("world")]"#, 10, 1, 11),
+            value: token(r#"[_("hello")|select:_("world")]"#, 10, 1, 11),
+            children: vec![ValueChild::Value(translation_value(
+                token(r#"_("hello")|select:_("world")"#, 11, 1, 12),
+                token(r#"_("hello")"#, 11, 1, 12),
+                None,
+                vec![TagValueFilter {
+                    token: token(r#"|select:_("world")"#, 21, 1, 22),
+                    name: token("select", 22, 1, 23),
+                    arg: Some(plain_translation_value(r#"_("world")"#, 29, 1, 30, None)),
+                }],
+                vec![],
+                vec![],
+            ))],
+            kind: ValueKind::List,
+            spread: None,
+            filters: vec![],
+            used_variables: vec![],
+            assigned_variables: vec![],
+        };
+        assert_eq!(
+            result,
+            Tag::Generic(GenericTag {
+                meta: TagMeta {
+                    token: token(r#"{% my_tag [_("hello")|select:_("world")] %}"#, 0, 1, 1),
+                    name: token("my_tag", 3, 1, 4),
+                    used_variables: vec![],
+                    assigned_variables: vec![],
+                },
+                attrs: vec![tag_attr(None, list_value, false)],
+                is_self_closing: false,
+            })
+        );
+    }
+
+    #[test]
+    fn test_translation_inside_list_with_filter_with_arg_and_spread() {
+        let input = r#"{% my_tag [*_("hello")|select:_("world")] %}"#;
+        let (result, _context) = plain_parse_tag_v1(input).unwrap();
+        let list_value = TagValue {
+            token: token(r#"[*_("hello")|select:_("world")]"#, 10, 1, 11),
+            value: token(r#"[*_("hello")|select:_("world")]"#, 10, 1, 11),
+            children: vec![ValueChild::Value(translation_value(
+                token(r#"*_("hello")|select:_("world")"#, 11, 1, 12),
+                token(r#"_("hello")"#, 12, 1, 13),
+                Some("*"),
+                vec![TagValueFilter {
+                    token: token(r#"|select:_("world")"#, 22, 1, 23),
+                    name: token("select", 23, 1, 24),
+                    arg: Some(plain_translation_value(r#"_("world")"#, 30, 1, 31, None)),
+                }],
+                vec![],
+                vec![],
+            ))],
+            kind: ValueKind::List,
+            spread: None,
+            filters: vec![],
+            used_variables: vec![],
+            assigned_variables: vec![],
+        };
+        assert_eq!(
+            result,
+            Tag::Generic(GenericTag {
+                meta: TagMeta {
+                    token: token(r#"{% my_tag [*_("hello")|select:_("world")] %}"#, 0, 1, 1),
+                    name: token("my_tag", 3, 1, 4),
+                    used_variables: vec![],
+                    assigned_variables: vec![],
+                },
+                attrs: vec![tag_attr(None, list_value, false)],
+                is_self_closing: false,
+            })
+        );
+    }
+
+    #[test]
+    fn test_translation_inside_list_with_spread() {
+        let input = r#"{% my_tag [*_("hello")] %}"#;
+        let (result, _context) = plain_parse_tag_v1(input).unwrap();
+        let list_value = TagValue {
+            token: token(r#"[*_("hello")]"#, 10, 1, 11),
+            value: token(r#"[*_("hello")]"#, 10, 1, 11),
+            children: vec![ValueChild::Value(plain_translation_value(
+                r#"_("hello")"#,
+                11,
+                1,
+                12,
+                Some("*"),
+            ))],
+            kind: ValueKind::List,
+            spread: None,
+            filters: vec![],
+            used_variables: vec![],
+            assigned_variables: vec![],
+        };
+        assert_eq!(
+            result,
+            Tag::Generic(GenericTag {
+                meta: TagMeta {
+                    token: token(r#"{% my_tag [*_("hello")] %}"#, 0, 1, 1),
+                    name: token("my_tag", 3, 1, 4),
+                    used_variables: vec![],
+                    assigned_variables: vec![],
+                },
+                attrs: vec![tag_attr(None, list_value, false)],
+                is_self_closing: false,
+            })
+        );
+    }
+
+    #[test]
+    fn test_translation_inside_dict_as_value() {
+        let input = r#"{% my_tag {key: _("hello")} %}"#;
+        let (result, _context) = plain_parse_tag_v1(input).unwrap();
+        let dict_value = TagValue {
+            token: token(r#"{key: _("hello")}"#, 10, 1, 11),
+            value: token(r#"{key: _("hello")}"#, 10, 1, 11),
+            children: vec![
+                ValueChild::Value(plain_variable_value("key", 11, 1, 12, None)),
+                ValueChild::Value(plain_translation_value(r#"_("hello")"#, 16, 1, 17, None)),
+            ],
+            kind: ValueKind::Dict,
+            spread: None,
+            filters: vec![],
+            used_variables: vec![],
+            assigned_variables: vec![],
+        };
+        assert_eq!(
+            result,
+            Tag::Generic(GenericTag {
+                meta: TagMeta {
+                    token: token(r#"{% my_tag {key: _("hello")} %}"#, 0, 1, 1),
+                    name: token("my_tag", 3, 1, 4),
+                    used_variables: vec![token("key", 11, 1, 12)],
+                    assigned_variables: vec![],
+                },
+                attrs: vec![tag_attr(None, dict_value, false)],
+                is_self_closing: false,
+            })
+        );
+    }
+
+    #[test]
+    fn test_translation_inside_dict_as_value_with_filter_with_arg() {
+        let input = r#"{% my_tag {key: _("hello")|select:_("world")} %}"#;
+        let (result, _context) = plain_parse_tag_v1(input).unwrap();
+        let dict_value = TagValue {
+            token: token(r#"{key: _("hello")|select:_("world")}"#, 10, 1, 11),
+            value: token(r#"{key: _("hello")|select:_("world")}"#, 10, 1, 11),
+            children: vec![
+                ValueChild::Value(plain_variable_value("key", 11, 1, 12, None)),
+                ValueChild::Value(translation_value(
+                    token(r#"_("hello")|select:_("world")"#, 16, 1, 17),
+                    token(r#"_("hello")"#, 16, 1, 17),
+                    None,
+                    vec![TagValueFilter {
+                        token: token(r#"|select:_("world")"#, 26, 1, 27),
+                        name: token("select", 27, 1, 28),
+                        arg: Some(plain_translation_value(r#"_("world")"#, 34, 1, 35, None)),
+                    }],
+                    vec![],
+                    vec![],
+                )),
+            ],
+            kind: ValueKind::Dict,
+            spread: None,
+            filters: vec![],
+            used_variables: vec![],
+            assigned_variables: vec![],
+        };
+        assert_eq!(
+            result,
+            Tag::Generic(GenericTag {
+                meta: TagMeta {
+                    token: token(
+                        r#"{% my_tag {key: _("hello")|select:_("world")} %}"#,
+                        0,
+                        1,
+                        1
+                    ),
+                    name: token("my_tag", 3, 1, 4),
+                    used_variables: vec![token("key", 11, 1, 12)],
+                    assigned_variables: vec![],
+                },
+                attrs: vec![tag_attr(None, dict_value, false)],
+                is_self_closing: false,
+            })
+        );
+    }
+
+    #[test]
+    fn test_translation_inside_dict_as_key_and_value() {
+        let input = r#"{% my_tag {_("key"): _("hello")} %}"#;
+        let (result, _context) = plain_parse_tag_v1(input).unwrap();
+        let dict_value = TagValue {
+            token: token(r#"{_("key"): _("hello")}"#, 10, 1, 11),
+            value: token(r#"{_("key"): _("hello")}"#, 10, 1, 11),
+            children: vec![
+                ValueChild::Value(plain_translation_value(r#"_("key")"#, 11, 1, 12, None)),
+                ValueChild::Value(plain_translation_value(r#"_("hello")"#, 21, 1, 22, None)),
+            ],
+            kind: ValueKind::Dict,
+            spread: None,
+            filters: vec![],
+            used_variables: vec![],
+            assigned_variables: vec![],
+        };
+        assert_eq!(
+            result,
+            Tag::Generic(GenericTag {
+                meta: TagMeta {
+                    token: token(r#"{% my_tag {_("key"): _("hello")} %}"#, 0, 1, 1),
+                    name: token("my_tag", 3, 1, 4),
+                    used_variables: vec![],
+                    assigned_variables: vec![],
+                },
+                attrs: vec![tag_attr(None, dict_value, false)],
+                is_self_closing: false,
+            })
+        );
+    }
+
+    #[test]
+    fn test_translation_inside_dict_as_key_and_value_with_filters_and_arg() {
+        let input = r#"{% my_tag {_("key")|lower: _("hello")|select:_("world")} %}"#;
+        let (result, _context) = plain_parse_tag_v1(input).unwrap();
+        let dict_value = TagValue {
+            token: token(
+                r#"{_("key")|lower: _("hello")|select:_("world")}"#,
+                10,
+                1,
+                11,
+            ),
+            value: token(
+                r#"{_("key")|lower: _("hello")|select:_("world")}"#,
+                10,
+                1,
+                11,
+            ),
+            children: vec![
+                ValueChild::Value(translation_value(
+                    token(r#"_("key")|lower"#, 11, 1, 12),
+                    token(r#"_("key")"#, 11, 1, 12),
+                    None,
+                    vec![TagValueFilter {
+                        token: token("|lower", 19, 1, 20),
+                        name: token("lower", 20, 1, 21),
+                        arg: None,
+                    }],
+                    vec![],
+                    vec![],
+                )),
+                ValueChild::Value(translation_value(
+                    token(r#"_("hello")|select:_("world")"#, 27, 1, 28),
+                    token(r#"_("hello")"#, 27, 1, 28),
+                    None,
+                    vec![TagValueFilter {
+                        token: token(r#"|select:_("world")"#, 37, 1, 38),
+                        name: token("select", 38, 1, 39),
+                        arg: Some(plain_translation_value(r#"_("world")"#, 45, 1, 46, None)),
+                    }],
+                    vec![],
+                    vec![],
+                )),
+            ],
+            kind: ValueKind::Dict,
+            spread: None,
+            filters: vec![],
+            used_variables: vec![],
+            assigned_variables: vec![],
+        };
+        assert_eq!(
+            result,
+            Tag::Generic(GenericTag {
+                meta: TagMeta {
+                    token: token(
+                        r#"{% my_tag {_("key")|lower: _("hello")|select:_("world")} %}"#,
+                        0,
+                        1,
+                        1
+                    ),
+                    name: token("my_tag", 3, 1, 4),
+                    used_variables: vec![],
+                    assigned_variables: vec![],
+                },
+                attrs: vec![tag_attr(None, dict_value, false)],
+                is_self_closing: false,
+            })
+        );
+    }
+
+    #[test]
+    fn test_translation_inside_dict_with_spread_and_filter() {
+        let input = r#"{% my_tag {**_("hello")|upper} %}"#;
+        let (result, _context) = plain_parse_tag_v1(input).unwrap();
+        let dict_value = TagValue {
+            token: token(r#"{**_("hello")|upper}"#, 10, 1, 11),
+            value: token(r#"{**_("hello")|upper}"#, 10, 1, 11),
+            children: vec![ValueChild::Value(translation_value(
+                token(r#"**_("hello")|upper"#, 11, 1, 12),
+                token(r#"_("hello")"#, 13, 1, 14),
+                Some("**"),
+                vec![TagValueFilter {
+                    token: token("|upper", 23, 1, 24),
+                    name: token("upper", 24, 1, 25),
+                    arg: None,
+                }],
+                vec![],
+                vec![],
+            ))],
+            kind: ValueKind::Dict,
+            spread: None,
+            filters: vec![],
+            used_variables: vec![],
+            assigned_variables: vec![],
+        };
+        assert_eq!(
+            result,
+            Tag::Generic(GenericTag {
+                meta: TagMeta {
+                    token: token(r#"{% my_tag {**_("hello")|upper} %}"#, 0, 1, 1),
+                    name: token("my_tag", 3, 1, 4),
+                    used_variables: vec![],
+                    assigned_variables: vec![],
+                },
+                attrs: vec![tag_attr(None, dict_value, false)],
+                is_self_closing: false,
+            })
+        );
+    }
+
+    // #######################################
+    // TRANSLATIONS EDGE CASES
+    // #######################################
+
+    #[test]
+    fn test_translation_single_quoted() {
+        let input = r#"{% my_tag _('hello world') %}"#;
+        let (result, _context) = plain_parse_tag_v1(input).unwrap();
+        assert_eq!(
+            result,
+            Tag::Generic(GenericTag {
+                meta: TagMeta {
+                    token: token(r#"{% my_tag _('hello world') %}"#, 0, 1, 1),
+                    name: token("my_tag", 3, 1, 4),
+                    used_variables: vec![],
+                    assigned_variables: vec![],
+                },
+                attrs: vec![tag_attr(
+                    None,
+                    plain_translation_value("_('hello world')", 10, 1, 11, None),
+                    false
+                )],
+                is_self_closing: false,
+            })
+        );
+    }
+
+    #[test]
+    fn test_translation_whitespace() {
+        let input = "{% my_tag value|default:_( 'hello' ) %}";
+        let (result, _context) = plain_parse_tag_v1(input).unwrap();
+        assert_eq!(
+            result,
+            Tag::Generic(GenericTag {
+                meta: TagMeta {
+                    token: token("{% my_tag value|default:_( 'hello' ) %}", 0, 1, 1),
+                    name: token("my_tag", 3, 1, 4),
+                    used_variables: vec![token("value", 10, 1, 11)],
+                    assigned_variables: vec![],
+                },
+                attrs: vec![tag_attr(
+                    None,
+                    variable_value(
+                        token("value|default:_( 'hello' )", 10, 1, 11),
+                        token("value", 10, 1, 11),
+                        None,
+                        vec![TagValueFilter {
+                            name: token("default", 16, 1, 17),
+                            token: token("|default:_( 'hello' )", 15, 1, 16),
+                            arg: Some(translation_value(
+                                token("_( 'hello' )", 24, 1, 25),
+                                Token {
+                                    content: "_('hello')".to_string(),
+                                    start_index: 24,
+                                    end_index: 36,
+                                    line_col: (1, 25),
+                                },
+                                None,
+                                vec![],
+                                vec![],
+                                vec![],
+                            )),
+                        }],
+                        vec![],
+                        vec![],
+                    ),
+                    false,
+                )],
+                is_self_closing: false,
+            }),
+        );
+    }
+}

--- a/crates/djc-template-parser/tests/tag_parser_variable.rs
+++ b/crates/djc-template-parser/tests/tag_parser_variable.rs
@@ -1,0 +1,833 @@
+// Each of the `tag_parser_<data_type>.rs` file tests following cases:
+//  1. as arg
+//  2. as multiple args
+//  3. as arg with filter without filter arg
+//  4. as arg with filter with filter arg
+//  5. as arg with `...` spread
+//  6. as kwarg
+//  7. as multiple kwargs
+//  8. as kwarg with filter without filter arg
+//  9. as kwarg with filter with filter arg
+// 10. as both arg and kwarg with filters
+// 11. as both arg and kwarg with filters and arg with `...` spreads
+// 12. inside list
+// 13. inside list with filter without filter arg
+// 14. inside list with filter with filter arg
+// 15. inside list with filter with filter arg and `*` spread.
+// 16. inside list with `*` spread.
+// 17. inside dict as value
+// 18. inside dict as value with filter with filter arg
+// 19. inside dict as key and value
+// 20. inside dict as key and value, both with filters, and value with filter arg.
+// 21. inside dict as neither key nor value, with `**` spread and filter without arg
+
+mod common;
+
+#[cfg(test)]
+mod tests {
+    use std::vec;
+
+    use djc_template_parser::ast::{
+        GenericTag, Tag, TagMeta, TagValue, TagValueFilter, ValueChild, ValueKind,
+    };
+
+    use super::common::{
+        plain_parse_tag_v1, plain_variable_value, tag_attr, token, variable_value,
+    };
+
+    #[test]
+    fn test_variable_as_arg() {
+        let input = "{% my_tag my_var %}";
+        let (result, _context) = plain_parse_tag_v1(input).unwrap();
+        assert_eq!(
+            result,
+            Tag::Generic(GenericTag {
+                meta: TagMeta {
+                    token: token("{% my_tag my_var %}", 0, 1, 1),
+                    name: token("my_tag", 3, 1, 4),
+                    used_variables: vec![token("my_var", 10, 1, 11)],
+                    assigned_variables: vec![],
+                },
+                attrs: vec![tag_attr(
+                    None,
+                    plain_variable_value("my_var", 10, 1, 11, None),
+                    false
+                )],
+                is_self_closing: false,
+            })
+        );
+    }
+
+    #[test]
+    fn test_variable_as_multiple_args() {
+        let input = "{% my_tag my_var1 my_var2 %}";
+        let (result, _context) = plain_parse_tag_v1(input).unwrap();
+        assert_eq!(
+            result,
+            Tag::Generic(GenericTag {
+                meta: TagMeta {
+                    token: token("{% my_tag my_var1 my_var2 %}", 0, 1, 1),
+                    name: token("my_tag", 3, 1, 4),
+                    used_variables: vec![token("my_var1", 10, 1, 11), token("my_var2", 18, 1, 19),],
+                    assigned_variables: vec![],
+                },
+                attrs: vec![
+                    tag_attr(
+                        None,
+                        plain_variable_value("my_var1", 10, 1, 11, None),
+                        false
+                    ),
+                    tag_attr(
+                        None,
+                        plain_variable_value("my_var2", 18, 1, 19, None),
+                        false
+                    ),
+                ],
+                is_self_closing: false,
+            })
+        );
+    }
+
+    #[test]
+    fn test_variable_as_arg_with_filter_without_arg() {
+        let input = "{% my_tag my_var|lower %}";
+        let (result, _context) = plain_parse_tag_v1(input).unwrap();
+        assert_eq!(
+            result,
+            Tag::Generic(GenericTag {
+                meta: TagMeta {
+                    token: token("{% my_tag my_var|lower %}", 0, 1, 1),
+                    name: token("my_tag", 3, 1, 4),
+                    used_variables: vec![token("my_var", 10, 1, 11)],
+                    assigned_variables: vec![],
+                },
+                attrs: vec![tag_attr(
+                    None,
+                    variable_value(
+                        token("my_var|lower", 10, 1, 11),
+                        token("my_var", 10, 1, 11),
+                        None,
+                        vec![TagValueFilter {
+                            token: token("|lower", 16, 1, 17),
+                            name: token("lower", 17, 1, 18),
+                            arg: None,
+                        }],
+                        vec![],
+                        vec![],
+                    ),
+                    false
+                )],
+                is_self_closing: false,
+            })
+        );
+    }
+
+    #[test]
+    fn test_variable_as_arg_with_filter_with_arg() {
+        let input = "{% my_tag my_var|select:other_var %}";
+        let (result, _context) = plain_parse_tag_v1(input).unwrap();
+        assert_eq!(
+            result,
+            Tag::Generic(GenericTag {
+                meta: TagMeta {
+                    token: token("{% my_tag my_var|select:other_var %}", 0, 1, 1),
+                    name: token("my_tag", 3, 1, 4),
+                    used_variables: vec![token("my_var", 10, 1, 11), token("other_var", 24, 1, 25),],
+                    assigned_variables: vec![],
+                },
+                attrs: vec![tag_attr(
+                    None,
+                    variable_value(
+                        token("my_var|select:other_var", 10, 1, 11),
+                        token("my_var", 10, 1, 11),
+                        None,
+                        vec![TagValueFilter {
+                            token: token("|select:other_var", 16, 1, 17),
+                            name: token("select", 17, 1, 18),
+                            arg: Some(plain_variable_value("other_var", 24, 1, 25, None)),
+                        }],
+                        vec![],
+                        vec![],
+                    ),
+                    false
+                )],
+                is_self_closing: false,
+            })
+        );
+    }
+
+    #[test]
+    fn test_variable_as_arg_with_spread() {
+        let input = "{% my_tag ...my_var %}";
+        let (result, _context) = plain_parse_tag_v1(input).unwrap();
+        assert_eq!(
+            result,
+            Tag::Generic(GenericTag {
+                meta: TagMeta {
+                    token: token("{% my_tag ...my_var %}", 0, 1, 1),
+                    name: token("my_tag", 3, 1, 4),
+                    used_variables: vec![token("my_var", 13, 1, 14)],
+                    assigned_variables: vec![],
+                },
+                attrs: vec![tag_attr(
+                    None,
+                    plain_variable_value("my_var", 10, 1, 11, Some("...")),
+                    false
+                )],
+                is_self_closing: false,
+            })
+        );
+    }
+
+    #[test]
+    fn test_variable_as_kwarg() {
+        let input = "{% my_tag key=my_var %}";
+        let (result, _context) = plain_parse_tag_v1(input).unwrap();
+        assert_eq!(
+            result,
+            Tag::Generic(GenericTag {
+                meta: TagMeta {
+                    token: token("{% my_tag key=my_var %}", 0, 1, 1),
+                    name: token("my_tag", 3, 1, 4),
+                    used_variables: vec![token("my_var", 14, 1, 15)],
+                    assigned_variables: vec![],
+                },
+                attrs: vec![tag_attr(
+                    Some(token("key", 10, 1, 11)),
+                    plain_variable_value("my_var", 14, 1, 15, None),
+                    false
+                )],
+                is_self_closing: false,
+            })
+        );
+    }
+
+    #[test]
+    fn test_variable_as_multiple_kwargs() {
+        let input = "{% my_tag key1=my_var1 key2=my_var2 %}";
+        let (result, _context) = plain_parse_tag_v1(input).unwrap();
+        assert_eq!(
+            result,
+            Tag::Generic(GenericTag {
+                meta: TagMeta {
+                    token: token("{% my_tag key1=my_var1 key2=my_var2 %}", 0, 1, 1),
+                    name: token("my_tag", 3, 1, 4),
+                    used_variables: vec![token("my_var1", 15, 1, 16), token("my_var2", 28, 1, 29),],
+                    assigned_variables: vec![],
+                },
+                attrs: vec![
+                    tag_attr(
+                        Some(token("key1", 10, 1, 11)),
+                        plain_variable_value("my_var1", 15, 1, 16, None),
+                        false
+                    ),
+                    tag_attr(
+                        Some(token("key2", 23, 1, 24)),
+                        plain_variable_value("my_var2", 28, 1, 29, None),
+                        false
+                    ),
+                ],
+                is_self_closing: false,
+            })
+        );
+    }
+
+    #[test]
+    fn test_variable_as_kwarg_with_filter_without_arg() {
+        let input = "{% my_tag key=my_var|upper %}";
+        let (result, _context) = plain_parse_tag_v1(input).unwrap();
+        assert_eq!(
+            result,
+            Tag::Generic(GenericTag {
+                meta: TagMeta {
+                    token: token("{% my_tag key=my_var|upper %}", 0, 1, 1),
+                    name: token("my_tag", 3, 1, 4),
+                    used_variables: vec![token("my_var", 14, 1, 15)],
+                    assigned_variables: vec![],
+                },
+                attrs: vec![tag_attr(
+                    Some(token("key", 10, 1, 11)),
+                    variable_value(
+                        token("my_var|upper", 14, 1, 15),
+                        token("my_var", 14, 1, 15),
+                        None,
+                        vec![TagValueFilter {
+                            token: token("|upper", 20, 1, 21),
+                            name: token("upper", 21, 1, 22),
+                            arg: None,
+                        }],
+                        vec![],
+                        vec![],
+                    ),
+                    false
+                )],
+                is_self_closing: false,
+            })
+        );
+    }
+
+    #[test]
+    fn test_variable_as_kwarg_with_filter_with_arg() {
+        let input = "{% my_tag key=my_var|select:other_var %}";
+        let (result, _context) = plain_parse_tag_v1(input).unwrap();
+        assert_eq!(
+            result,
+            Tag::Generic(GenericTag {
+                meta: TagMeta {
+                    token: token("{% my_tag key=my_var|select:other_var %}", 0, 1, 1),
+                    name: token("my_tag", 3, 1, 4),
+                    used_variables: vec![token("my_var", 14, 1, 15), token("other_var", 28, 1, 29),],
+                    assigned_variables: vec![],
+                },
+                attrs: vec![tag_attr(
+                    Some(token("key", 10, 1, 11)),
+                    variable_value(
+                        token("my_var|select:other_var", 14, 1, 15),
+                        token("my_var", 14, 1, 15),
+                        None,
+                        vec![TagValueFilter {
+                            token: token("|select:other_var", 20, 1, 21),
+                            name: token("select", 21, 1, 22),
+                            arg: Some(plain_variable_value("other_var", 28, 1, 29, None)),
+                        }],
+                        vec![],
+                        vec![],
+                    ),
+                    false
+                )],
+                is_self_closing: false,
+            })
+        );
+    }
+
+    #[test]
+    fn test_variable_as_both_arg_and_kwarg_with_filters() {
+        let input = "{% my_tag my_var|lower key=other_var|upper %}";
+        let (result, _context) = plain_parse_tag_v1(input).unwrap();
+        assert_eq!(
+            result,
+            Tag::Generic(GenericTag {
+                meta: TagMeta {
+                    token: token("{% my_tag my_var|lower key=other_var|upper %}", 0, 1, 1),
+                    name: token("my_tag", 3, 1, 4),
+                    used_variables: vec![token("my_var", 10, 1, 11), token("other_var", 27, 1, 28),],
+                    assigned_variables: vec![],
+                },
+                attrs: vec![
+                    tag_attr(
+                        None,
+                        variable_value(
+                            token("my_var|lower", 10, 1, 11),
+                            token("my_var", 10, 1, 11),
+                            None,
+                            vec![TagValueFilter {
+                                token: token("|lower", 16, 1, 17),
+                                name: token("lower", 17, 1, 18),
+                                arg: None,
+                            }],
+                            vec![],
+                            vec![],
+                        ),
+                        false
+                    ),
+                    tag_attr(
+                        Some(token("key", 23, 1, 24)),
+                        variable_value(
+                            token("other_var|upper", 27, 1, 28),
+                            token("other_var", 27, 1, 28),
+                            None,
+                            vec![TagValueFilter {
+                                token: token("|upper", 36, 1, 37),
+                                name: token("upper", 37, 1, 38),
+                                arg: None,
+                            }],
+                            vec![],
+                            vec![],
+                        ),
+                        false
+                    ),
+                ],
+                is_self_closing: false,
+            })
+        );
+    }
+
+    #[test]
+    fn test_variable_as_both_arg_and_kwarg_with_filters_and_spread() {
+        let input = "{% my_tag ...my_var|lower key=other_var|upper %}";
+        let (result, _context) = plain_parse_tag_v1(input).unwrap();
+        assert_eq!(
+            result,
+            Tag::Generic(GenericTag {
+                meta: TagMeta {
+                    token: token("{% my_tag ...my_var|lower key=other_var|upper %}", 0, 1, 1),
+                    name: token("my_tag", 3, 1, 4),
+                    used_variables: vec![token("my_var", 13, 1, 14), token("other_var", 30, 1, 31),],
+                    assigned_variables: vec![],
+                },
+                attrs: vec![
+                    tag_attr(
+                        None,
+                        variable_value(
+                            token("...my_var|lower", 10, 1, 11),
+                            token("my_var", 13, 1, 14),
+                            Some("..."),
+                            vec![TagValueFilter {
+                                token: token("|lower", 19, 1, 20),
+                                name: token("lower", 20, 1, 21),
+                                arg: None,
+                            }],
+                            vec![],
+                            vec![],
+                        ),
+                        false
+                    ),
+                    tag_attr(
+                        Some(token("key", 26, 1, 27)),
+                        variable_value(
+                            token("other_var|upper", 30, 1, 31),
+                            token("other_var", 30, 1, 31),
+                            None,
+                            vec![TagValueFilter {
+                                token: token("|upper", 39, 1, 40),
+                                name: token("upper", 40, 1, 41),
+                                arg: None,
+                            }],
+                            vec![],
+                            vec![],
+                        ),
+                        false
+                    ),
+                ],
+                is_self_closing: false,
+            })
+        );
+    }
+
+    #[test]
+    fn test_variable_inside_list() {
+        let input = "{% my_tag [my_var] %}";
+        let (result, _context) = plain_parse_tag_v1(input).unwrap();
+        let list_value = TagValue {
+            token: token("[my_var]", 10, 1, 11),
+            value: token("[my_var]", 10, 1, 11),
+            children: vec![ValueChild::Value(plain_variable_value(
+                "my_var", 11, 1, 12, None,
+            ))],
+            kind: ValueKind::List,
+            spread: None,
+            filters: vec![],
+            used_variables: vec![],
+            assigned_variables: vec![],
+        };
+        assert_eq!(
+            result,
+            Tag::Generic(GenericTag {
+                meta: TagMeta {
+                    token: token("{% my_tag [my_var] %}", 0, 1, 1),
+                    name: token("my_tag", 3, 1, 4),
+                    used_variables: vec![token("my_var", 11, 1, 12)],
+                    assigned_variables: vec![],
+                },
+                attrs: vec![tag_attr(None, list_value, false)],
+                is_self_closing: false,
+            })
+        );
+    }
+
+    #[test]
+    fn test_variable_inside_list_with_filter_without_arg() {
+        let input = "{% my_tag [my_var|lower] %}";
+        let (result, _context) = plain_parse_tag_v1(input).unwrap();
+        let list_value = TagValue {
+            token: token("[my_var|lower]", 10, 1, 11),
+            value: token("[my_var|lower]", 10, 1, 11),
+            children: vec![ValueChild::Value(variable_value(
+                token("my_var|lower", 11, 1, 12),
+                token("my_var", 11, 1, 12),
+                None,
+                vec![TagValueFilter {
+                    token: token("|lower", 17, 1, 18),
+                    name: token("lower", 18, 1, 19),
+                    arg: None,
+                }],
+                vec![],
+                vec![],
+            ))],
+            kind: ValueKind::List,
+            spread: None,
+            filters: vec![],
+            used_variables: vec![],
+            assigned_variables: vec![],
+        };
+        assert_eq!(
+            result,
+            Tag::Generic(GenericTag {
+                meta: TagMeta {
+                    token: token("{% my_tag [my_var|lower] %}", 0, 1, 1),
+                    name: token("my_tag", 3, 1, 4),
+                    used_variables: vec![token("my_var", 11, 1, 12)],
+                    assigned_variables: vec![],
+                },
+                attrs: vec![tag_attr(None, list_value, false)],
+                is_self_closing: false,
+            })
+        );
+    }
+
+    #[test]
+    fn test_variable_inside_list_with_filter_with_arg() {
+        let input = "{% my_tag [my_var|select:other_var] %}";
+        let (result, _context) = plain_parse_tag_v1(input).unwrap();
+        let list_value = TagValue {
+            token: token("[my_var|select:other_var]", 10, 1, 11),
+            value: token("[my_var|select:other_var]", 10, 1, 11),
+            children: vec![ValueChild::Value(variable_value(
+                token("my_var|select:other_var", 11, 1, 12),
+                token("my_var", 11, 1, 12),
+                None,
+                vec![TagValueFilter {
+                    token: token("|select:other_var", 17, 1, 18),
+                    name: token("select", 18, 1, 19),
+                    arg: Some(plain_variable_value("other_var", 25, 1, 26, None)),
+                }],
+                vec![],
+                vec![],
+            ))],
+            kind: ValueKind::List,
+            spread: None,
+            filters: vec![],
+            used_variables: vec![],
+            assigned_variables: vec![],
+        };
+        assert_eq!(
+            result,
+            Tag::Generic(GenericTag {
+                meta: TagMeta {
+                    token: token("{% my_tag [my_var|select:other_var] %}", 0, 1, 1),
+                    name: token("my_tag", 3, 1, 4),
+                    used_variables: vec![token("my_var", 11, 1, 12), token("other_var", 25, 1, 26)],
+                    assigned_variables: vec![],
+                },
+                attrs: vec![tag_attr(None, list_value, false)],
+                is_self_closing: false,
+            })
+        );
+    }
+
+    #[test]
+    fn test_variable_inside_list_with_filter_with_arg_and_spread() {
+        let input = "{% my_tag [*my_var|select:other_var] %}";
+        let (result, _context) = plain_parse_tag_v1(input).unwrap();
+        let list_value = TagValue {
+            token: token("[*my_var|select:other_var]", 10, 1, 11),
+            value: token("[*my_var|select:other_var]", 10, 1, 11),
+            children: vec![ValueChild::Value(variable_value(
+                token("*my_var|select:other_var", 11, 1, 12),
+                token("my_var", 12, 1, 13),
+                Some("*"),
+                vec![TagValueFilter {
+                    token: token("|select:other_var", 18, 1, 19),
+                    name: token("select", 19, 1, 20),
+                    arg: Some(plain_variable_value("other_var", 26, 1, 27, None)),
+                }],
+                vec![],
+                vec![],
+            ))],
+            kind: ValueKind::List,
+            spread: None,
+            filters: vec![],
+            used_variables: vec![],
+            assigned_variables: vec![],
+        };
+        assert_eq!(
+            result,
+            Tag::Generic(GenericTag {
+                meta: TagMeta {
+                    token: token("{% my_tag [*my_var|select:other_var] %}", 0, 1, 1),
+                    name: token("my_tag", 3, 1, 4),
+                    used_variables: vec![token("my_var", 12, 1, 13), token("other_var", 26, 1, 27)],
+                    assigned_variables: vec![],
+                },
+                attrs: vec![tag_attr(None, list_value, false)],
+                is_self_closing: false,
+            })
+        );
+    }
+
+    #[test]
+    fn test_variable_inside_list_with_spread() {
+        let input = "{% my_tag [*my_var] %}";
+        let (result, _context) = plain_parse_tag_v1(input).unwrap();
+        let list_value = TagValue {
+            token: token("[*my_var]", 10, 1, 11),
+            value: token("[*my_var]", 10, 1, 11),
+            children: vec![ValueChild::Value(plain_variable_value(
+                "my_var",
+                11,
+                1,
+                12,
+                Some("*"),
+            ))],
+            kind: ValueKind::List,
+            spread: None,
+            filters: vec![],
+            used_variables: vec![],
+            assigned_variables: vec![],
+        };
+        assert_eq!(
+            result,
+            Tag::Generic(GenericTag {
+                meta: TagMeta {
+                    token: token("{% my_tag [*my_var] %}", 0, 1, 1),
+                    name: token("my_tag", 3, 1, 4),
+                    used_variables: vec![token("my_var", 12, 1, 13)],
+                    assigned_variables: vec![],
+                },
+                attrs: vec![tag_attr(None, list_value, false)],
+                is_self_closing: false,
+            })
+        );
+    }
+
+    #[test]
+    fn test_variable_inside_dict_as_value() {
+        let input = "{% my_tag {key: my_var} %}";
+        let (result, _context) = plain_parse_tag_v1(input).unwrap();
+        let dict_value = TagValue {
+            token: token("{key: my_var}", 10, 1, 11),
+            value: token("{key: my_var}", 10, 1, 11),
+            children: vec![
+                ValueChild::Value(plain_variable_value("key", 11, 1, 12, None)),
+                ValueChild::Value(plain_variable_value("my_var", 16, 1, 17, None)),
+            ],
+            kind: ValueKind::Dict,
+            spread: None,
+            filters: vec![],
+            used_variables: vec![],
+            assigned_variables: vec![],
+        };
+        assert_eq!(
+            result,
+            Tag::Generic(GenericTag {
+                meta: TagMeta {
+                    token: token("{% my_tag {key: my_var} %}", 0, 1, 1),
+                    name: token("my_tag", 3, 1, 4),
+                    used_variables: vec![token("key", 11, 1, 12), token("my_var", 16, 1, 17)],
+                    assigned_variables: vec![],
+                },
+                attrs: vec![tag_attr(None, dict_value, false)],
+                is_self_closing: false,
+            })
+        );
+    }
+
+    #[test]
+    fn test_variable_inside_dict_as_value_with_filter_with_arg() {
+        let input = "{% my_tag {key: my_var|select:other_var} %}";
+        let (result, _context) = plain_parse_tag_v1(input).unwrap();
+        let dict_value = TagValue {
+            token: token("{key: my_var|select:other_var}", 10, 1, 11),
+            value: token("{key: my_var|select:other_var}", 10, 1, 11),
+            children: vec![
+                ValueChild::Value(plain_variable_value("key", 11, 1, 12, None)),
+                ValueChild::Value(variable_value(
+                    token("my_var|select:other_var", 16, 1, 17),
+                    token("my_var", 16, 1, 17),
+                    None,
+                    vec![TagValueFilter {
+                        token: token("|select:other_var", 22, 1, 23),
+                        name: token("select", 23, 1, 24),
+                        arg: Some(plain_variable_value("other_var", 30, 1, 31, None)),
+                    }],
+                    vec![],
+                    vec![],
+                )),
+            ],
+            kind: ValueKind::Dict,
+            spread: None,
+            filters: vec![],
+            used_variables: vec![],
+            assigned_variables: vec![],
+        };
+        assert_eq!(
+            result,
+            Tag::Generic(GenericTag {
+                meta: TagMeta {
+                    token: token("{% my_tag {key: my_var|select:other_var} %}", 0, 1, 1),
+                    name: token("my_tag", 3, 1, 4),
+                    used_variables: vec![
+                        token("key", 11, 1, 12),
+                        token("my_var", 16, 1, 17),
+                        token("other_var", 30, 1, 31)
+                    ],
+                    assigned_variables: vec![],
+                },
+                attrs: vec![tag_attr(None, dict_value, false)],
+                is_self_closing: false,
+            })
+        );
+    }
+
+    #[test]
+    fn test_variable_inside_dict_as_key_and_value() {
+        let input = "{% my_tag {my_key: my_var} %}";
+        let (result, _context) = plain_parse_tag_v1(input).unwrap();
+        let dict_value = TagValue {
+            token: token("{my_key: my_var}", 10, 1, 11),
+            value: token("{my_key: my_var}", 10, 1, 11),
+            children: vec![
+                ValueChild::Value(plain_variable_value("my_key", 11, 1, 12, None)),
+                ValueChild::Value(plain_variable_value("my_var", 19, 1, 20, None)),
+            ],
+            kind: ValueKind::Dict,
+            spread: None,
+            filters: vec![],
+            used_variables: vec![],
+            assigned_variables: vec![],
+        };
+        assert_eq!(
+            result,
+            Tag::Generic(GenericTag {
+                meta: TagMeta {
+                    token: token("{% my_tag {my_key: my_var} %}", 0, 1, 1),
+                    name: token("my_tag", 3, 1, 4),
+                    used_variables: vec![token("my_key", 11, 1, 12), token("my_var", 19, 1, 20)],
+                    assigned_variables: vec![],
+                },
+                attrs: vec![tag_attr(None, dict_value, false)],
+                is_self_closing: false,
+            })
+        );
+    }
+
+    #[test]
+    fn test_variable_inside_dict_as_key_and_value_with_filters_and_arg() {
+        let input = "{% my_tag {my_key|lower: my_var|select:other_var} %}";
+        let (result, _context) = plain_parse_tag_v1(input).unwrap();
+        let dict_value = TagValue {
+            token: token("{my_key|lower: my_var|select:other_var}", 10, 1, 11),
+            value: token("{my_key|lower: my_var|select:other_var}", 10, 1, 11),
+            children: vec![
+                ValueChild::Value(variable_value(
+                    token("my_key|lower", 11, 1, 12),
+                    token("my_key", 11, 1, 12),
+                    None,
+                    vec![TagValueFilter {
+                        token: token("|lower", 17, 1, 18),
+                        name: token("lower", 18, 1, 19),
+                        arg: None,
+                    }],
+                    vec![],
+                    vec![],
+                )),
+                ValueChild::Value(variable_value(
+                    token("my_var|select:other_var", 25, 1, 26),
+                    token("my_var", 25, 1, 26),
+                    None,
+                    vec![TagValueFilter {
+                        token: token("|select:other_var", 31, 1, 32),
+                        name: token("select", 32, 1, 33),
+                        arg: Some(plain_variable_value("other_var", 39, 1, 40, None)),
+                    }],
+                    vec![],
+                    vec![],
+                )),
+            ],
+            kind: ValueKind::Dict,
+            spread: None,
+            filters: vec![],
+            used_variables: vec![],
+            assigned_variables: vec![],
+        };
+        assert_eq!(
+            result,
+            Tag::Generic(GenericTag {
+                meta: TagMeta {
+                    token: token(
+                        "{% my_tag {my_key|lower: my_var|select:other_var} %}",
+                        0,
+                        1,
+                        1
+                    ),
+                    name: token("my_tag", 3, 1, 4),
+                    used_variables: vec![
+                        token("my_key", 11, 1, 12),
+                        token("my_var", 25, 1, 26),
+                        token("other_var", 39, 1, 40),
+                    ],
+                    assigned_variables: vec![],
+                },
+                attrs: vec![tag_attr(None, dict_value, false)],
+                is_self_closing: false,
+            })
+        );
+    }
+
+    #[test]
+    fn test_variable_inside_dict_with_spread_and_filter() {
+        let input = "{% my_tag {**my_var|upper} %}";
+        let (result, _context) = plain_parse_tag_v1(input).unwrap();
+        let dict_value = TagValue {
+            token: token("{**my_var|upper}", 10, 1, 11),
+            value: token("{**my_var|upper}", 10, 1, 11),
+            children: vec![ValueChild::Value(variable_value(
+                token("**my_var|upper", 11, 1, 12),
+                token("my_var", 13, 1, 14),
+                Some("**"),
+                vec![TagValueFilter {
+                    token: token("|upper", 19, 1, 20),
+                    name: token("upper", 20, 1, 21),
+                    arg: None,
+                }],
+                vec![],
+                vec![],
+            ))],
+            kind: ValueKind::Dict,
+            spread: None,
+            filters: vec![],
+            used_variables: vec![],
+            assigned_variables: vec![],
+        };
+        assert_eq!(
+            result,
+            Tag::Generic(GenericTag {
+                meta: TagMeta {
+                    token: token("{% my_tag {**my_var|upper} %}", 0, 1, 1),
+                    name: token("my_tag", 3, 1, 4),
+                    used_variables: vec![token("my_var", 13, 1, 14)],
+                    assigned_variables: vec![],
+                },
+                attrs: vec![tag_attr(None, dict_value, false)],
+                is_self_closing: false,
+            })
+        );
+    }
+
+    // #######################################
+    // VARIABLES EDGE CASES
+    // #######################################
+
+    #[test]
+    fn test_variable_with_dots() {
+        let input = "{% my_tag my.nested.value %}";
+        let (result, _context) = plain_parse_tag_v1(input).unwrap();
+        assert_eq!(
+            result,
+            Tag::Generic(GenericTag {
+                meta: TagMeta {
+                    token: token("{% my_tag my.nested.value %}", 0, 1, 1),
+                    name: token("my_tag", 3, 1, 4),
+                    used_variables: vec![token("my", 10, 1, 11)],
+                    assigned_variables: vec![],
+                },
+                attrs: vec![tag_attr(
+                    None,
+                    plain_variable_value("my.nested.value", 10, 1, 11, None),
+                    false
+                )],
+                is_self_closing: false,
+            })
+        );
+    }
+}

--- a/tests/test_template_parser__tag.py
+++ b/tests/test_template_parser__tag.py
@@ -8,7 +8,7 @@ Source of truth is djc_core_template_parser.
 
 # ruff: noqa: ANN201,ARG005,S101,S105,S106,E501
 import re
-from typing import Any, List
+from typing import Any, List, Optional, Union
 from unittest.mock import Mock
 
 import pytest
@@ -60,7 +60,7 @@ def variable_resolver(ctx, src, token, filters, tags, var):
 ###############################
 
 
-def _simple_compile_tag(tag_or_attrs: GenericTag | List[TagAttr], source: str):
+def _simple_compile_tag(tag_or_attrs: Union[GenericTag, List[TagAttr]], source: str):
     return compile_tag(
         tag_or_attrs,
         source,
@@ -90,7 +90,7 @@ def token(content: str, start_index: int, line: int, col: int) -> Token:
 # Takes key (optional), value, and is_flag
 # Calculates the token field internally from key token + "=" + value token
 # If key is None, the token is just the value token
-def tag_attr(key: Token | None, value: TagValue, is_flag: bool) -> TagAttr:
+def tag_attr(key: Optional[Token], value: TagValue, is_flag: bool) -> TagAttr:
     if key is not None:
         # Calculate token content: key + "=" + value.token.content
         token_content = f"{key.content}={value.token.content}"
@@ -119,7 +119,7 @@ def plain_string_value(
     start_index: int,
     line: int,
     col: int,
-    spread: str | None = None,
+    spread: Optional[str] = None,
 ) -> TagValue:
     if spread is not None:
         token_content = f"{spread}{content}"
@@ -150,7 +150,7 @@ def plain_int_value(
     start_index: int,
     line: int,
     col: int,
-    spread: str | None = None,
+    spread: Optional[str] = None,
 ) -> TagValue:
     if spread is not None:
         token_content = f"{spread}{content}"
@@ -181,7 +181,7 @@ def plain_float_value(
     start_index: int,
     line: int,
     col: int,
-    spread: str | None = None,
+    spread: Optional[str] = None,
 ) -> TagValue:
     if spread is not None:
         token_content = f"{spread}{content}"
@@ -212,7 +212,7 @@ def plain_translation_value(
     start_index: int,
     line: int,
     col: int,
-    spread: str | None = None,
+    spread: Optional[str] = None,
 ) -> TagValue:
     if spread is not None:
         token_content = f"{spread}{content}"
@@ -245,7 +245,7 @@ def plain_variable_value(
     start_index: int,
     line: int,
     col: int,
-    spread: str | None = None,
+    spread: Optional[str] = None,
 ) -> TagValue:
     if spread is not None:
         token_content = f"{spread}{content}"
@@ -280,7 +280,7 @@ def plain_variable_value(
 def string_value(
     token: Token,
     value: Token,
-    spread: str | None,
+    spread: Optional[str],
     filters: List[TagValueFilter],
     used_variables: List[Token],
     assigned_variables: List[Token],
@@ -302,7 +302,7 @@ def string_value(
 def int_value(
     token: Token,
     value: Token,
-    spread: str | None,
+    spread: Optional[str],
     filters: List[TagValueFilter],
     used_variables: List[Token],
     assigned_variables: List[Token],
@@ -325,7 +325,7 @@ def int_value(
 def variable_value(
     full_token: Token,
     value: Token,
-    spread: str | None,
+    spread: Optional[str],
     filters: List[TagValueFilter],
     used_variables: List[Token],
     assigned_variables: List[Token],
@@ -356,7 +356,7 @@ def variable_value(
 def float_value(
     token: Token,
     value: Token,
-    spread: str | None,
+    spread: Optional[str],
     filters: List[TagValueFilter],
     used_variables: List[Token],
     assigned_variables: List[Token],
@@ -378,7 +378,7 @@ def float_value(
 def translation_value(
     token: Token,
     value: Token,
-    spread: str | None,
+    spread: Optional[str],
     filters: List[TagValueFilter],
     used_variables: List[Token],
     assigned_variables: List[Token],
@@ -403,7 +403,7 @@ def plain_template_string_value(
     start_index: int,
     line: int,
     col: int,
-    spread: str | None = None,
+    spread: Optional[str] = None,
 ) -> TagValue:
     if spread is not None:
         token_content = f"{spread}{content}"
@@ -431,7 +431,7 @@ def plain_template_string_value(
 def template_string_value(
     token: Token,
     value: Token,
-    spread: str | None,
+    spread: Optional[str],
     filters: List[TagValueFilter],
     used_variables: List[Token],
     assigned_variables: List[Token],
@@ -456,7 +456,7 @@ def plain_python_expr_value(
     start_index: int,
     line: int,
     col: int,
-    spread: str | None = None,
+    spread: Optional[str] = None,
 ) -> TagValue:
     if spread is not None:
         token_content = f"{spread}{content}"
@@ -484,7 +484,7 @@ def plain_python_expr_value(
 def python_expr_value(
     token: Token,
     value: Token,
-    spread: str | None,
+    spread: Optional[str],
     filters: List[TagValueFilter],
     used_variables: List[Token],
     assigned_variables: List[Token],

--- a/tests/test_template_parser__tag.py
+++ b/tests/test_template_parser__tag.py
@@ -1,0 +1,5098 @@
+"""
+Test for parsing and compilation of template tags like `{% my_tag key=value %}`.
+
+This file is defined both in django-components and djc_core_template_parser to ensure compatibility.
+
+Source of truth is djc_core_template_parser.
+"""
+
+# ruff: noqa: ANN201,ARG005,S101,S105,S106,E501
+import re
+from typing import Any, List
+from unittest.mock import Mock
+
+import pytest
+from djc_core.template_parser import (
+    EndTag,
+    ForLoopTag,
+    GenericTag,
+    ParserConfig,
+    TagAttr,
+    TagConfig,
+    TagSpec,
+    TemplateVersion,
+    Token,
+    TagValue,
+    TagValueFilter,
+    ValueChild,
+    ValueKind,
+    compile_tag,
+    parse_tag,
+)
+
+###############################
+# RESOLVERS
+###############################
+
+
+def expr_resolver(ctx, src, token, filters, tags, expr):
+    return f"EXPR_RESOLVED:{expr}"
+
+
+def template_resolver(ctx, src, token, filters, tags, template):
+    return f"TEMPLATE_RESOLVED:{template}"
+
+
+def translation_resolver(ctx, src, token, filters, tags, text):
+    return f"TRANSLATION_RESOLVED:{text}"
+
+
+def filter_resolver(ctx, src, token, filters, tags, name, value, arg=None):
+    return f"{name}({value}, {arg})"
+
+
+def variable_resolver(ctx, src, token, filters, tags, var):
+    return ctx[var]
+
+
+###############################
+# HELPERS
+###############################
+
+
+def _simple_compile_tag(tag_or_attrs: GenericTag | List[TagAttr], source: str):
+    return compile_tag(
+        tag_or_attrs,
+        source,
+        filters={},
+        tags={},
+        template_string=template_resolver,
+        expr=expr_resolver,
+        translation=translation_resolver,
+        filter=filter_resolver,
+        variable=variable_resolver,
+    )
+
+
+# Helper function to create a Token struct
+# Takes content, start_index, line number, and column number
+# Calculates end_index automatically as start_index + len(content)
+def token(content: str, start_index: int, line: int, col: int) -> Token:
+    return Token(
+        content=content,
+        start_index=start_index,
+        end_index=start_index + len(content),
+        line_col=(line, col),
+    )
+
+
+# Helper function to create a TagAttr
+# Takes key (optional), value, and is_flag
+# Calculates the token field internally from key token + "=" + value token
+# If key is None, the token is just the value token
+def tag_attr(key: Token | None, value: TagValue, is_flag: bool) -> TagAttr:
+    if key is not None:
+        # Calculate token content: key + "=" + value.token.content
+        token_content = f"{key.content}={value.token.content}"
+        attr_token = Token(
+            content=token_content,
+            start_index=key.start_index,
+            end_index=value.token.end_index,
+            line_col=key.line_col,
+        )
+    else:
+        # If no key, token is just the value token
+        attr_token = value.token
+    return TagAttr(
+        token=attr_token,
+        key=key,
+        value=value,
+        is_flag=is_flag,
+    )
+
+
+# Helper function to create a plain TagValue with ValueKind::String.
+# No filters, no children, and no used/assigned variables
+# If spread is provided, the token includes the spread prefix, but value does not
+def plain_string_value(
+    content: str,
+    start_index: int,
+    line: int,
+    col: int,
+    spread: str | None = None,
+) -> TagValue:
+    if spread is not None:
+        token_content = f"{spread}{content}"
+        value_start_index = start_index + len(spread)
+        value_col = col + len(spread)
+        token_val = token(token_content, start_index, line, col)
+        value_token = token(content, value_start_index, line, value_col)
+    else:
+        token_val = token(content, start_index, line, col)
+        value_token = token_val
+    return TagValue(
+        token=token_val,
+        value=value_token,
+        children=[],
+        kind=ValueKind("string"),
+        spread=spread,
+        filters=[],
+        used_variables=[],
+        assigned_variables=[],
+    )
+
+
+# Helper function to create a plain TagValue with ValueKind::Int.
+# No filters, no children, and no used/assigned variables
+# If spread is provided, the token includes the spread prefix, but value does not
+def plain_int_value(
+    content: str,
+    start_index: int,
+    line: int,
+    col: int,
+    spread: str | None = None,
+) -> TagValue:
+    if spread is not None:
+        token_content = f"{spread}{content}"
+        value_start_index = start_index + len(spread)
+        value_col = col + len(spread)
+        token_val = token(token_content, start_index, line, col)
+        value_token = token(content, value_start_index, line, value_col)
+    else:
+        token_val = token(content, start_index, line, col)
+        value_token = token_val
+    return TagValue(
+        token=token_val,
+        value=value_token,
+        children=[],
+        kind=ValueKind("int"),
+        spread=spread,
+        filters=[],
+        used_variables=[],
+        assigned_variables=[],
+    )
+
+
+# Helper function to create a plain TagValue with ValueKind::Float.
+# No filters, no children, and no used/assigned variables
+# If spread is provided, the token includes the spread prefix, but value does not
+def plain_float_value(
+    content: str,
+    start_index: int,
+    line: int,
+    col: int,
+    spread: str | None = None,
+) -> TagValue:
+    if spread is not None:
+        token_content = f"{spread}{content}"
+        value_start_index = start_index + len(spread)
+        value_col = col + len(spread)
+        token_val = token(token_content, start_index, line, col)
+        value_token = token(content, value_start_index, line, value_col)
+    else:
+        token_val = token(content, start_index, line, col)
+        value_token = token_val
+    return TagValue(
+        token=token_val,
+        value=value_token,
+        children=[],
+        kind=ValueKind("float"),
+        spread=spread,
+        filters=[],
+        used_variables=[],
+        assigned_variables=[],
+    )
+
+
+# Helper function to create a plain TagValue with ValueKind::Translation.
+# No filters, no children, and no used/assigned variables
+# If spread is provided, the token includes the spread prefix, but value does not
+def plain_translation_value(
+    content: str,
+    start_index: int,
+    line: int,
+    col: int,
+    spread: str | None = None,
+) -> TagValue:
+    if spread is not None:
+        token_content = f"{spread}{content}"
+        value_start_index = start_index + len(spread)
+        value_col = col + len(spread)
+        token_val = token(token_content, start_index, line, col)
+        value_token = token(content, value_start_index, line, value_col)
+    else:
+        token_val = token(content, start_index, line, col)
+        value_token = token_val
+    return TagValue(
+        token=token_val,
+        value=value_token,
+        children=[],
+        kind=ValueKind("translation"),
+        spread=spread,
+        filters=[],
+        used_variables=[],
+        assigned_variables=[],
+    )
+
+
+# Helper function to create a plain TagValue with ValueKind::Variable.
+# No filters, no children, and no assigned_variables
+# Populates used_variables with a single token for the root variable name
+# (the part before the first dot, or the entire variable if no dots)
+# If spread is provided, the token includes the spread prefix, but value does not
+def plain_variable_value(
+    content: str,
+    start_index: int,
+    line: int,
+    col: int,
+    spread: str | None = None,
+) -> TagValue:
+    if spread is not None:
+        token_content = f"{spread}{content}"
+        value_start_index = start_index + len(spread)
+        value_col = col + len(spread)
+        token_val = token(token_content, start_index, line, col)
+        value_token = token(content, value_start_index, line, value_col)
+    else:
+        token_val = token(content, start_index, line, col)
+        value_token = token_val
+    # Extract root variable name (everything before first dot, or entire content if no dot)
+    root_var = content.split(".")[0] if "." in content else content
+    used_var_start_index = (
+        start_index + len(spread) if spread is not None else start_index
+    )
+    used_var_col = col + len(spread) if spread is not None else col
+    used_var_token = token(root_var, used_var_start_index, line, used_var_col)
+    return TagValue(
+        token=token_val,
+        value=value_token,
+        children=[],
+        kind=ValueKind("variable"),
+        spread=spread,
+        filters=[],
+        used_variables=[used_var_token],
+        assigned_variables=[],
+    )
+
+
+# Helper function to create a TagValue with ValueKind::String
+# Creates a TagValue with empty children
+def string_value(
+    token: Token,
+    value: Token,
+    spread: str | None,
+    filters: List[TagValueFilter],
+    used_variables: List[Token],
+    assigned_variables: List[Token],
+) -> TagValue:
+    return TagValue(
+        token=token,
+        value=value,
+        children=[],
+        kind=ValueKind("string"),
+        spread=spread,
+        filters=filters,
+        used_variables=used_variables,
+        assigned_variables=assigned_variables,
+    )
+
+
+# Helper function to create a TagValue with ValueKind::Int
+# Creates a TagValue with empty children
+def int_value(
+    token: Token,
+    value: Token,
+    spread: str | None,
+    filters: List[TagValueFilter],
+    used_variables: List[Token],
+    assigned_variables: List[Token],
+) -> TagValue:
+    return TagValue(
+        token=token,
+        value=value,
+        children=[],
+        kind=ValueKind("int"),
+        spread=spread,
+        filters=filters,
+        used_variables=used_variables,
+        assigned_variables=assigned_variables,
+    )
+
+
+# Helper function to create a TagValue with ValueKind::Variable
+# Creates a TagValue with empty children
+# Automatically computes and adds the root variable name (before first dot) to used_variables
+def variable_value(
+    full_token: Token,
+    value: Token,
+    spread: str | None,
+    filters: List[TagValueFilter],
+    used_variables: List[Token],
+    assigned_variables: List[Token],
+) -> TagValue:
+    # Extract root variable name (everything before first dot, or entire value if no dot)
+    root_var = value.content.split(".")[0] if "." in value.content else value.content
+    used_var_token = token(
+        root_var,
+        value.start_index,
+        value.line_col[0],
+        value.line_col[1],
+    )
+    used_variables = used_variables + [used_var_token]
+    return TagValue(
+        token=full_token,
+        value=value,
+        children=[],
+        kind=ValueKind("variable"),
+        spread=spread,
+        filters=filters,
+        used_variables=used_variables,
+        assigned_variables=assigned_variables,
+    )
+
+
+# Helper function to create a TagValue with ValueKind::Float
+# Creates a TagValue with empty children
+def float_value(
+    token: Token,
+    value: Token,
+    spread: str | None,
+    filters: List[TagValueFilter],
+    used_variables: List[Token],
+    assigned_variables: List[Token],
+) -> TagValue:
+    return TagValue(
+        token=token,
+        value=value,
+        children=[],
+        kind=ValueKind("float"),
+        spread=spread,
+        filters=filters,
+        used_variables=used_variables,
+        assigned_variables=assigned_variables,
+    )
+
+
+# Helper function to create a TagValue with ValueKind::Translation
+# Creates a TagValue with empty children
+def translation_value(
+    token: Token,
+    value: Token,
+    spread: str | None,
+    filters: List[TagValueFilter],
+    used_variables: List[Token],
+    assigned_variables: List[Token],
+) -> TagValue:
+    return TagValue(
+        token=token,
+        value=value,
+        children=[],
+        kind=ValueKind("translation"),
+        spread=spread,
+        filters=filters,
+        used_variables=used_variables,
+        assigned_variables=assigned_variables,
+    )
+
+
+# Helper function to create a plain TagValue with ValueKind::TemplateString.
+# No filters, no children, and no used/assigned variables
+# If spread is provided, the token includes the spread prefix, but value does not
+def plain_template_string_value(
+    content: str,
+    start_index: int,
+    line: int,
+    col: int,
+    spread: str | None = None,
+) -> TagValue:
+    if spread is not None:
+        token_content = f"{spread}{content}"
+        value_start_index = start_index + len(spread)
+        value_col = col + len(spread)
+        token_val = token(token_content, start_index, line, col)
+        value_token = token(content, value_start_index, line, value_col)
+    else:
+        token_val = token(content, start_index, line, col)
+        value_token = token_val
+    return TagValue(
+        token=token_val,
+        value=value_token,
+        children=[],
+        kind=ValueKind("template_string"),
+        spread=spread,
+        filters=[],
+        used_variables=[],
+        assigned_variables=[],
+    )
+
+
+# Helper function to create a TagValue with ValueKind::TemplateString
+# Creates a TagValue with empty children
+def template_string_value(
+    token: Token,
+    value: Token,
+    spread: str | None,
+    filters: List[TagValueFilter],
+    used_variables: List[Token],
+    assigned_variables: List[Token],
+) -> TagValue:
+    return TagValue(
+        token=token,
+        value=value,
+        children=[],
+        kind=ValueKind("template_string"),
+        spread=spread,
+        filters=filters,
+        used_variables=used_variables,
+        assigned_variables=assigned_variables,
+    )
+
+
+# Helper function to create a plain TagValue with ValueKind::PythonExpr.
+# No filters, no children, and no used/assigned variables
+# If spread is provided, the token includes the spread prefix, but value does not
+def plain_python_expr_value(
+    content: str,
+    start_index: int,
+    line: int,
+    col: int,
+    spread: str | None = None,
+) -> TagValue:
+    if spread is not None:
+        token_content = f"{spread}{content}"
+        value_start_index = start_index + len(spread)
+        value_col = col + len(spread)
+        token_val = token(token_content, start_index, line, col)
+        value_token = token(content, value_start_index, line, value_col)
+    else:
+        token_val = token(content, start_index, line, col)
+        value_token = token_val
+    return TagValue(
+        token=token_val,
+        value=value_token,
+        children=[],
+        kind=ValueKind("python_expr"),
+        spread=spread,
+        filters=[],
+        used_variables=[],
+        assigned_variables=[],
+    )
+
+
+# Helper function to create a TagValue with ValueKind::PythonExpr
+# Creates a TagValue with empty children
+def python_expr_value(
+    token: Token,
+    value: Token,
+    spread: str | None,
+    filters: List[TagValueFilter],
+    used_variables: List[Token],
+    assigned_variables: List[Token],
+) -> TagValue:
+    return TagValue(
+        token=token,
+        value=value,
+        children=[],
+        kind=ValueKind("python_expr"),
+        spread=spread,
+        filters=filters,
+        used_variables=used_variables,
+        assigned_variables=assigned_variables,
+    )
+
+
+# Helper function to create a simple TagValue with ValueKind::Dict.
+# No spread, no filters, and no used/assigned variables.
+# The token and value are the same.
+def plain_dict_value(
+    token: Token,
+    children: List[ValueChild],
+) -> TagValue:
+    return TagValue(
+        token=token,
+        value=token,
+        children=children,
+        kind=ValueKind("dict"),
+        spread=None,
+        filters=[],
+        used_variables=[],
+        assigned_variables=[],
+    )
+
+
+# Helper function to create a simple TagValue with ValueKind::List.
+# No spread, no filters, and no used/assigned variables.
+# The token and value are the same.
+def plain_list_value(
+    token: Token,
+    children: List[ValueChild],
+) -> TagValue:
+    return TagValue(
+        token=token,
+        value=token,
+        children=children,
+        kind=ValueKind("list"),
+        spread=None,
+        filters=[],
+        used_variables=[],
+        assigned_variables=[],
+    )
+
+
+############################################################
+# TESTS
+############################################################
+
+
+# Test that resolvers are called correctly
+class TestResolvers:
+    def _setup_resolver_test(self, tag_content: str, context: Any):
+        tag = parse_tag(tag_content)
+
+        # Mock variable resolver to return different values for different variables
+        def variable_side_effect(ctx, src, token, filters, tags, var):
+            if var == "my_var":
+                return "test_value"
+            elif var == "arg":
+                return "arg_value"
+            return None
+
+        mock_variable = Mock(side_effect=variable_side_effect)
+        mock_template_string = Mock(return_value="resolved_template")
+        mock_translation = Mock(return_value="resolved_translation")
+        mock_filter = Mock(return_value="resolved_filter")
+        mock_expr = Mock(return_value="resolved_expr")
+
+        filters = {"my_filter": lambda *args, **kwargs: "<my_filter>"}
+        tags = {"my_tag": lambda *args, **kwargs: "<my_tag>"}
+
+        tag_func = compile_tag(
+            tag,
+            tag_content,
+            filters=filters,
+            tags=tags,
+            variable=mock_variable,
+            template_string=mock_template_string,
+            translation=mock_translation,
+            filter=mock_filter,
+            expr=mock_expr,
+        )
+
+        tag_func(context)
+
+        return (
+            mock_variable,
+            mock_template_string,
+            mock_translation,
+            mock_filter,
+            mock_expr,
+            filters,
+            tags,
+        )
+
+    def test_variable_resolver(self):
+        context = {"my_var": "test"}
+        tag_content = "{% component my_var %}"
+        (
+            mock_variable,
+            mock_template_string,
+            mock_translation,
+            mock_filter,
+            mock_expr,
+            filters,
+            tags,
+        ) = self._setup_resolver_test(tag_content, context)
+
+        # Assert variable resolver was called once with expected arguments
+        mock_variable.assert_called_once()
+        call_args = mock_variable.call_args
+        assert call_args[0][0] == context  # context
+        assert call_args[0][1] == tag_content  # source
+        assert call_args[0][2] == (13, 19)  # token (start_index, end_index)
+        assert call_args[0][3] == filters  # filters
+        assert call_args[0][4] == tags  # tags
+        assert call_args[0][5] == "my_var"  # var
+
+        # Other resolvers should not be called
+        mock_template_string.assert_not_called()
+        mock_translation.assert_not_called()
+        mock_filter.assert_not_called()
+        mock_expr.assert_not_called()
+
+    def test_template_string_resolver(self):
+        context = {}
+        tag_content = "{% component '{% lorem w 4 %}' %}"
+        (
+            mock_variable,
+            mock_template_string,
+            mock_translation,
+            mock_filter,
+            mock_expr,
+            filters,
+            tags,
+        ) = self._setup_resolver_test(tag_content, context)
+
+        # Assert template_string resolver was called once with expected arguments
+        mock_template_string.assert_called_once()
+        call_args = mock_template_string.call_args
+        assert call_args[0][0] == context  # context
+        assert call_args[0][1] == tag_content  # source
+        assert call_args[0][2] == (13, 30)  # token (start_index, end_index)
+        assert call_args[0][3] == filters  # filters
+        assert call_args[0][4] == tags  # tags
+        assert call_args[0][5] == "{% lorem w 4 %}"  # expr
+
+        # Other resolvers should not be called
+        mock_variable.assert_not_called()
+        mock_translation.assert_not_called()
+        mock_filter.assert_not_called()
+        mock_expr.assert_not_called()
+
+    def test_translation_resolver(self):
+        context = {}
+        tag_content = '{% component _("hello world") %}'
+        (
+            mock_variable,
+            mock_template_string,
+            mock_translation,
+            mock_filter,
+            mock_expr,
+            filters,
+            tags,
+        ) = self._setup_resolver_test(tag_content, context)
+
+        # Assert translation resolver was called once with expected arguments
+        mock_translation.assert_called_once()
+        call_args = mock_translation.call_args
+        assert call_args[0][0] == context  # context
+        assert call_args[0][1] == tag_content  # source
+        assert call_args[0][2] == (13, 29)  # token (start_index, end_index)
+        assert call_args[0][3] == filters  # filters
+        assert call_args[0][4] == tags  # tags
+        assert call_args[0][5] == "hello world"  # text (inner string without quotes)
+
+        # Other resolvers should not be called
+        mock_variable.assert_not_called()
+        mock_template_string.assert_not_called()
+        mock_filter.assert_not_called()
+        mock_expr.assert_not_called()
+
+    def test_expr_resolver(self):
+        context = {}
+        tag_content = "{% component (1 + 2) %}"
+        (
+            mock_variable,
+            mock_template_string,
+            mock_translation,
+            mock_filter,
+            mock_expr,
+            filters,
+            tags,
+        ) = self._setup_resolver_test(tag_content, context)
+
+        # Assert expr resolver was called once with expected arguments
+        mock_expr.assert_called_once()
+        call_args = mock_expr.call_args
+        assert call_args[0][0] == context  # context
+        assert call_args[0][1] == tag_content  # source
+        assert call_args[0][2] == (13, 20)  # token (start_index, end_index)
+        assert call_args[0][3] == filters  # filters
+        assert call_args[0][4] == tags  # tags
+        assert call_args[0][5] == "(1 + 2)"  # code
+
+        # Other resolvers should not be called
+        mock_variable.assert_not_called()
+        mock_template_string.assert_not_called()
+        mock_translation.assert_not_called()
+        mock_filter.assert_not_called()
+
+    def test_filter_resolver(self):
+        context = {}
+        tag_content = "{% component my_var|upper:arg %}"
+        (
+            mock_variable,
+            mock_template_string,
+            mock_translation,
+            mock_filter,
+            mock_expr,
+            filters,
+            tags,
+        ) = self._setup_resolver_test(tag_content, context)
+
+        # Assert filter resolver was called once with expected arguments
+        mock_filter.assert_called_once()
+        call_args = mock_filter.call_args
+        assert call_args[0][0] == context  # context
+        assert call_args[0][1] == tag_content  # source
+        assert call_args[0][2] == (
+            19,
+            29,
+        )  # token (start_index, end_index) - filter token |upper:arg
+        assert call_args[0][3] == filters  # filters
+        assert call_args[0][4] == tags  # tags
+        assert call_args[0][5] == "upper"  # name
+        assert call_args[0][6] == "test_value"  # value (from variable resolver)
+        assert call_args[0][7] == "arg_value"  # arg (from variable resolver)
+
+        # Variable resolver should be called twice (for the value and arg)
+        assert mock_variable.call_count == 2
+
+        # Other resolvers should not be called
+        mock_template_string.assert_not_called()
+        mock_translation.assert_not_called()
+        mock_expr.assert_not_called()
+
+
+class TestTagParser:
+    def test_args_kwargs(self):
+        tag_content = "{% component 'my_comp' key=val key2='val2 two' %}"
+        tag = parse_tag(tag_content)
+
+        expected_tag = GenericTag(
+            token=token(tag_content, 0, 1, 1),
+            name=token("component", 3, 1, 4),
+            attrs=[
+                TagAttr(
+                    token=token("'my_comp'", 13, 1, 14),
+                    key=None,
+                    value=plain_string_value("'my_comp'", 13, 1, 14, None),
+                    is_flag=False,
+                ),
+                TagAttr(
+                    token=token("key=val", 23, 1, 24),
+                    key=token("key", 23, 1, 24),
+                    value=plain_variable_value("val", 27, 1, 28, None),
+                    is_flag=False,
+                ),
+                TagAttr(
+                    token=token("key2='val2 two'", 31, 1, 32),
+                    key=token("key2", 31, 1, 32),
+                    value=plain_string_value("'val2 two'", 36, 1, 37, None),
+                    is_flag=False,
+                ),
+            ],
+            is_self_closing=False,
+            used_variables=[token("val", 27, 1, 28)],
+            assigned_variables=[],
+        )
+
+        assert tag == expected_tag
+
+        tag_func = _simple_compile_tag(tag, tag_content)
+        args, kwargs = tag_func({"val": [1, 2, 3]})
+
+        assert args == ["my_comp"]
+        assert kwargs == [("key", [1, 2, 3]), ("key2", "val2 two")]
+
+    def test_nested_quotes(self):
+        tag_content = "{% component 'my_comp' key=val key2='val2 \"two\"' text=\"organisation's\" %}"
+        tag = parse_tag(tag_content)
+
+        expected_tag = GenericTag(
+            token=token(tag_content, 0, 1, 1),
+            name=token("component", 3, 1, 4),
+            attrs=[
+                TagAttr(
+                    token=token("'my_comp'", 13, 1, 14),
+                    key=None,
+                    value=plain_string_value("'my_comp'", 13, 1, 14, None),
+                    is_flag=False,
+                ),
+                TagAttr(
+                    token=token("key=val", 23, 1, 24),
+                    key=token("key", 23, 1, 24),
+                    value=plain_variable_value("val", 27, 1, 28, None),
+                    is_flag=False,
+                ),
+                TagAttr(
+                    token=token("key2='val2 \"two\"'", 31, 1, 32),
+                    key=token("key2", 31, 1, 32),
+                    value=plain_string_value("'val2 \"two\"'", 36, 1, 37, None),
+                    is_flag=False,
+                ),
+                TagAttr(
+                    token=token('text="organisation\'s"', 49, 1, 50),
+                    key=token("text", 49, 1, 50),
+                    value=plain_string_value('"organisation\'s"', 54, 1, 55, None),
+                    is_flag=False,
+                ),
+            ],
+            is_self_closing=False,
+            used_variables=[token("val", 27, 1, 28)],
+            assigned_variables=[],
+        )
+
+        assert tag == expected_tag
+
+        tag_func = _simple_compile_tag(tag, tag_content)
+        args, kwargs = tag_func({"val": "some_value"})
+
+        assert args == ["my_comp"]
+        assert kwargs == [
+            ("key", "some_value"),
+            ("key2", 'val2 "two"'),
+            ("text", "organisation's"),
+        ]
+
+    def test_trailing_quote_single(self):
+        # Unclosed quote in positional arg
+        with pytest.raises(
+            SyntaxError,
+            match="expected self_closing_slash, attribute, filter, or COMMENT",
+        ):
+            parse_tag(
+                "{% component 'my_comp' key=val key2='val2 \"two\"' text=\"organisation's\" 'abc %}"
+            )
+
+    def test_trailing_quote_double(self):
+        # Unclosed double quote in positional arg
+        with pytest.raises(
+            SyntaxError,
+            match="expected self_closing_slash, attribute, filter, or COMMENT",
+        ):
+            parse_tag(
+                '{% component "my_comp" key=val key2="val2 \'two\'" text=\'organisation"s\' "abc %}'
+            )
+
+    def test_trailing_quote_as_value_single(self):
+        # Unclosed quote in key=value pair
+        with pytest.raises(SyntaxError, match="expected value"):
+            parse_tag(
+                "{% component 'my_comp' key=val key2='val2 \"two\"' text=\"organisation's\" value='abc %}"
+            )
+
+    def test_trailing_quote_as_value_double(self):
+        # Unclosed double quote in key=value pair
+        with pytest.raises(SyntaxError, match="expected value"):
+            parse_tag(
+                '{% component "my_comp" key=val key2="val2 \'two\'" text=\'organisation"s\' value="abc %}'
+            )
+
+
+class TestTranslation:
+    def test_translation(self):
+        tag_content = '{% component "my_comp" _("one") key=_("two") %}'
+        tag = parse_tag(tag_content)
+
+        expected_tag = GenericTag(
+            token=token(tag_content, 0, 1, 1),
+            name=token("component", 3, 1, 4),
+            attrs=[
+                TagAttr(
+                    token=token('"my_comp"', 13, 1, 14),
+                    key=None,
+                    value=plain_string_value('"my_comp"', 13, 1, 14, None),
+                    is_flag=False,
+                ),
+                TagAttr(
+                    token=token('_("one")', 23, 1, 24),
+                    key=None,
+                    value=plain_translation_value('_("one")', 23, 1, 24, None),
+                    is_flag=False,
+                ),
+                TagAttr(
+                    token=token('key=_("two")', 32, 1, 33),
+                    key=token("key", 32, 1, 33),
+                    value=plain_translation_value('_("two")', 36, 1, 37, None),
+                    is_flag=False,
+                ),
+            ],
+            is_self_closing=False,
+            used_variables=[],
+            assigned_variables=[],
+        )
+
+        assert tag == expected_tag
+
+        tag_func = _simple_compile_tag(tag, tag_content)
+        args, kwargs = tag_func({})
+
+        assert args == ["my_comp", "TRANSLATION_RESOLVED:one"]
+        assert kwargs == [("key", "TRANSLATION_RESOLVED:two")]
+
+    def test_translation_whitespace(self):
+        tag_content = '{% component value=_(  "test"  ) %}'
+        tag = parse_tag(tag_content)
+
+        expected_tag = GenericTag(
+            token=token(tag_content, 0, 1, 1),
+            name=token("component", 3, 1, 4),
+            attrs=[
+                TagAttr(
+                    token=token('value=_(  "test"  )', 13, 1, 14),
+                    key=token("value", 13, 1, 14),
+                    value=translation_value(
+                        token('_(  "test"  )', 19, 1, 20),
+                        Token('_("test")', 19, 32, (1, 20)),
+                        None,
+                        [],
+                        [],
+                        [],
+                    ),
+                    is_flag=False,
+                ),
+            ],
+            is_self_closing=False,
+            used_variables=[],
+            assigned_variables=[],
+        )
+
+        assert tag == expected_tag
+
+        tag_func = _simple_compile_tag(tag, tag_content)
+        args, kwargs = tag_func({})
+
+        assert args == []
+        assert kwargs == [("value", "TRANSLATION_RESOLVED:test")]
+
+    def test_translation_with_filter(self):
+        tag_content = '{% component _("hello")|upper %}'
+        tag = parse_tag(tag_content)
+
+        expected_tag = GenericTag(
+            token=token(tag_content, 0, 1, 1),
+            name=token("component", 3, 1, 4),
+            attrs=[
+                TagAttr(
+                    token=token('_("hello")|upper', 13, 1, 14),
+                    key=None,
+                    value=translation_value(
+                        token('_("hello")|upper', 13, 1, 14),
+                        token('_("hello")', 13, 1, 14),
+                        None,
+                        [
+                            TagValueFilter(
+                                token=token("|upper", 23, 1, 24),
+                                name=token("upper", 24, 1, 25),
+                                arg=None,
+                            )
+                        ],
+                        [],
+                        [],
+                    ),
+                    is_flag=False,
+                ),
+            ],
+            is_self_closing=False,
+            used_variables=[],
+            assigned_variables=[],
+        )
+
+        assert tag == expected_tag
+
+        tag_func = _simple_compile_tag(tag, tag_content)
+        args, kwargs = tag_func({})
+
+        assert args == ["upper(TRANSLATION_RESOLVED:hello, None)"]
+        assert kwargs == []
+
+    def test_translation_as_filter_arg(self):
+        tag_content = '{% component my_var|default:_("fallback") %}'
+        tag = parse_tag(tag_content)
+
+        expected_tag = GenericTag(
+            token=token(tag_content, 0, 1, 1),
+            name=token("component", 3, 1, 4),
+            attrs=[
+                TagAttr(
+                    token=token('my_var|default:_("fallback")', 13, 1, 14),
+                    key=None,
+                    value=variable_value(
+                        token('my_var|default:_("fallback")', 13, 1, 14),
+                        token("my_var", 13, 1, 14),
+                        None,
+                        [
+                            TagValueFilter(
+                                token=token('|default:_("fallback")', 19, 1, 20),
+                                name=token("default", 20, 1, 21),
+                                arg=plain_translation_value(
+                                    '_("fallback")', 28, 1, 29, None
+                                ),
+                            )
+                        ],
+                        [],
+                        [],
+                    ),
+                    is_flag=False,
+                ),
+            ],
+            is_self_closing=False,
+            used_variables=[token("my_var", 13, 1, 14)],
+            assigned_variables=[],
+        )
+
+        assert tag == expected_tag
+
+        tag_func = _simple_compile_tag(tag, tag_content)
+        args, kwargs = tag_func({"my_var": None})
+
+        assert args == ["default(None, TRANSLATION_RESOLVED:fallback)"]
+        assert kwargs == []
+
+    def test_translation_in_list(self):
+        tag_content = '{% component [_("one"), _("two"), _("three")] %}'
+        tag = parse_tag(tag_content)
+
+        expected_tag = GenericTag(
+            token=token(tag_content, 0, 1, 1),
+            name=token("component", 3, 1, 4),
+            attrs=[
+                TagAttr(
+                    token=token('[_("one"), _("two"), _("three")]', 13, 1, 14),
+                    key=None,
+                    value=plain_list_value(
+                        token('[_("one"), _("two"), _("three")]', 13, 1, 14),
+                        [
+                            ValueChild(
+                                plain_translation_value('_("one")', 14, 1, 15, None)
+                            ),
+                            ValueChild(
+                                plain_translation_value('_("two")', 24, 1, 25, None)
+                            ),
+                            ValueChild(
+                                plain_translation_value('_("three")', 34, 1, 35, None)
+                            ),
+                        ],
+                    ),
+                    is_flag=False,
+                ),
+            ],
+            is_self_closing=False,
+            used_variables=[],
+            assigned_variables=[],
+        )
+
+        assert tag == expected_tag
+
+        tag_func = _simple_compile_tag(tag, tag_content)
+        args, kwargs = tag_func({})
+
+        assert args == [
+            [
+                "TRANSLATION_RESOLVED:one",
+                "TRANSLATION_RESOLVED:two",
+                "TRANSLATION_RESOLVED:three",
+            ]
+        ]
+        assert kwargs == []
+
+    def test_translation_in_dict(self):
+        tag_content = '{% component {key: _("value")|upper} %}'
+        tag = parse_tag(tag_content)
+
+        expected_tag = GenericTag(
+            token=token(tag_content, 0, 1, 1),
+            name=token("component", 3, 1, 4),
+            attrs=[
+                TagAttr(
+                    token=token('{key: _("value")|upper}', 13, 1, 14),
+                    key=None,
+                    value=plain_dict_value(
+                        token('{key: _("value")|upper}', 13, 1, 14),
+                        [
+                            ValueChild(plain_variable_value("key", 14, 1, 15, None)),
+                            ValueChild(
+                                translation_value(
+                                    token('_("value")|upper', 19, 1, 20),
+                                    token('_("value")', 19, 1, 20),
+                                    None,
+                                    [
+                                        TagValueFilter(
+                                            token=token("|upper", 29, 1, 30),
+                                            name=token("upper", 30, 1, 31),
+                                            arg=None,
+                                        )
+                                    ],
+                                    [],
+                                    [],
+                                )
+                            ),
+                        ],
+                    ),
+                    is_flag=False,
+                ),
+            ],
+            is_self_closing=False,
+            used_variables=[token("key", 14, 1, 15)],
+            assigned_variables=[],
+        )
+
+        assert tag == expected_tag
+
+        tag_func = _simple_compile_tag(tag, tag_content)
+        args, kwargs = tag_func({"key": "some_key"})
+
+        assert args == [{"some_key": "upper(TRANSLATION_RESOLVED:value, None)"}]
+        assert kwargs == []
+
+
+class TestFilter:
+    def test_tag_parser_filters(self):
+        tag_content = '{% component "my_comp" value|lower key=val|yesno:"yes,no" key2=val2|default:"N/A"|upper %}'
+        tag = parse_tag(tag_content)
+
+        expected_tag = GenericTag(
+            token=token(tag_content, 0, 1, 1),
+            name=token("component", 3, 1, 4),
+            attrs=[
+                TagAttr(
+                    token=token('"my_comp"', 13, 1, 14),
+                    key=None,
+                    value=plain_string_value('"my_comp"', 13, 1, 14, None),
+                    is_flag=False,
+                ),
+                TagAttr(
+                    token=token("value|lower", 23, 1, 24),
+                    key=None,
+                    value=variable_value(
+                        token("value|lower", 23, 1, 24),
+                        token("value", 23, 1, 24),
+                        None,
+                        [
+                            TagValueFilter(
+                                token=token("|lower", 28, 1, 29),
+                                name=token("lower", 29, 1, 30),
+                                arg=None,
+                            )
+                        ],
+                        [],
+                        [],
+                    ),
+                    is_flag=False,
+                ),
+                TagAttr(
+                    token=token('key=val|yesno:"yes,no"', 35, 1, 36),
+                    key=token("key", 35, 1, 36),
+                    value=variable_value(
+                        token('val|yesno:"yes,no"', 39, 1, 40),
+                        token("val", 39, 1, 40),
+                        None,
+                        [
+                            TagValueFilter(
+                                token=token('|yesno:"yes,no"', 42, 1, 43),
+                                name=token("yesno", 43, 1, 44),
+                                arg=plain_string_value('"yes,no"', 49, 1, 50, None),
+                            )
+                        ],
+                        [],
+                        [],
+                    ),
+                    is_flag=False,
+                ),
+                TagAttr(
+                    token=token('key2=val2|default:"N/A"|upper', 58, 1, 59),
+                    key=token("key2", 58, 1, 59),
+                    value=variable_value(
+                        token('val2|default:"N/A"|upper', 63, 1, 64),
+                        token("val2", 63, 1, 64),
+                        None,
+                        [
+                            TagValueFilter(
+                                token=token('|default:"N/A"', 67, 1, 68),
+                                name=token("default", 68, 1, 69),
+                                arg=plain_string_value('"N/A"', 76, 1, 77, None),
+                            ),
+                            TagValueFilter(
+                                token=token("|upper", 81, 1, 82),
+                                name=token("upper", 82, 1, 83),
+                                arg=None,
+                            ),
+                        ],
+                        [],
+                        [],
+                    ),
+                    is_flag=False,
+                ),
+            ],
+            is_self_closing=False,
+            used_variables=[
+                token("value", 23, 1, 24),
+                token("val", 39, 1, 40),
+                token("val2", 63, 1, 64),
+            ],
+            assigned_variables=[],
+        )
+
+        assert tag == expected_tag
+
+        tag_func = _simple_compile_tag(tag, tag_content)
+        args, kwargs = tag_func({"value": "HELLO", "val": True, "val2": None})
+
+        assert args == ["my_comp", "lower(HELLO, None)"]
+        assert kwargs == [
+            ("key", "yesno(True, yes,no)"),
+            ("key2", "upper(default(None, N/A), None)"),
+        ]
+
+    def test_filter_whitespace(self):
+        tag_content = (
+            "{% component value  |  lower    key=val  |  upper    key2=val2 %}"
+        )
+        tag = parse_tag(tag_content)
+
+        expected_tag = GenericTag(
+            token=token(tag_content, 0, 1, 1),
+            name=token("component", 3, 1, 4),
+            attrs=[
+                TagAttr(
+                    token=token("value  |  lower", 13, 1, 14),
+                    key=None,
+                    value=variable_value(
+                        token("value  |  lower", 13, 1, 14),
+                        token("value", 13, 1, 14),
+                        None,
+                        [
+                            TagValueFilter(
+                                token=token("|  lower", 20, 1, 21),
+                                name=token("lower", 23, 1, 24),
+                                arg=None,
+                            )
+                        ],
+                        [],
+                        [],
+                    ),
+                    is_flag=False,
+                ),
+                TagAttr(
+                    token=token("key=val  |  upper", 32, 1, 33),
+                    key=token("key", 32, 1, 33),
+                    value=variable_value(
+                        token("val  |  upper", 36, 1, 37),
+                        token("val", 36, 1, 37),
+                        None,
+                        [
+                            TagValueFilter(
+                                token=token("|  upper", 41, 1, 42),
+                                name=token("upper", 44, 1, 45),
+                                arg=None,
+                            )
+                        ],
+                        [],
+                        [],
+                    ),
+                    is_flag=False,
+                ),
+                TagAttr(
+                    token=token("key2=val2", 53, 1, 54),
+                    key=token("key2", 53, 1, 54),
+                    value=plain_variable_value("val2", 58, 1, 59, None),
+                    is_flag=False,
+                ),
+            ],
+            is_self_closing=False,
+            used_variables=[
+                token("value", 13, 1, 14),
+                token("val", 36, 1, 37),
+                token("val2", 58, 1, 59),
+            ],
+            assigned_variables=[],
+        )
+
+        assert tag == expected_tag
+
+        tag_func = _simple_compile_tag(tag, tag_content)
+        args, kwargs = tag_func({"value": "HELLO", "val": "world", "val2": "test"})
+
+        assert args == ["lower(HELLO, None)"]
+        assert kwargs == [
+            ("key", "upper(world, None)"),
+            ("key2", "test"),
+        ]
+
+    def test_filter_argument_must_follow_filter(self):
+        with pytest.raises(
+            SyntaxError,
+            match=re.escape("expected self_closing_slash, filter, or COMMENT"),
+        ):
+            parse_tag('{% component value=val|yesno:"yes,no":arg %}')
+
+
+class TestFloat:
+    def test_float_simple_as_arg(self):
+        tag_content = "{% component -1.5 %}"
+        tag = parse_tag(tag_content)
+
+        expected_tag = GenericTag(
+            token=token(tag_content, 0, 1, 1),
+            name=token("component", 3, 1, 4),
+            attrs=[
+                TagAttr(
+                    token=token("-1.5", 13, 1, 14),
+                    key=None,
+                    value=plain_float_value("-1.5", 13, 1, 14, None),
+                    is_flag=False,
+                ),
+            ],
+            is_self_closing=False,
+            used_variables=[],
+            assigned_variables=[],
+        )
+
+        assert tag == expected_tag
+
+        tag_func = _simple_compile_tag(tag, tag_content)
+        args, kwargs = tag_func({})
+
+        assert args == [-1.5]
+        assert kwargs == []
+
+    def test_float_simple_as_kwarg(self):
+        tag_content = "{% component key=+2. %}"
+        tag = parse_tag(tag_content)
+
+        expected_tag = GenericTag(
+            token=token(tag_content, 0, 1, 1),
+            name=token("component", 3, 1, 4),
+            attrs=[
+                TagAttr(
+                    token=token("key=+2.", 13, 1, 14),
+                    key=token("key", 13, 1, 14),
+                    value=plain_float_value("+2.", 17, 1, 18, None),
+                    is_flag=False,
+                ),
+            ],
+            is_self_closing=False,
+            used_variables=[],
+            assigned_variables=[],
+        )
+
+        assert tag == expected_tag
+
+        tag_func = _simple_compile_tag(tag, tag_content)
+        args, kwargs = tag_func({})
+
+        assert args == []
+        assert kwargs == [("key", 2.0)]
+
+    def test_float_with_filter(self):
+        tag_content = "{% component -1.2e2|abs %}"
+        tag = parse_tag(tag_content)
+
+        expected_tag = GenericTag(
+            token=token(tag_content, 0, 1, 1),
+            name=token("component", 3, 1, 4),
+            attrs=[
+                TagAttr(
+                    token=token("-1.2e2|abs", 13, 1, 14),
+                    key=None,
+                    value=float_value(
+                        token("-1.2e2|abs", 13, 1, 14),
+                        token("-1.2e2", 13, 1, 14),
+                        None,
+                        [
+                            TagValueFilter(
+                                token=token("|abs", 19, 1, 20),
+                                name=token("abs", 20, 1, 21),
+                                arg=None,
+                            )
+                        ],
+                        [],
+                        [],
+                    ),
+                    is_flag=False,
+                ),
+            ],
+            is_self_closing=False,
+            used_variables=[],
+            assigned_variables=[],
+        )
+
+        assert tag == expected_tag
+
+        tag_func = _simple_compile_tag(tag, tag_content)
+        args, kwargs = tag_func({})
+
+        assert args == ["abs(-120.0, None)"]
+        assert kwargs == []
+
+    def test_float_as_filter_arg(self):
+        tag_content = "{% component 42.5|add:.2e-02 %}"
+        tag = parse_tag(tag_content)
+
+        expected_tag = GenericTag(
+            token=token(tag_content, 0, 1, 1),
+            name=token("component", 3, 1, 4),
+            attrs=[
+                TagAttr(
+                    token=token("42.5|add:.2e-02", 13, 1, 14),
+                    key=None,
+                    value=float_value(
+                        token("42.5|add:.2e-02", 13, 1, 14),
+                        token("42.5", 13, 1, 14),
+                        None,
+                        [
+                            TagValueFilter(
+                                token=token("|add:.2e-02", 17, 1, 18),
+                                name=token("add", 18, 1, 19),
+                                arg=plain_float_value(".2e-02", 22, 1, 23, None),
+                            )
+                        ],
+                        [],
+                        [],
+                    ),
+                    is_flag=False,
+                ),
+            ],
+            is_self_closing=False,
+            used_variables=[],
+            assigned_variables=[],
+        )
+
+        assert tag == expected_tag
+
+        tag_func = _simple_compile_tag(tag, tag_content)
+        args, kwargs = tag_func({})
+
+        assert args == ["add(42.5, 0.002)"]
+        assert kwargs == []
+
+    def test_float_in_list(self):
+        tag_content = "{% component [-1.5, +2., -1.2e2, .2e-02] %}"
+        tag = parse_tag(tag_content)
+
+        expected_tag = GenericTag(
+            token=token(tag_content, 0, 1, 1),
+            name=token("component", 3, 1, 4),
+            attrs=[
+                TagAttr(
+                    token=token("[-1.5, +2., -1.2e2, .2e-02]", 13, 1, 14),
+                    key=None,
+                    value=plain_list_value(
+                        token("[-1.5, +2., -1.2e2, .2e-02]", 13, 1, 14),
+                        [
+                            ValueChild(plain_float_value("-1.5", 14, 1, 15, None)),
+                            ValueChild(plain_float_value("+2.", 20, 1, 21, None)),
+                            ValueChild(plain_float_value("-1.2e2", 25, 1, 26, None)),
+                            ValueChild(plain_float_value(".2e-02", 33, 1, 34, None)),
+                        ],
+                    ),
+                    is_flag=False,
+                ),
+            ],
+            is_self_closing=False,
+            used_variables=[],
+            assigned_variables=[],
+        )
+
+        assert tag == expected_tag
+
+        tag_func = _simple_compile_tag(tag, tag_content)
+        args, kwargs = tag_func({})
+
+        assert args == [[-1.5, 2.0, -120.0, 0.002]]
+        assert kwargs == []
+
+    def test_float_in_dict(self):
+        tag_content = "{% component {key: -1.5|add:.2e-02} %}"
+        tag = parse_tag(tag_content)
+
+        expected_tag = GenericTag(
+            token=token(tag_content, 0, 1, 1),
+            name=token("component", 3, 1, 4),
+            attrs=[
+                TagAttr(
+                    token=token("{key: -1.5|add:.2e-02}", 13, 1, 14),
+                    key=None,
+                    value=plain_dict_value(
+                        token("{key: -1.5|add:.2e-02}", 13, 1, 14),
+                        [
+                            ValueChild(plain_variable_value("key", 14, 1, 15, None)),
+                            ValueChild(
+                                float_value(
+                                    token("-1.5|add:.2e-02", 19, 1, 20),
+                                    token("-1.5", 19, 1, 20),
+                                    None,
+                                    [
+                                        TagValueFilter(
+                                            token=token("|add:.2e-02", 23, 1, 24),
+                                            name=token("add", 24, 1, 25),
+                                            arg=plain_float_value(
+                                                ".2e-02", 28, 1, 29, None
+                                            ),
+                                        )
+                                    ],
+                                    [],
+                                    [],
+                                )
+                            ),
+                        ],
+                    ),
+                    is_flag=False,
+                ),
+            ],
+            is_self_closing=False,
+            used_variables=[token("key", 14, 1, 15)],
+            assigned_variables=[],
+        )
+
+        assert tag == expected_tag
+
+        tag_func = _simple_compile_tag(tag, tag_content)
+        args, kwargs = tag_func({"key": "some_key"})
+
+        assert args == [{"some_key": "add(-1.5, 0.002)"}]
+        assert kwargs == []
+
+
+class TestInt:
+    def test_int_simple_as_arg(self):
+        tag_content = "{% component -42 %}"
+        tag = parse_tag(tag_content)
+
+        expected_tag = GenericTag(
+            token=token(tag_content, 0, 1, 1),
+            name=token("component", 3, 1, 4),
+            attrs=[
+                TagAttr(
+                    token=token("-42", 13, 1, 14),
+                    key=None,
+                    value=plain_int_value("-42", 13, 1, 14, None),
+                    is_flag=False,
+                ),
+            ],
+            is_self_closing=False,
+            used_variables=[],
+            assigned_variables=[],
+        )
+
+        assert tag == expected_tag
+
+        tag_func = _simple_compile_tag(tag, tag_content)
+        args, kwargs = tag_func({})
+
+        assert args == [-42]
+        assert kwargs == []
+
+    def test_int_simple_as_kwarg(self):
+        tag_content = "{% component key=123 %}"
+        tag = parse_tag(tag_content)
+
+        expected_tag = GenericTag(
+            token=token(tag_content, 0, 1, 1),
+            name=token("component", 3, 1, 4),
+            attrs=[
+                TagAttr(
+                    token=token("key=123", 13, 1, 14),
+                    key=token("key", 13, 1, 14),
+                    value=plain_int_value("123", 17, 1, 18, None),
+                    is_flag=False,
+                ),
+            ],
+            is_self_closing=False,
+            used_variables=[],
+            assigned_variables=[],
+        )
+
+        assert tag == expected_tag
+
+        tag_func = _simple_compile_tag(tag, tag_content)
+        args, kwargs = tag_func({})
+
+        assert args == []
+        assert kwargs == [("key", 123)]
+
+    def test_int_with_filter(self):
+        tag_content = "{% component -42|abs %}"
+        tag = parse_tag(tag_content)
+
+        expected_tag = GenericTag(
+            token=token(tag_content, 0, 1, 1),
+            name=token("component", 3, 1, 4),
+            attrs=[
+                TagAttr(
+                    token=token("-42|abs", 13, 1, 14),
+                    key=None,
+                    value=int_value(
+                        token("-42|abs", 13, 1, 14),
+                        token("-42", 13, 1, 14),
+                        None,
+                        [
+                            TagValueFilter(
+                                token=token("|abs", 16, 1, 17),
+                                name=token("abs", 17, 1, 18),
+                                arg=None,
+                            )
+                        ],
+                        [],
+                        [],
+                    ),
+                    is_flag=False,
+                ),
+            ],
+            is_self_closing=False,
+            used_variables=[],
+            assigned_variables=[],
+        )
+
+        assert tag == expected_tag
+
+        tag_func = _simple_compile_tag(tag, tag_content)
+        args, kwargs = tag_func({})
+
+        assert args == ["abs(-42, None)"]
+        assert kwargs == []
+
+    def test_int_as_filter_arg(self):
+        tag_content = "{% component 42|add:-5 %}"
+        tag = parse_tag(tag_content)
+
+        expected_tag = GenericTag(
+            token=token(tag_content, 0, 1, 1),
+            name=token("component", 3, 1, 4),
+            attrs=[
+                TagAttr(
+                    token=token("42|add:-5", 13, 1, 14),
+                    key=None,
+                    value=int_value(
+                        token("42|add:-5", 13, 1, 14),
+                        token("42", 13, 1, 14),
+                        None,
+                        [
+                            TagValueFilter(
+                                token=token("|add:-5", 15, 1, 16),
+                                name=token("add", 16, 1, 17),
+                                arg=plain_int_value("-5", 20, 1, 21, None),
+                            )
+                        ],
+                        [],
+                        [],
+                    ),
+                    is_flag=False,
+                ),
+            ],
+            is_self_closing=False,
+            used_variables=[],
+            assigned_variables=[],
+        )
+
+        assert tag == expected_tag
+
+        tag_func = _simple_compile_tag(tag, tag_content)
+        args, kwargs = tag_func({})
+
+        assert args == ["add(42, -5)"]
+        assert kwargs == []
+
+    def test_int_in_list(self):
+        tag_content = "{% component [-42, 123, 0, -1] %}"
+        tag = parse_tag(tag_content)
+
+        expected_tag = GenericTag(
+            token=token(tag_content, 0, 1, 1),
+            name=token("component", 3, 1, 4),
+            attrs=[
+                TagAttr(
+                    token=token("[-42, 123, 0, -1]", 13, 1, 14),
+                    key=None,
+                    value=plain_list_value(
+                        token("[-42, 123, 0, -1]", 13, 1, 14),
+                        [
+                            ValueChild(plain_int_value("-42", 14, 1, 15, None)),
+                            ValueChild(plain_int_value("123", 19, 1, 20, None)),
+                            ValueChild(plain_int_value("0", 24, 1, 25, None)),
+                            ValueChild(plain_int_value("-1", 27, 1, 28, None)),
+                        ],
+                    ),
+                    is_flag=False,
+                ),
+            ],
+            is_self_closing=False,
+            used_variables=[],
+            assigned_variables=[],
+        )
+
+        assert tag == expected_tag
+
+        tag_func = _simple_compile_tag(tag, tag_content)
+        args, kwargs = tag_func({})
+
+        assert args == [[-42, 123, 0, -1]]
+        assert kwargs == []
+
+    def test_int_in_dict(self):
+        tag_content = "{% component {key: -42|add:5} %}"
+        tag = parse_tag(tag_content)
+
+        expected_tag = GenericTag(
+            token=token(tag_content, 0, 1, 1),
+            name=token("component", 3, 1, 4),
+            attrs=[
+                TagAttr(
+                    token=token("{key: -42|add:5}", 13, 1, 14),
+                    key=None,
+                    value=plain_dict_value(
+                        token("{key: -42|add:5}", 13, 1, 14),
+                        [
+                            ValueChild(plain_variable_value("key", 14, 1, 15, None)),
+                            ValueChild(
+                                int_value(
+                                    token("-42|add:5", 19, 1, 20),
+                                    token("-42", 19, 1, 20),
+                                    None,
+                                    [
+                                        TagValueFilter(
+                                            token=token("|add:5", 22, 1, 23),
+                                            name=token("add", 23, 1, 24),
+                                            arg=plain_int_value("5", 27, 1, 28, None),
+                                        )
+                                    ],
+                                    [],
+                                    [],
+                                )
+                            ),
+                        ],
+                    ),
+                    is_flag=False,
+                ),
+            ],
+            is_self_closing=False,
+            used_variables=[token("key", 14, 1, 15)],
+            assigned_variables=[],
+        )
+
+        assert tag == expected_tag
+
+        tag_func = _simple_compile_tag(tag, tag_content)
+        args, kwargs = tag_func({"key": "some_key"})
+
+        assert args == [{"some_key": "add(-42, 5)"}]
+        assert kwargs == []
+
+
+class TestString:
+    def test_string_simple_as_arg(self):
+        tag_content = "{% component 'hello' %}"
+        tag = parse_tag(tag_content)
+
+        expected_tag = GenericTag(
+            token=token(tag_content, 0, 1, 1),
+            name=token("component", 3, 1, 4),
+            attrs=[
+                TagAttr(
+                    token=token("'hello'", 13, 1, 14),
+                    key=None,
+                    value=plain_string_value("'hello'", 13, 1, 14, None),
+                    is_flag=False,
+                ),
+            ],
+            is_self_closing=False,
+            used_variables=[],
+            assigned_variables=[],
+        )
+
+        assert tag == expected_tag
+
+        tag_func = _simple_compile_tag(tag, tag_content)
+        args, kwargs = tag_func({})
+
+        assert args == ["hello"]
+        assert kwargs == []
+
+    def test_string_simple_as_kwarg(self):
+        tag_content = '{% component key="world" %}'
+        tag = parse_tag(tag_content)
+
+        expected_tag = GenericTag(
+            token=token(tag_content, 0, 1, 1),
+            name=token("component", 3, 1, 4),
+            attrs=[
+                TagAttr(
+                    token=token('key="world"', 13, 1, 14),
+                    key=token("key", 13, 1, 14),
+                    value=plain_string_value('"world"', 17, 1, 18, None),
+                    is_flag=False,
+                ),
+            ],
+            is_self_closing=False,
+            used_variables=[],
+            assigned_variables=[],
+        )
+
+        assert tag == expected_tag
+
+        tag_func = _simple_compile_tag(tag, tag_content)
+        args, kwargs = tag_func({})
+
+        assert args == []
+        assert kwargs == [("key", "world")]
+
+    def test_string_with_filter(self):
+        tag_content = "{% component 'hello'|upper %}"
+        tag = parse_tag(tag_content)
+
+        expected_tag = GenericTag(
+            token=token(tag_content, 0, 1, 1),
+            name=token("component", 3, 1, 4),
+            attrs=[
+                TagAttr(
+                    token=token("'hello'|upper", 13, 1, 14),
+                    key=None,
+                    value=string_value(
+                        token("'hello'|upper", 13, 1, 14),
+                        token("'hello'", 13, 1, 14),
+                        None,
+                        [
+                            TagValueFilter(
+                                token=token("|upper", 20, 1, 21),
+                                name=token("upper", 21, 1, 22),
+                                arg=None,
+                            )
+                        ],
+                        [],
+                        [],
+                    ),
+                    is_flag=False,
+                ),
+            ],
+            is_self_closing=False,
+            used_variables=[],
+            assigned_variables=[],
+        )
+
+        assert tag == expected_tag
+
+        tag_func = _simple_compile_tag(tag, tag_content)
+        args, kwargs = tag_func({})
+
+        assert args == ["upper(hello, None)"]
+        assert kwargs == []
+
+    def test_string_as_filter_arg(self):
+        tag_content = '{% component "test"|default:"default_value" %}'
+        tag = parse_tag(tag_content)
+
+        expected_tag = GenericTag(
+            token=token(tag_content, 0, 1, 1),
+            name=token("component", 3, 1, 4),
+            attrs=[
+                TagAttr(
+                    token=token('"test"|default:"default_value"', 13, 1, 14),
+                    key=None,
+                    value=string_value(
+                        token('"test"|default:"default_value"', 13, 1, 14),
+                        token('"test"', 13, 1, 14),
+                        None,
+                        [
+                            TagValueFilter(
+                                token=token('|default:"default_value"', 19, 1, 20),
+                                name=token("default", 20, 1, 21),
+                                arg=plain_string_value(
+                                    '"default_value"', 28, 1, 29, None
+                                ),
+                            )
+                        ],
+                        [],
+                        [],
+                    ),
+                    is_flag=False,
+                ),
+            ],
+            is_self_closing=False,
+            used_variables=[],
+            assigned_variables=[],
+        )
+
+        assert tag == expected_tag
+
+        tag_func = _simple_compile_tag(tag, tag_content)
+        args, kwargs = tag_func({})
+
+        assert args == ["default(test, default_value)"]
+        assert kwargs == []
+
+    def test_string_in_list(self):
+        tag_content = "{% component ['hello', \"world\", 'test'] %}"
+        tag = parse_tag(tag_content)
+
+        expected_tag = GenericTag(
+            token=token(tag_content, 0, 1, 1),
+            name=token("component", 3, 1, 4),
+            attrs=[
+                TagAttr(
+                    token=token("['hello', \"world\", 'test']", 13, 1, 14),
+                    key=None,
+                    value=plain_list_value(
+                        token("['hello', \"world\", 'test']", 13, 1, 14),
+                        [
+                            ValueChild(plain_string_value("'hello'", 14, 1, 15, None)),
+                            ValueChild(plain_string_value('"world"', 23, 1, 24, None)),
+                            ValueChild(plain_string_value("'test'", 32, 1, 33, None)),
+                        ],
+                    ),
+                    is_flag=False,
+                ),
+            ],
+            is_self_closing=False,
+            used_variables=[],
+            assigned_variables=[],
+        )
+
+        assert tag == expected_tag
+
+        tag_func = _simple_compile_tag(tag, tag_content)
+        args, kwargs = tag_func({})
+
+        assert args == [["hello", "world", "test"]]
+        assert kwargs == []
+
+    def test_string_in_dict(self):
+        tag_content = '{% component {key: "hello"|upper} %}'
+        tag = parse_tag(tag_content)
+
+        expected_tag = GenericTag(
+            token=token(tag_content, 0, 1, 1),
+            name=token("component", 3, 1, 4),
+            attrs=[
+                TagAttr(
+                    token=token('{key: "hello"|upper}', 13, 1, 14),
+                    key=None,
+                    value=plain_dict_value(
+                        token('{key: "hello"|upper}', 13, 1, 14),
+                        [
+                            ValueChild(plain_variable_value("key", 14, 1, 15, None)),
+                            ValueChild(
+                                string_value(
+                                    token('"hello"|upper', 19, 1, 20),
+                                    token('"hello"', 19, 1, 20),
+                                    None,
+                                    [
+                                        TagValueFilter(
+                                            token=token("|upper", 26, 1, 27),
+                                            name=token("upper", 27, 1, 28),
+                                            arg=None,
+                                        )
+                                    ],
+                                    [],
+                                    [],
+                                )
+                            ),
+                        ],
+                    ),
+                    is_flag=False,
+                ),
+            ],
+            is_self_closing=False,
+            used_variables=[token("key", 14, 1, 15)],
+            assigned_variables=[],
+        )
+
+        assert tag == expected_tag
+
+        tag_func = _simple_compile_tag(tag, tag_content)
+        args, kwargs = tag_func({"key": "some_key"})
+
+        assert args == [{"some_key": "upper(hello, None)"}]
+        assert kwargs == []
+
+
+class TestVariable:
+    def test_variable_simple_as_arg(self):
+        tag_content = "{% component my_var %}"
+        tag = parse_tag(tag_content)
+
+        expected_tag = GenericTag(
+            token=token(tag_content, 0, 1, 1),
+            name=token("component", 3, 1, 4),
+            attrs=[
+                TagAttr(
+                    token=token("my_var", 13, 1, 14),
+                    key=None,
+                    value=plain_variable_value("my_var", 13, 1, 14, None),
+                    is_flag=False,
+                ),
+            ],
+            is_self_closing=False,
+            used_variables=[token("my_var", 13, 1, 14)],
+            assigned_variables=[],
+        )
+
+        assert tag == expected_tag
+
+        tag_func = _simple_compile_tag(tag, tag_content)
+        args, kwargs = tag_func({"my_var": "test_value"})
+
+        assert args == ["test_value"]
+        assert kwargs == []
+
+    def test_variable_simple_as_kwarg(self):
+        tag_content = "{% component key=my_var %}"
+        tag = parse_tag(tag_content)
+
+        expected_tag = GenericTag(
+            token=token(tag_content, 0, 1, 1),
+            name=token("component", 3, 1, 4),
+            attrs=[
+                TagAttr(
+                    token=token("key=my_var", 13, 1, 14),
+                    key=token("key", 13, 1, 14),
+                    value=plain_variable_value("my_var", 17, 1, 18, None),
+                    is_flag=False,
+                ),
+            ],
+            is_self_closing=False,
+            used_variables=[token("my_var", 17, 1, 18)],
+            assigned_variables=[],
+        )
+
+        assert tag == expected_tag
+
+        tag_func = _simple_compile_tag(tag, tag_content)
+        args, kwargs = tag_func({"my_var": "test_value"})
+
+        assert args == []
+        assert kwargs == [("key", "test_value")]
+
+    def test_variable_with_filter(self):
+        tag_content = "{% component my_var|upper %}"
+        tag = parse_tag(tag_content)
+
+        expected_tag = GenericTag(
+            token=token(tag_content, 0, 1, 1),
+            name=token("component", 3, 1, 4),
+            attrs=[
+                TagAttr(
+                    token=token("my_var|upper", 13, 1, 14),
+                    key=None,
+                    value=variable_value(
+                        token("my_var|upper", 13, 1, 14),
+                        token("my_var", 13, 1, 14),
+                        None,
+                        [
+                            TagValueFilter(
+                                token=token("|upper", 19, 1, 20),
+                                name=token("upper", 20, 1, 21),
+                                arg=None,
+                            )
+                        ],
+                        [],
+                        [],
+                    ),
+                    is_flag=False,
+                ),
+            ],
+            is_self_closing=False,
+            used_variables=[token("my_var", 13, 1, 14)],
+            assigned_variables=[],
+        )
+
+        assert tag == expected_tag
+
+        tag_func = _simple_compile_tag(tag, tag_content)
+        args, kwargs = tag_func({"my_var": "hello"})
+
+        assert args == ["upper(hello, None)"]
+        assert kwargs == []
+
+    def test_variable_as_filter_arg(self):
+        tag_content = "{% component my_var|default:other_var %}"
+        tag = parse_tag(tag_content)
+
+        expected_tag = GenericTag(
+            token=token(tag_content, 0, 1, 1),
+            name=token("component", 3, 1, 4),
+            attrs=[
+                TagAttr(
+                    token=token("my_var|default:other_var", 13, 1, 14),
+                    key=None,
+                    value=variable_value(
+                        token("my_var|default:other_var", 13, 1, 14),
+                        token("my_var", 13, 1, 14),
+                        None,
+                        [
+                            TagValueFilter(
+                                token=token("|default:other_var", 19, 1, 20),
+                                name=token("default", 20, 1, 21),
+                                arg=plain_variable_value("other_var", 28, 1, 29, None),
+                            )
+                        ],
+                        [],
+                        [],
+                    ),
+                    is_flag=False,
+                ),
+            ],
+            is_self_closing=False,
+            used_variables=[
+                token("my_var", 13, 1, 14),
+                token("other_var", 28, 1, 29),
+            ],
+            assigned_variables=[],
+        )
+
+        assert tag == expected_tag
+
+        tag_func = _simple_compile_tag(tag, tag_content)
+        args, kwargs = tag_func({"my_var": None, "other_var": "fallback"})
+
+        assert args == ["default(None, fallback)"]
+        assert kwargs == []
+
+    def test_variable_in_list(self):
+        tag_content = "{% component [var1, var2, var3] %}"
+        tag = parse_tag(tag_content)
+
+        expected_tag = GenericTag(
+            token=token(tag_content, 0, 1, 1),
+            name=token("component", 3, 1, 4),
+            attrs=[
+                TagAttr(
+                    token=token("[var1, var2, var3]", 13, 1, 14),
+                    key=None,
+                    value=plain_list_value(
+                        token("[var1, var2, var3]", 13, 1, 14),
+                        [
+                            ValueChild(plain_variable_value("var1", 14, 1, 15, None)),
+                            ValueChild(plain_variable_value("var2", 20, 1, 21, None)),
+                            ValueChild(plain_variable_value("var3", 26, 1, 27, None)),
+                        ],
+                    ),
+                    is_flag=False,
+                ),
+            ],
+            is_self_closing=False,
+            used_variables=[
+                token("var1", 14, 1, 15),
+                token("var2", 20, 1, 21),
+                token("var3", 26, 1, 27),
+            ],
+            assigned_variables=[],
+        )
+
+        assert tag == expected_tag
+
+        tag_func = _simple_compile_tag(tag, tag_content)
+        args, kwargs = tag_func({"var1": "value1", "var2": "value2", "var3": "value3"})
+
+        assert args == [["value1", "value2", "value3"]]
+        assert kwargs == []
+
+    def test_variable_in_dict(self):
+        tag_content = "{% component {key: my_var|upper} %}"
+        tag = parse_tag(tag_content)
+
+        expected_tag = GenericTag(
+            token=token(tag_content, 0, 1, 1),
+            name=token("component", 3, 1, 4),
+            attrs=[
+                TagAttr(
+                    token=token("{key: my_var|upper}", 13, 1, 14),
+                    key=None,
+                    value=plain_dict_value(
+                        token("{key: my_var|upper}", 13, 1, 14),
+                        [
+                            ValueChild(plain_variable_value("key", 14, 1, 15, None)),
+                            ValueChild(
+                                variable_value(
+                                    token("my_var|upper", 19, 1, 20),
+                                    token("my_var", 19, 1, 20),
+                                    None,
+                                    [
+                                        TagValueFilter(
+                                            token=token("|upper", 25, 1, 26),
+                                            name=token("upper", 26, 1, 27),
+                                            arg=None,
+                                        )
+                                    ],
+                                    [],
+                                    [],
+                                )
+                            ),
+                        ],
+                    ),
+                    is_flag=False,
+                ),
+            ],
+            is_self_closing=False,
+            used_variables=[
+                token("key", 14, 1, 15),
+                token("my_var", 19, 1, 20),
+            ],
+            assigned_variables=[],
+        )
+
+        assert tag == expected_tag
+
+        tag_func = _simple_compile_tag(tag, tag_content)
+        args, kwargs = tag_func({"key": "some_key", "my_var": "hello"})
+
+        assert args == [{"some_key": "upper(hello, None)"}]
+        assert kwargs == []
+
+
+class TestPythonExpr:
+    def test_python_expr_as_arg(self):
+        tag_content = "{% component ('hello'.append(myvar)) %}"
+        tag = parse_tag(tag_content)
+
+        expected_tag = GenericTag(
+            token=token(tag_content, 0, 1, 1),
+            name=token("component", 3, 1, 4),
+            attrs=[
+                TagAttr(
+                    token=token("('hello'.append(myvar))", 13, 1, 14),
+                    key=None,
+                    value=TagValue(
+                        token=token("('hello'.append(myvar))", 13, 1, 14),
+                        value=token("('hello'.append(myvar))", 13, 1, 14),
+                        children=[],
+                        kind=ValueKind("python_expr"),
+                        spread=None,
+                        filters=[],
+                        used_variables=[token("myvar", 29, 1, 30)],
+                        assigned_variables=[],
+                    ),
+                    is_flag=False,
+                ),
+            ],
+            is_self_closing=False,
+            used_variables=[token("myvar", 29, 1, 30)],
+            assigned_variables=[],
+        )
+
+        assert tag == expected_tag
+
+        tag_func = _simple_compile_tag(tag, tag_content)
+        args, kwargs = tag_func({})
+
+        assert args == ["EXPR_RESOLVED:('hello'.append(myvar))"]
+        assert kwargs == []
+
+    def test_python_expr_simple_as_kwarg(self):
+        tag_content = "{% component key=('world'.append(myvar)) %}"
+        tag = parse_tag(tag_content)
+
+        expected_tag = GenericTag(
+            token=token(tag_content, 0, 1, 1),
+            name=token("component", 3, 1, 4),
+            attrs=[
+                TagAttr(
+                    token=token("key=('world'.append(myvar))", 13, 1, 14),
+                    key=token("key", 13, 1, 14),
+                    value=TagValue(
+                        token=token("('world'.append(myvar))", 17, 1, 18),
+                        value=token("('world'.append(myvar))", 17, 1, 18),
+                        children=[],
+                        kind=ValueKind("python_expr"),
+                        spread=None,
+                        filters=[],
+                        used_variables=[token("myvar", 33, 1, 34)],
+                        assigned_variables=[],
+                    ),
+                    is_flag=False,
+                ),
+            ],
+            is_self_closing=False,
+            used_variables=[token("myvar", 33, 1, 34)],
+            assigned_variables=[],
+        )
+
+        assert tag == expected_tag
+
+        tag_func = _simple_compile_tag(tag, tag_content)
+        args, kwargs = tag_func({})
+
+        assert args == []
+        assert kwargs == [("key", "EXPR_RESOLVED:('world'.append(myvar))")]
+
+    def test_python_expr_with_filter(self):
+        tag_content = "{% component ('test'.upper())|lower %}"
+        tag = parse_tag(tag_content)
+
+        expected_tag = GenericTag(
+            token=token(tag_content, 0, 1, 1),
+            name=token("component", 3, 1, 4),
+            attrs=[
+                TagAttr(
+                    token=token("('test'.upper())|lower", 13, 1, 14),
+                    key=None,
+                    value=python_expr_value(
+                        token("('test'.upper())|lower", 13, 1, 14),
+                        token("('test'.upper())", 13, 1, 14),
+                        None,
+                        [
+                            TagValueFilter(
+                                token=token("|lower", 29, 1, 30),
+                                name=token("lower", 30, 1, 31),
+                                arg=None,
+                            )
+                        ],
+                        [],
+                        [],
+                    ),
+                    is_flag=False,
+                ),
+            ],
+            is_self_closing=False,
+            used_variables=[],
+            assigned_variables=[],
+        )
+
+        assert tag == expected_tag
+
+        tag_func = _simple_compile_tag(tag, tag_content)
+        args, kwargs = tag_func({})
+
+        assert args == ["lower(EXPR_RESOLVED:('test'.upper()), None)"]
+        assert kwargs == []
+
+    def test_python_expr_as_filter_arg(self):
+        tag_content = "{% component my_var|default:('fallback'.append(myvar)) %}"
+        tag = parse_tag(tag_content)
+
+        expected_tag = GenericTag(
+            token=token(tag_content, 0, 1, 1),
+            name=token("component", 3, 1, 4),
+            attrs=[
+                TagAttr(
+                    token=token("my_var|default:('fallback'.append(myvar))", 13, 1, 14),
+                    key=None,
+                    value=variable_value(
+                        token("my_var|default:('fallback'.append(myvar))", 13, 1, 14),
+                        token("my_var", 13, 1, 14),
+                        None,
+                        [
+                            TagValueFilter(
+                                token=token(
+                                    "|default:('fallback'.append(myvar))", 19, 1, 20
+                                ),
+                                name=token("default", 20, 1, 21),
+                                arg=TagValue(
+                                    token=token(
+                                        "('fallback'.append(myvar))", 28, 1, 29
+                                    ),
+                                    value=token(
+                                        "('fallback'.append(myvar))", 28, 1, 29
+                                    ),
+                                    children=[],
+                                    kind=ValueKind("python_expr"),
+                                    spread=None,
+                                    filters=[],
+                                    used_variables=[token("myvar", 47, 1, 48)],
+                                    assigned_variables=[],
+                                ),
+                            )
+                        ],
+                        [],
+                        [],
+                    ),
+                    is_flag=False,
+                ),
+            ],
+            is_self_closing=False,
+            used_variables=[token("my_var", 13, 1, 14), token("myvar", 47, 1, 48)],
+            assigned_variables=[],
+        )
+
+        assert tag == expected_tag
+
+        tag_func = _simple_compile_tag(tag, tag_content)
+        args, kwargs = tag_func({"my_var": None})
+
+        assert args == ["default(None, EXPR_RESOLVED:('fallback'.append(myvar)))"]
+        assert kwargs == []
+
+    def test_python_expr_in_list(self):
+        tag_content = "{% component [('one'.upper()), ('two'.lower())] %}"
+        tag = parse_tag(tag_content)
+
+        expected_tag = GenericTag(
+            token=token(tag_content, 0, 1, 1),
+            name=token("component", 3, 1, 4),
+            attrs=[
+                TagAttr(
+                    token=token(
+                        "[('one'.upper()), ('two'.lower())]",
+                        13,
+                        1,
+                        14,
+                    ),
+                    key=None,
+                    value=plain_list_value(
+                        token(
+                            "[('one'.upper()), ('two'.lower())]",
+                            13,
+                            1,
+                            14,
+                        ),
+                        [
+                            ValueChild(
+                                plain_python_expr_value(
+                                    "('one'.upper())", 14, 1, 15, None
+                                )
+                            ),
+                            ValueChild(
+                                plain_python_expr_value(
+                                    "('two'.lower())", 31, 1, 32, None
+                                )
+                            ),
+                        ],
+                    ),
+                    is_flag=False,
+                ),
+            ],
+            is_self_closing=False,
+            used_variables=[],
+            assigned_variables=[],
+        )
+
+        assert tag == expected_tag
+
+        tag_func = _simple_compile_tag(tag, tag_content)
+        args, kwargs = tag_func({})
+
+        assert args == [
+            [
+                "EXPR_RESOLVED:('one'.upper())",
+                "EXPR_RESOLVED:('two'.lower())",
+            ]
+        ]
+        assert kwargs == []
+
+    def test_python_expr_in_dict(self):
+        tag_content = "{% component {('key'.upper()): ('val'.lower())|upper} %}"
+        tag = parse_tag(tag_content)
+
+        expected_tag = GenericTag(
+            token=token(tag_content, 0, 1, 1),
+            name=token("component", 3, 1, 4),
+            attrs=[
+                TagAttr(
+                    token=token("{('key'.upper()): ('val'.lower())|upper}", 13, 1, 14),
+                    key=None,
+                    value=plain_dict_value(
+                        token(
+                            "{('key'.upper()): ('val'.lower())|upper}",
+                            13,
+                            1,
+                            14,
+                        ),
+                        [
+                            ValueChild(
+                                plain_python_expr_value(
+                                    "('key'.upper())", 14, 1, 15, None
+                                )
+                            ),
+                            ValueChild(
+                                python_expr_value(
+                                    token("('val'.lower())|upper", 31, 1, 32),
+                                    token("('val'.lower())", 31, 1, 32),
+                                    None,
+                                    [
+                                        TagValueFilter(
+                                            token=token("|upper", 46, 1, 47),
+                                            name=token("upper", 47, 1, 48),
+                                            arg=None,
+                                        )
+                                    ],
+                                    [],
+                                    [],
+                                )
+                            ),
+                        ],
+                    ),
+                    is_flag=False,
+                ),
+            ],
+            is_self_closing=False,
+            used_variables=[],
+            assigned_variables=[],
+        )
+
+        assert tag == expected_tag
+
+        tag_func = _simple_compile_tag(tag, tag_content)
+        args, kwargs = tag_func({})
+
+        assert args == [
+            {
+                "EXPR_RESOLVED:('key'.upper())": "upper(EXPR_RESOLVED:('val'.lower()), None)"
+            }
+        ]
+        assert kwargs == []
+
+
+class TestEndTag:
+    def test_endtag_normal(self):
+        tag_content = "{% endslot %}"
+        tag = parse_tag(tag_content)
+
+        expected_tag = EndTag(
+            token=token(tag_content, 0, 1, 1),
+            name=token("endslot", 3, 1, 4),
+        )
+
+        assert tag == expected_tag
+
+    def test_endtag_just_end(self):
+        tag_content = "{% end %}"
+        tag = parse_tag(tag_content)
+
+        expected_tag = GenericTag(
+            token=token(tag_content, 0, 1, 1),
+            name=token("end", 3, 1, 4),
+            attrs=[],
+            is_self_closing=False,
+            used_variables=[],
+            assigned_variables=[],
+        )
+
+        assert tag == expected_tag
+
+    def test_endtag_no_whitespace(self):
+        tag_content = "{%endslot%}"
+        tag = parse_tag(tag_content)
+
+        expected_tag = EndTag(
+            token=token(tag_content, 0, 1, 1),
+            name=token("endslot", 2, 1, 3),
+        )
+
+        assert tag == expected_tag
+
+    def test_endtag_with_comments(self):
+        tag_content = "{% {# comment #} endslot {# another #} %}"
+        tag = parse_tag(tag_content)
+
+        expected_tag = EndTag(
+            token=token(tag_content, 0, 1, 1),
+            name=token("endslot", 17, 1, 18),
+        )
+
+        assert tag == expected_tag
+
+    def test_endtag_with_attrs_errors(self):
+        tag_content = "{% endslot key=val %}"
+        with pytest.raises(SyntaxError, match="End tags can only contain the tag name"):
+            parse_tag(tag_content)
+
+    def test_endtag_self_closing_errors(self):
+        tag_content = "{% endslot / %}"
+        with pytest.raises(SyntaxError, match="End tags can only contain the tag name"):
+            parse_tag(tag_content)
+
+    def test_endtag_different_names(self):
+        tag_content = "{% endif %}"
+        tag = parse_tag(tag_content)
+
+        expected_tag = EndTag(
+            token=token(tag_content, 0, 1, 1),
+            name=token("endif", 3, 1, 4),
+        )
+
+        assert tag == expected_tag
+
+        tag_content2 = "{% endfor %}"
+        tag2 = parse_tag(tag_content2)
+
+        expected_tag2 = EndTag(
+            token=token(tag_content2, 0, 1, 1),
+            name=token("endfor", 3, 1, 4),
+        )
+
+        assert tag2 == expected_tag2
+
+
+class TestForLoopTag:
+    def test_forloop_basic(self):
+        tag_content = "{% for item in items %}"
+        tag = parse_tag(tag_content)
+
+        expected_tag = ForLoopTag(
+            token=token(tag_content, 0, 1, 1),
+            name=token("for", 3, 1, 4),
+            targets=[token("item", 7, 1, 8)],
+            iterable=plain_variable_value("items", 15, 1, 16, None),
+            used_variables=[token("items", 15, 1, 16)],
+            assigned_variables=[],
+        )
+
+        assert tag == expected_tag
+
+    def test_forloop_multiple_targets(self):
+        tag_content = "{% for x, y, z in matrix %}"
+        tag = parse_tag(tag_content)
+
+        expected_tag = ForLoopTag(
+            token=token(tag_content, 0, 1, 1),
+            name=token("for", 3, 1, 4),
+            targets=[
+                token("x", 7, 1, 8),
+                token("y", 10, 1, 11),
+                token("z", 13, 1, 14),
+            ],
+            iterable=plain_variable_value("matrix", 18, 1, 19, None),
+            used_variables=[token("matrix", 18, 1, 19)],
+            assigned_variables=[],
+        )
+
+        assert tag == expected_tag
+
+    def test_forloop_with_filter_on_iterable(self):
+        tag_content = "{% for item in items|filter:arg %}"
+        tag = parse_tag(tag_content)
+
+        expected_tag = ForLoopTag(
+            token=token(tag_content, 0, 1, 1),
+            name=token("for", 3, 1, 4),
+            targets=[token("item", 7, 1, 8)],
+            iterable=variable_value(
+                token("items|filter:arg", 15, 1, 16),
+                token("items", 15, 1, 16),
+                None,
+                [
+                    TagValueFilter(
+                        token=token("|filter:arg", 20, 1, 21),
+                        name=token("filter", 21, 1, 22),
+                        arg=plain_variable_value("arg", 28, 1, 29, None),
+                    )
+                ],
+                [],
+                [],
+            ),
+            used_variables=[token("items", 15, 1, 16), token("arg", 28, 1, 29)],
+            assigned_variables=[],
+        )
+
+        assert tag == expected_tag
+
+    def test_forloop_with_python_expr_iterable(self):
+        tag_content = "{% for item in (items + other_items) %}"
+        tag = parse_tag(tag_content)
+
+        expected_tag = ForLoopTag(
+            token=token(tag_content, 0, 1, 1),
+            name=token("for", 3, 1, 4),
+            targets=[token("item", 7, 1, 8)],
+            iterable=TagValue(
+                token=token("(items + other_items)", 15, 1, 16),
+                value=token("(items + other_items)", 15, 1, 16),
+                children=[],
+                kind=ValueKind("python_expr"),
+                spread=None,
+                filters=[],
+                used_variables=[
+                    token("items", 16, 1, 17),
+                    token("other_items", 24, 1, 25),
+                ],
+                assigned_variables=[],
+            ),
+            used_variables=[token("items", 16, 1, 17), token("other_items", 24, 1, 25)],
+            assigned_variables=[],
+        )
+
+        assert tag == expected_tag
+
+    def test_forloop_missing_in_keyword(self):
+        tag_content = "{% for item items %}"
+        with pytest.raises(SyntaxError):
+            parse_tag(tag_content)
+
+    def test_forloop_missing_iterable(self):
+        tag_content = "{% for item in %}"
+        with pytest.raises(SyntaxError):
+            parse_tag(tag_content)
+
+    def test_forloop_missing_targets(self):
+        tag_content = "{% for in items %}"
+        with pytest.raises(SyntaxError):
+            parse_tag(tag_content)
+
+    def test_forloop_self_closing_error(self):
+        tag_content = "{% for item in items / %}"
+        with pytest.raises(SyntaxError):
+            parse_tag(tag_content)
+
+
+class TestDict:
+    def test_dict_simple(self):
+        tag_content = '{% component data={ "key": "val" } %}'
+        tag = parse_tag(tag_content)
+
+        expected_tag = GenericTag(
+            token=token(tag_content, 0, 1, 1),
+            name=token("component", 3, 1, 4),
+            attrs=[
+                TagAttr(
+                    token=token('data={ "key": "val" }', 13, 1, 14),
+                    key=token("data", 13, 1, 14),
+                    value=plain_dict_value(
+                        token('{ "key": "val" }', 18, 1, 19),
+                        [
+                            ValueChild(plain_string_value('"key"', 20, 1, 21, None)),
+                            ValueChild(plain_string_value('"val"', 27, 1, 28, None)),
+                        ],
+                    ),
+                    is_flag=False,
+                ),
+            ],
+            is_self_closing=False,
+            used_variables=[],
+            assigned_variables=[],
+        )
+
+        assert tag == expected_tag
+
+        tag_func = _simple_compile_tag(tag, tag_content)
+        args, kwargs = tag_func({})
+
+        assert args == []
+        assert kwargs == [("data", {"key": "val"})]
+
+    def test_dict_trailing_comma(self):
+        tag_content = '{% component data={ "key": "val", } %}'
+        tag = parse_tag(tag_content)
+
+        expected_tag = GenericTag(
+            token=token(tag_content, 0, 1, 1),
+            name=token("component", 3, 1, 4),
+            attrs=[
+                TagAttr(
+                    token=token('data={ "key": "val", }', 13, 1, 14),
+                    key=token("data", 13, 1, 14),
+                    value=plain_dict_value(
+                        token('{ "key": "val", }', 18, 1, 19),
+                        [
+                            ValueChild(plain_string_value('"key"', 20, 1, 21, None)),
+                            ValueChild(plain_string_value('"val"', 27, 1, 28, None)),
+                        ],
+                    ),
+                    is_flag=False,
+                ),
+            ],
+            is_self_closing=False,
+            used_variables=[],
+            assigned_variables=[],
+        )
+
+        assert tag == expected_tag
+
+        tag_func = _simple_compile_tag(tag, tag_content)
+        args, kwargs = tag_func({})
+
+        assert args == []
+        assert kwargs == [("data", {"key": "val"})]
+
+    def test_dict_with_filter(self):
+        tag_content = '{% component data={ "key": "val" }|upper %}'
+        tag = parse_tag(tag_content)
+
+        expected_tag = GenericTag(
+            token=token(tag_content, 0, 1, 1),
+            name=token("component", 3, 1, 4),
+            attrs=[
+                TagAttr(
+                    token=token('data={ "key": "val" }|upper', 13, 1, 14),
+                    key=token("data", 13, 1, 14),
+                    value=TagValue(
+                        token=token('{ "key": "val" }|upper', 18, 1, 19),
+                        value=token('{ "key": "val" }', 18, 1, 19),
+                        children=[
+                            ValueChild(plain_string_value('"key"', 20, 1, 21, None)),
+                            ValueChild(plain_string_value('"val"', 27, 1, 28, None)),
+                        ],
+                        kind=ValueKind("dict"),
+                        spread=None,
+                        filters=[
+                            TagValueFilter(
+                                token=token("|upper", 34, 1, 35),
+                                name=token("upper", 35, 1, 36),
+                                arg=None,
+                            )
+                        ],
+                        used_variables=[],
+                        assigned_variables=[],
+                    ),
+                    is_flag=False,
+                ),
+            ],
+            is_self_closing=False,
+            used_variables=[],
+            assigned_variables=[],
+        )
+
+        assert tag == expected_tag
+
+        tag_func = _simple_compile_tag(tag, tag_content)
+        args, kwargs = tag_func({})
+
+        assert args == []
+        assert kwargs == [("data", "upper({'key': 'val'}, None)")]
+
+    def test_dict_as_filter_arg(self):
+        tag_content = '{% component my_var|default:{ "key": "val" } %}'
+        tag = parse_tag(tag_content)
+
+        expected_tag = GenericTag(
+            token=token(tag_content, 0, 1, 1),
+            name=token("component", 3, 1, 4),
+            attrs=[
+                TagAttr(
+                    token=token('my_var|default:{ "key": "val" }', 13, 1, 14),
+                    key=None,
+                    value=variable_value(
+                        token('my_var|default:{ "key": "val" }', 13, 1, 14),
+                        token("my_var", 13, 1, 14),
+                        None,
+                        [
+                            TagValueFilter(
+                                token=token('|default:{ "key": "val" }', 19, 1, 20),
+                                name=token("default", 20, 1, 21),
+                                arg=plain_dict_value(
+                                    token('{ "key": "val" }', 28, 1, 29),
+                                    [
+                                        ValueChild(
+                                            plain_string_value('"key"', 30, 1, 31, None)
+                                        ),
+                                        ValueChild(
+                                            plain_string_value('"val"', 37, 1, 38, None)
+                                        ),
+                                    ],
+                                ),
+                            )
+                        ],
+                        [],
+                        [],
+                    ),
+                    is_flag=False,
+                ),
+            ],
+            is_self_closing=False,
+            used_variables=[token("my_var", 13, 1, 14)],
+            assigned_variables=[],
+        )
+
+        assert tag == expected_tag
+
+        tag_func = _simple_compile_tag(tag, tag_content)
+        args, kwargs = tag_func({"my_var": None})
+
+        assert args == ["default(None, {'key': 'val'})"]
+        assert kwargs == []
+
+    def test_dict_missing_colon(self):
+        with pytest.raises(
+            SyntaxError,
+            match=re.escape("expected filter_noarg or COMMENT"),
+        ):
+            parse_tag('{% component data={ "key" } %}')
+
+    def test_dict_missing_colon_2(self):
+        with pytest.raises(
+            SyntaxError,
+            match=re.escape("expected filter_chain_noarg or COMMENT"),
+        ):
+            parse_tag('{% component data={ "key", "val" } %}')
+
+    def test_dict_extra_colon(self):
+        with pytest.raises(
+            SyntaxError,
+            match=re.escape("expected value or COMMENT"),
+        ):
+            parse_tag("{% component data={ key:: key } %}")
+
+    def test_dict_spread(self):
+        tag_content = "{% component data={ **spread } %}"
+        tag = parse_tag(tag_content)
+
+        expected_tag = GenericTag(
+            token=token(tag_content, 0, 1, 1),
+            name=token("component", 3, 1, 4),
+            attrs=[
+                TagAttr(
+                    token=token("data={ **spread }", 13, 1, 14),
+                    key=token("data", 13, 1, 14),
+                    value=plain_dict_value(
+                        token("{ **spread }", 18, 1, 19),
+                        [
+                            ValueChild(plain_variable_value("spread", 20, 1, 21, "**")),
+                        ],
+                    ),
+                    is_flag=False,
+                ),
+            ],
+            is_self_closing=False,
+            used_variables=[token("spread", 22, 1, 23)],
+            assigned_variables=[],
+        )
+
+        assert tag == expected_tag
+
+        tag_func = _simple_compile_tag(tag, tag_content)
+        args1, kwargs1 = tag_func({"spread": {"key": "val"}})
+        assert args1 == []
+        assert kwargs1 == [("data", {"key": "val"})]
+
+        args2, kwargs2 = tag_func({"spread": {}})
+        assert args2 == []
+        assert kwargs2 == [("data", {})]
+
+        with pytest.raises(
+            TypeError,
+            match=re.escape("'list' object is not a mapping"),
+        ):
+            tag_func({"spread": [1, 2, 3]})
+
+        with pytest.raises(
+            TypeError,
+            match=re.escape("'int' object is not a mapping"),
+        ):
+            tag_func({"spread": 3})
+
+        with pytest.raises(
+            TypeError,
+            match=re.escape("'NoneType' object is not a mapping"),
+        ):
+            tag_func({"spread": None})
+
+    def test_dict_spread_between_key_value_pairs(self):
+        tag_content = '{% component data={ "key": val, **spread, "key2": val2 } %}'
+        tag = parse_tag(tag_content)
+
+        expected_tag = GenericTag(
+            token=token(tag_content, 0, 1, 1),
+            name=token("component", 3, 1, 4),
+            attrs=[
+                TagAttr(
+                    token=token(
+                        'data={ "key": val, **spread, "key2": val2 }', 13, 1, 14
+                    ),
+                    key=token("data", 13, 1, 14),
+                    value=plain_dict_value(
+                        token('{ "key": val, **spread, "key2": val2 }', 18, 1, 19),
+                        [
+                            ValueChild(plain_string_value('"key"', 20, 1, 21, None)),
+                            ValueChild(plain_variable_value("val", 27, 1, 28, None)),
+                            ValueChild(plain_variable_value("spread", 32, 1, 33, "**")),
+                            ValueChild(plain_string_value('"key2"', 42, 1, 43, None)),
+                            ValueChild(plain_variable_value("val2", 50, 1, 51, None)),
+                        ],
+                    ),
+                    is_flag=False,
+                ),
+            ],
+            is_self_closing=False,
+            used_variables=[
+                token("val", 27, 1, 28),
+                token("spread", 34, 1, 35),
+                token("val2", 50, 1, 51),
+            ],
+            assigned_variables=[],
+        )
+
+        assert tag == expected_tag
+
+        tag_func = _simple_compile_tag(tag, tag_content)
+        args1, kwargs1 = tag_func({"spread": {"a": 1}, "val": "HELLO", "val2": "WORLD"})
+        assert args1 == []
+        assert kwargs1 == [("data", {"key": "HELLO", "a": 1, "key2": "WORLD"})]
+
+    # Test that dictionary keys cannot have filter arguments - The `:` is parsed as dictionary key separator
+    # So instead, the content below will be parsed as key `"key"|filter`, and value `"arg":"value"'
+    # And the latter is invalid because it's missing the `|` separator.
+    def test_colon_in_dictionary_keys(self):
+        with pytest.raises(
+            SyntaxError,
+            match=re.escape("expected filter_chain or COMMENT"),
+        ):
+            parse_tag('{% component data={"key"|filter:"arg": "value"} %}')
+
+    def test_dicts_complex(self):
+        # NOTE: In this example, it looks like e.g. `"e"` should be a filter argument
+        # to `c|default`. BUT! variables like `c|default` are inside a dictionary,
+        # so the `:` is preferentially interpreted as dictionary key separator (`{key: val}`).
+        # So e.g. line `{c|default: "e"|yesno:"yes,no"}`
+        # actually means `{<key>: <val>}`,
+        # where `<key>` is `c|default` and `val` is `"e"|yesno:"yes,no"`.
+        tag_content = """
+            {% component
+            simple={
+                "a": 1|add:2
+            }
+            nested={
+                "key"|upper: val|lower,
+                **spread,
+                "obj": {"x": 1|add:2}
+            }
+            filters={
+                "a"|lower: "b"|upper,
+                c|default: "e"|yesno:"yes,no"
+            }
+            %}"""
+        tag = parse_tag(tag_content)
+
+        expected_tag = GenericTag(
+            token=token(tag_content[13:], 13, 2, 13),
+            name=token("component", 16, 2, 16),
+            attrs=[
+                TagAttr(
+                    token=token(
+                        'simple={\n                "a": 1|add:2\n            }',
+                        38,
+                        3,
+                        13,
+                    ),
+                    key=token("simple", 38, 3, 13),
+                    value=plain_dict_value(
+                        token(
+                            '{\n                "a": 1|add:2\n            }', 45, 3, 20
+                        ),
+                        [
+                            ValueChild(plain_string_value('"a"', 63, 4, 17, None)),
+                            ValueChild(
+                                int_value(
+                                    token("1|add:2", 68, 4, 22),
+                                    token("1", 68, 4, 22),
+                                    None,
+                                    [
+                                        TagValueFilter(
+                                            token=token("|add:2", 69, 4, 23),
+                                            name=token("add", 70, 4, 24),
+                                            arg=plain_int_value("2", 74, 4, 28, None),
+                                        )
+                                    ],
+                                    [],
+                                    [],
+                                )
+                            ),
+                        ],
+                    ),
+                    is_flag=False,
+                ),
+                TagAttr(
+                    token=token(
+                        'nested={\n                "key"|upper: val|lower,\n                **spread,\n                "obj": {"x": 1|add:2}\n            }',
+                        102,
+                        6,
+                        13,
+                    ),
+                    key=token("nested", 102, 6, 13),
+                    value=plain_dict_value(
+                        token(
+                            '{\n                "key"|upper: val|lower,\n                **spread,\n                "obj": {"x": 1|add:2}\n            }',
+                            109,
+                            6,
+                            20,
+                        ),
+                        [
+                            ValueChild(
+                                string_value(
+                                    token('"key"|upper', 127, 7, 17),
+                                    token('"key"', 127, 7, 17),
+                                    None,
+                                    [
+                                        TagValueFilter(
+                                            token=token("|upper", 132, 7, 22),
+                                            name=token("upper", 133, 7, 23),
+                                            arg=None,
+                                        )
+                                    ],
+                                    [],
+                                    [],
+                                )
+                            ),
+                            ValueChild(
+                                variable_value(
+                                    token("val|lower", 140, 7, 30),
+                                    token("val", 140, 7, 30),
+                                    None,
+                                    [
+                                        TagValueFilter(
+                                            token=token("|lower", 143, 7, 33),
+                                            name=token("lower", 144, 7, 34),
+                                            arg=None,
+                                        )
+                                    ],
+                                    [],
+                                    [],
+                                )
+                            ),
+                            ValueChild(
+                                plain_variable_value("spread", 167, 8, 17, "**")
+                            ),
+                            ValueChild(plain_string_value('"obj"', 193, 9, 17, None)),
+                            ValueChild(
+                                plain_dict_value(
+                                    token('{"x": 1|add:2}', 200, 9, 24),
+                                    [
+                                        ValueChild(
+                                            plain_string_value('"x"', 201, 9, 25, None)
+                                        ),
+                                        ValueChild(
+                                            int_value(
+                                                token("1|add:2", 206, 9, 30),
+                                                token("1", 206, 9, 30),
+                                                None,
+                                                [
+                                                    TagValueFilter(
+                                                        token=token(
+                                                            "|add:2", 207, 9, 31
+                                                        ),
+                                                        name=token("add", 208, 9, 32),
+                                                        arg=plain_int_value(
+                                                            "2", 212, 9, 36, None
+                                                        ),
+                                                    )
+                                                ],
+                                                [],
+                                                [],
+                                            )
+                                        ),
+                                    ],
+                                )
+                            ),
+                        ],
+                    ),
+                    is_flag=False,
+                ),
+                TagAttr(
+                    token=token(
+                        'filters={\n                "a"|lower: "b"|upper,\n                c|default: "e"|yesno:"yes,no"\n            }',
+                        241,
+                        11,
+                        13,
+                    ),
+                    key=token("filters", 241, 11, 13),
+                    value=plain_dict_value(
+                        token(
+                            '{\n                "a"|lower: "b"|upper,\n                c|default: "e"|yesno:"yes,no"\n            }',
+                            249,
+                            11,
+                            21,
+                        ),
+                        [
+                            ValueChild(
+                                string_value(
+                                    token('"a"|lower', 267, 12, 17),
+                                    token('"a"', 267, 12, 17),
+                                    None,
+                                    [
+                                        TagValueFilter(
+                                            token=token("|lower", 270, 12, 20),
+                                            name=token("lower", 271, 12, 21),
+                                            arg=None,
+                                        )
+                                    ],
+                                    [],
+                                    [],
+                                )
+                            ),
+                            ValueChild(
+                                string_value(
+                                    token('"b"|upper', 278, 12, 28),
+                                    token('"b"', 278, 12, 28),
+                                    None,
+                                    [
+                                        TagValueFilter(
+                                            token=token("|upper", 281, 12, 31),
+                                            name=token("upper", 282, 12, 32),
+                                            arg=None,
+                                        )
+                                    ],
+                                    [],
+                                    [],
+                                )
+                            ),
+                            ValueChild(
+                                variable_value(
+                                    token("c|default", 305, 13, 17),
+                                    token("c", 305, 13, 17),
+                                    None,
+                                    [
+                                        TagValueFilter(
+                                            token=token("|default", 306, 13, 18),
+                                            name=token("default", 307, 13, 19),
+                                            arg=None,
+                                        )
+                                    ],
+                                    [],
+                                    [],
+                                )
+                            ),
+                            ValueChild(
+                                string_value(
+                                    token('"e"|yesno:"yes,no"', 316, 13, 28),
+                                    token('"e"', 316, 13, 28),
+                                    None,
+                                    [
+                                        TagValueFilter(
+                                            token=token('|yesno:"yes,no"', 319, 13, 31),
+                                            name=token("yesno", 320, 13, 32),
+                                            arg=plain_string_value(
+                                                '"yes,no"', 326, 13, 38, None
+                                            ),
+                                        )
+                                    ],
+                                    [],
+                                    [],
+                                )
+                            ),
+                        ],
+                    ),
+                    is_flag=False,
+                ),
+            ],
+            is_self_closing=False,
+            used_variables=[
+                token("val", 140, 7, 30),
+                token("spread", 169, 8, 19),
+                token("c", 305, 13, 17),
+            ],
+            assigned_variables=[],
+        )
+
+        assert tag == expected_tag
+
+        tag_func = _simple_compile_tag(tag, tag_content)
+        args1, kwargs1 = tag_func({"spread": {6: 7}, "c": None, "val": "bar"})
+        assert args1 == []
+        assert kwargs1 == [
+            ("simple", {"a": "add(1, 2)"}),
+            (
+                "nested",
+                {
+                    "upper(key, None)": "lower(bar, None)",
+                    6: 7,
+                    "obj": {"x": "add(1, 2)"},
+                },
+            ),
+            (
+                "filters",
+                {
+                    "lower(a, None)": "upper(b, None)",
+                    "default(None, None)": "yesno(e, yes,no)",
+                },
+            ),
+        ]
+
+
+class TestList:
+    def test_list_simple(self):
+        tag_content = "{% component data=[1, 2, 3] %}"
+        tag = parse_tag(tag_content)
+
+        expected_tag = GenericTag(
+            token=token(tag_content, 0, 1, 1),
+            name=token("component", 3, 1, 4),
+            attrs=[
+                TagAttr(
+                    token=token("data=[1, 2, 3]", 13, 1, 14),
+                    key=token("data", 13, 1, 14),
+                    value=plain_list_value(
+                        token("[1, 2, 3]", 18, 1, 19),
+                        [
+                            ValueChild(plain_int_value("1", 19, 1, 20, None)),
+                            ValueChild(plain_int_value("2", 22, 1, 23, None)),
+                            ValueChild(plain_int_value("3", 25, 1, 26, None)),
+                        ],
+                    ),
+                    is_flag=False,
+                ),
+            ],
+            is_self_closing=False,
+            used_variables=[],
+            assigned_variables=[],
+        )
+
+        assert tag == expected_tag
+
+        tag_func = _simple_compile_tag(tag, tag_content)
+        args1, kwargs1 = tag_func({})
+        assert args1 == []
+        assert kwargs1 == [("data", [1, 2, 3])]
+
+    def test_list_trailing_comma(self):
+        tag_content = "{% component data=[1, 2, 3, ] %}"
+        tag = parse_tag(tag_content)
+
+        expected_tag = GenericTag(
+            token=token(tag_content, 0, 1, 1),
+            name=token("component", 3, 1, 4),
+            attrs=[
+                TagAttr(
+                    token=token("data=[1, 2, 3, ]", 13, 1, 14),
+                    key=token("data", 13, 1, 14),
+                    value=plain_list_value(
+                        token("[1, 2, 3, ]", 18, 1, 19),
+                        [
+                            ValueChild(plain_int_value("1", 19, 1, 20, None)),
+                            ValueChild(plain_int_value("2", 22, 1, 23, None)),
+                            ValueChild(plain_int_value("3", 25, 1, 26, None)),
+                        ],
+                    ),
+                    is_flag=False,
+                ),
+            ],
+            is_self_closing=False,
+            used_variables=[],
+            assigned_variables=[],
+        )
+
+        assert tag == expected_tag
+
+        tag_func = _simple_compile_tag(tag, tag_content)
+        args1, kwargs1 = tag_func({})
+        assert args1 == []
+        assert kwargs1 == [("data", [1, 2, 3])]
+
+    def test_list_with_filter(self):
+        tag_content = "{% component data=[1, 2, 3]|upper %}"
+        tag = parse_tag(tag_content)
+
+        expected_tag = GenericTag(
+            token=token(tag_content, 0, 1, 1),
+            name=token("component", 3, 1, 4),
+            attrs=[
+                TagAttr(
+                    token=token("data=[1, 2, 3]|upper", 13, 1, 14),
+                    key=token("data", 13, 1, 14),
+                    value=TagValue(
+                        token=token("[1, 2, 3]|upper", 18, 1, 19),
+                        value=token("[1, 2, 3]", 18, 1, 19),
+                        children=[
+                            ValueChild(plain_int_value("1", 19, 1, 20, None)),
+                            ValueChild(plain_int_value("2", 22, 1, 23, None)),
+                            ValueChild(plain_int_value("3", 25, 1, 26, None)),
+                        ],
+                        kind=ValueKind("list"),
+                        spread=None,
+                        filters=[
+                            TagValueFilter(
+                                token=token("|upper", 27, 1, 28),
+                                name=token("upper", 28, 1, 29),
+                                arg=None,
+                            )
+                        ],
+                        used_variables=[],
+                        assigned_variables=[],
+                    ),
+                    is_flag=False,
+                ),
+            ],
+            is_self_closing=False,
+            used_variables=[],
+            assigned_variables=[],
+        )
+
+        assert tag == expected_tag
+
+        tag_func = _simple_compile_tag(tag, tag_content)
+        args, kwargs = tag_func({})
+
+        assert args == []
+        assert kwargs == [("data", "upper([1, 2, 3], None)")]
+
+    def test_list_as_filter_arg(self):
+        tag_content = "{% component my_var|default:[1, 2, 3] %}"
+        tag = parse_tag(tag_content)
+
+        expected_tag = GenericTag(
+            token=token(tag_content, 0, 1, 1),
+            name=token("component", 3, 1, 4),
+            attrs=[
+                TagAttr(
+                    token=token("my_var|default:[1, 2, 3]", 13, 1, 14),
+                    key=None,
+                    value=variable_value(
+                        token("my_var|default:[1, 2, 3]", 13, 1, 14),
+                        token("my_var", 13, 1, 14),
+                        None,
+                        [
+                            TagValueFilter(
+                                token=token("|default:[1, 2, 3]", 19, 1, 20),
+                                name=token("default", 20, 1, 21),
+                                arg=plain_list_value(
+                                    token("[1, 2, 3]", 28, 1, 29),
+                                    [
+                                        ValueChild(
+                                            plain_int_value("1", 29, 1, 30, None)
+                                        ),
+                                        ValueChild(
+                                            plain_int_value("2", 32, 1, 33, None)
+                                        ),
+                                        ValueChild(
+                                            plain_int_value("3", 35, 1, 36, None)
+                                        ),
+                                    ],
+                                ),
+                            )
+                        ],
+                        [],
+                        [],
+                    ),
+                    is_flag=False,
+                ),
+            ],
+            is_self_closing=False,
+            used_variables=[token("my_var", 13, 1, 14)],
+            assigned_variables=[],
+        )
+
+        assert tag == expected_tag
+
+        tag_func = _simple_compile_tag(tag, tag_content)
+        args, kwargs = tag_func({"my_var": None})
+
+        assert args == ["default(None, [1, 2, 3])"]
+        assert kwargs == []
+
+    def test_lists_complex(self):
+        tag_content = """
+                {% component
+                nums=[
+                    1,
+                    2|add:3,
+                    *spread
+                ]
+                items=[
+                    "a"|upper,
+                    'b'|lower,
+                    c|default:"d"
+                ]
+                mixed=[
+                    1,
+                    [*nested],
+                    {"key": "val"}
+                ]
+            %}"""
+        tag = parse_tag(tag_content)
+
+        expected_tag = GenericTag(
+            token=token(tag_content[17:], 17, 2, 17),
+            name=token("component", 20, 2, 20),
+            attrs=[
+                TagAttr(
+                    token=token(
+                        "nums=[\n                    1,\n                    2|add:3,\n                    *spread\n                ]",
+                        46,
+                        3,
+                        17,
+                    ),
+                    key=token("nums", 46, 3, 17),
+                    value=plain_list_value(
+                        token(
+                            "[\n                    1,\n                    2|add:3,\n                    *spread\n                ]",
+                            51,
+                            3,
+                            22,
+                        ),
+                        [
+                            ValueChild(plain_int_value("1", 73, 4, 21, None)),
+                            ValueChild(
+                                int_value(
+                                    token("2|add:3", 96, 5, 21),
+                                    token("2", 96, 5, 21),
+                                    None,
+                                    [
+                                        TagValueFilter(
+                                            token=token("|add:3", 97, 5, 22),
+                                            name=token("add", 98, 5, 23),
+                                            arg=plain_int_value("3", 102, 5, 27, None),
+                                        )
+                                    ],
+                                    [],
+                                    [],
+                                )
+                            ),
+                            ValueChild(plain_variable_value("spread", 125, 6, 21, "*")),
+                        ],
+                    ),
+                    is_flag=False,
+                ),
+                TagAttr(
+                    token=token(
+                        'items=[\n                    "a"|upper,\n                    \'b\'|lower,\n                    c|default:"d"\n                ]',
+                        167,
+                        8,
+                        17,
+                    ),
+                    key=token("items", 167, 8, 17),
+                    value=plain_list_value(
+                        token(
+                            '[\n                    "a"|upper,\n                    \'b\'|lower,\n                    c|default:"d"\n                ]',
+                            173,
+                            8,
+                            23,
+                        ),
+                        [
+                            ValueChild(
+                                string_value(
+                                    token('"a"|upper', 195, 9, 21),
+                                    token('"a"', 195, 9, 21),
+                                    None,
+                                    [
+                                        TagValueFilter(
+                                            token=token("|upper", 198, 9, 24),
+                                            name=token("upper", 199, 9, 25),
+                                            arg=None,
+                                        )
+                                    ],
+                                    [],
+                                    [],
+                                )
+                            ),
+                            ValueChild(
+                                string_value(
+                                    token("'b'|lower", 226, 10, 21),
+                                    token("'b'", 226, 10, 21),
+                                    None,
+                                    [
+                                        TagValueFilter(
+                                            token=token("|lower", 229, 10, 24),
+                                            name=token("lower", 230, 10, 25),
+                                            arg=None,
+                                        )
+                                    ],
+                                    [],
+                                    [],
+                                )
+                            ),
+                            ValueChild(
+                                variable_value(
+                                    token('c|default:"d"', 257, 11, 21),
+                                    token("c", 257, 11, 21),
+                                    None,
+                                    [
+                                        TagValueFilter(
+                                            token=token('|default:"d"', 258, 11, 22),
+                                            name=token("default", 259, 11, 23),
+                                            arg=plain_string_value(
+                                                '"d"', 267, 11, 31, None
+                                            ),
+                                        )
+                                    ],
+                                    [],
+                                    [],
+                                )
+                            ),
+                        ],
+                    ),
+                    is_flag=False,
+                ),
+                TagAttr(
+                    token=token(
+                        'mixed=[\n                    1,\n                    [*nested],\n                    {"key": "val"}\n                ]',
+                        305,
+                        13,
+                        17,
+                    ),
+                    key=token("mixed", 305, 13, 17),
+                    value=plain_list_value(
+                        token(
+                            '[\n                    1,\n                    [*nested],\n                    {"key": "val"}\n                ]',
+                            311,
+                            13,
+                            23,
+                        ),
+                        [
+                            ValueChild(plain_int_value("1", 333, 14, 21, None)),
+                            ValueChild(
+                                plain_list_value(
+                                    token("[*nested]", 356, 15, 21),
+                                    [
+                                        ValueChild(
+                                            plain_variable_value(
+                                                "nested", 357, 15, 22, "*"
+                                            )
+                                        )
+                                    ],
+                                )
+                            ),
+                            ValueChild(
+                                plain_dict_value(
+                                    token('{"key": "val"}', 387, 16, 21),
+                                    [
+                                        ValueChild(
+                                            plain_string_value(
+                                                '"key"', 388, 16, 22, None
+                                            )
+                                        ),
+                                        ValueChild(
+                                            plain_string_value(
+                                                '"val"', 395, 16, 29, None
+                                            )
+                                        ),
+                                    ],
+                                )
+                            ),
+                        ],
+                    ),
+                    is_flag=False,
+                ),
+            ],
+            is_self_closing=False,
+            used_variables=[
+                token("spread", 126, 6, 22),
+                token("c", 257, 11, 21),
+                token("nested", 358, 15, 23),
+            ],
+            assigned_variables=[],
+        )
+
+        assert tag == expected_tag
+
+        tag_func = _simple_compile_tag(tag, tag_content)
+        args1, kwargs1 = tag_func({"nested": [1, 2, 3], "spread": [5, 6], "c": None})
+        assert args1 == []
+        assert kwargs1 == [
+            ("nums", [1, "add(2, 3)", 5, 6]),
+            ("items", ["upper(a, None)", "lower(b, None)", "default(None, d)"]),
+            ("mixed", [1, [1, 2, 3], {"key": "val"}]),
+        ]
+
+    def test_mixed_complex(self):
+        tag_content = """
+            {% component
+            data={
+                "items": [
+                    1|add:2,
+                    {"x"|upper: 2|add:3},
+                    *spread_items|default:""
+                ],
+                "nested": {
+                    "a": [
+                        1|add:2,
+                        *nums|default:""
+                    ],
+                    "b": {
+                        "x": [
+                            *more|default:""
+                        ]
+                    }
+                },
+                **rest|injectd,
+                "key": _('value')|upper
+            }
+            %}"""
+        tag = parse_tag(tag_content)
+
+        expected_tag = GenericTag(
+            token=token(tag_content[13:], 13, 2, 13),
+            name=token("component", 16, 2, 16),
+            attrs=[
+                TagAttr(
+                    token=token(
+                        'data={\n                "items": [\n                    1|add:2,\n                    {"x"|upper: 2|add:3},\n                    *spread_items|default:""\n                ],\n                "nested": {\n                    "a": [\n                        1|add:2,\n                        *nums|default:""\n                    ],\n                    "b": {\n                        "x": [\n                            *more|default:""\n                        ]\n                    }\n                },\n                **rest|injectd,\n                "key": _(\'value\')|upper\n            }',
+                        38,
+                        3,
+                        13,
+                    ),
+                    key=token("data", 38, 3, 13),
+                    value=plain_dict_value(
+                        token(
+                            '{\n                "items": [\n                    1|add:2,\n                    {"x"|upper: 2|add:3},\n                    *spread_items|default:""\n                ],\n                "nested": {\n                    "a": [\n                        1|add:2,\n                        *nums|default:""\n                    ],\n                    "b": {\n                        "x": [\n                            *more|default:""\n                        ]\n                    }\n                },\n                **rest|injectd,\n                "key": _(\'value\')|upper\n            }',
+                            43,
+                            3,
+                            18,
+                        ),
+                        [
+                            ValueChild(plain_string_value('"items"', 61, 4, 17, None)),
+                            ValueChild(
+                                plain_list_value(
+                                    token(
+                                        '[\n                    1|add:2,\n                    {"x"|upper: 2|add:3},\n                    *spread_items|default:""\n                ]',
+                                        70,
+                                        4,
+                                        26,
+                                    ),
+                                    [
+                                        ValueChild(
+                                            int_value(
+                                                token("1|add:2", 92, 5, 21),
+                                                token("1", 92, 5, 21),
+                                                None,
+                                                [
+                                                    TagValueFilter(
+                                                        token=token(
+                                                            "|add:2", 93, 5, 22
+                                                        ),
+                                                        name=token("add", 94, 5, 23),
+                                                        arg=plain_int_value(
+                                                            "2", 98, 5, 27, None
+                                                        ),
+                                                    )
+                                                ],
+                                                [],
+                                                [],
+                                            )
+                                        ),
+                                        ValueChild(
+                                            plain_dict_value(
+                                                token(
+                                                    '{"x"|upper: 2|add:3}', 121, 6, 21
+                                                ),
+                                                [
+                                                    ValueChild(
+                                                        string_value(
+                                                            token(
+                                                                '"x"|upper', 122, 6, 22
+                                                            ),
+                                                            token('"x"', 122, 6, 22),
+                                                            None,
+                                                            [
+                                                                TagValueFilter(
+                                                                    token=token(
+                                                                        "|upper",
+                                                                        125,
+                                                                        6,
+                                                                        25,
+                                                                    ),
+                                                                    name=token(
+                                                                        "upper",
+                                                                        126,
+                                                                        6,
+                                                                        26,
+                                                                    ),
+                                                                    arg=None,
+                                                                )
+                                                            ],
+                                                            [],
+                                                            [],
+                                                        )
+                                                    ),
+                                                    ValueChild(
+                                                        int_value(
+                                                            token(
+                                                                "2|add:3", 133, 6, 33
+                                                            ),
+                                                            token("2", 133, 6, 33),
+                                                            None,
+                                                            [
+                                                                TagValueFilter(
+                                                                    token=token(
+                                                                        "|add:3",
+                                                                        134,
+                                                                        6,
+                                                                        34,
+                                                                    ),
+                                                                    name=token(
+                                                                        "add",
+                                                                        135,
+                                                                        6,
+                                                                        35,
+                                                                    ),
+                                                                    arg=plain_int_value(
+                                                                        "3",
+                                                                        139,
+                                                                        6,
+                                                                        39,
+                                                                        None,
+                                                                    ),
+                                                                )
+                                                            ],
+                                                            [],
+                                                            [],
+                                                        )
+                                                    ),
+                                                ],
+                                            )
+                                        ),
+                                        ValueChild(
+                                            variable_value(
+                                                token(
+                                                    '*spread_items|default:""',
+                                                    163,
+                                                    7,
+                                                    21,
+                                                ),
+                                                token("spread_items", 164, 7, 22),
+                                                "*",
+                                                [
+                                                    TagValueFilter(
+                                                        token=token(
+                                                            '|default:""', 176, 7, 34
+                                                        ),
+                                                        name=token(
+                                                            "default", 177, 7, 35
+                                                        ),
+                                                        arg=plain_string_value(
+                                                            '""', 185, 7, 43, None
+                                                        ),
+                                                    )
+                                                ],
+                                                [],
+                                                [],
+                                            )
+                                        ),
+                                    ],
+                                )
+                            ),
+                            ValueChild(
+                                plain_string_value('"nested"', 223, 9, 17, None)
+                            ),
+                            ValueChild(
+                                plain_dict_value(
+                                    token(
+                                        '{\n                    "a": [\n                        1|add:2,\n                        *nums|default:""\n                    ],\n                    "b": {\n                        "x": [\n                            *more|default:""\n                        ]\n                    }\n                }',
+                                        233,
+                                        9,
+                                        27,
+                                    ),
+                                    [
+                                        ValueChild(
+                                            plain_string_value('"a"', 255, 10, 21, None)
+                                        ),
+                                        ValueChild(
+                                            plain_list_value(
+                                                token(
+                                                    '[\n                        1|add:2,\n                        *nums|default:""\n                    ]',
+                                                    260,
+                                                    10,
+                                                    26,
+                                                ),
+                                                [
+                                                    ValueChild(
+                                                        int_value(
+                                                            token(
+                                                                "1|add:2", 286, 11, 25
+                                                            ),
+                                                            token("1", 286, 11, 25),
+                                                            None,
+                                                            [
+                                                                TagValueFilter(
+                                                                    token=token(
+                                                                        "|add:2",
+                                                                        287,
+                                                                        11,
+                                                                        26,
+                                                                    ),
+                                                                    name=token(
+                                                                        "add",
+                                                                        288,
+                                                                        11,
+                                                                        27,
+                                                                    ),
+                                                                    arg=plain_int_value(
+                                                                        "2",
+                                                                        292,
+                                                                        11,
+                                                                        31,
+                                                                        None,
+                                                                    ),
+                                                                )
+                                                            ],
+                                                            [],
+                                                            [],
+                                                        )
+                                                    ),
+                                                    ValueChild(
+                                                        variable_value(
+                                                            token(
+                                                                '*nums|default:""',
+                                                                319,
+                                                                12,
+                                                                25,
+                                                            ),
+                                                            token("nums", 320, 12, 26),
+                                                            "*",
+                                                            [
+                                                                TagValueFilter(
+                                                                    token=token(
+                                                                        '|default:""',
+                                                                        324,
+                                                                        12,
+                                                                        30,
+                                                                    ),
+                                                                    name=token(
+                                                                        "default",
+                                                                        325,
+                                                                        12,
+                                                                        31,
+                                                                    ),
+                                                                    arg=plain_string_value(
+                                                                        '""',
+                                                                        333,
+                                                                        12,
+                                                                        39,
+                                                                        None,
+                                                                    ),
+                                                                )
+                                                            ],
+                                                            [],
+                                                            [],
+                                                        )
+                                                    ),
+                                                ],
+                                            )
+                                        ),
+                                        ValueChild(
+                                            plain_string_value('"b"', 379, 14, 21, None)
+                                        ),
+                                        ValueChild(
+                                            plain_dict_value(
+                                                token(
+                                                    '{\n                        "x": [\n                            *more|default:""\n                        ]\n                    }',
+                                                    384,
+                                                    14,
+                                                    26,
+                                                ),
+                                                [
+                                                    ValueChild(
+                                                        plain_string_value(
+                                                            '"x"', 410, 15, 25, None
+                                                        )
+                                                    ),
+                                                    ValueChild(
+                                                        plain_list_value(
+                                                            token(
+                                                                '[\n                            *more|default:""\n                        ]',
+                                                                415,
+                                                                15,
+                                                                30,
+                                                            ),
+                                                            [
+                                                                ValueChild(
+                                                                    variable_value(
+                                                                        token(
+                                                                            '*more|default:""',
+                                                                            445,
+                                                                            16,
+                                                                            29,
+                                                                        ),
+                                                                        token(
+                                                                            "more",
+                                                                            446,
+                                                                            16,
+                                                                            30,
+                                                                        ),
+                                                                        "*",
+                                                                        [
+                                                                            TagValueFilter(
+                                                                                token=token(
+                                                                                    '|default:""',
+                                                                                    450,
+                                                                                    16,
+                                                                                    34,
+                                                                                ),
+                                                                                name=token(
+                                                                                    "default",
+                                                                                    451,
+                                                                                    16,
+                                                                                    35,
+                                                                                ),
+                                                                                arg=plain_string_value(
+                                                                                    '""',
+                                                                                    459,
+                                                                                    16,
+                                                                                    43,
+                                                                                    None,
+                                                                                ),
+                                                                            )
+                                                                        ],
+                                                                        [],
+                                                                        [],
+                                                                    )
+                                                                ),
+                                                            ],
+                                                        )
+                                                    ),
+                                                ],
+                                            )
+                                        ),
+                                    ],
+                                )
+                            ),
+                            ValueChild(
+                                variable_value(
+                                    token("**rest|injectd", 545, 20, 17),
+                                    token("rest", 547, 20, 19),
+                                    "**",
+                                    [
+                                        TagValueFilter(
+                                            token=token("|injectd", 551, 20, 23),
+                                            name=token("injectd", 552, 20, 24),
+                                            arg=None,
+                                        )
+                                    ],
+                                    [],
+                                    [],
+                                )
+                            ),
+                            ValueChild(plain_string_value('"key"', 577, 21, 17, None)),
+                            ValueChild(
+                                translation_value(
+                                    token("_('value')|upper", 584, 21, 24),
+                                    token("_('value')", 584, 21, 24),
+                                    None,
+                                    [
+                                        TagValueFilter(
+                                            token=token("|upper", 594, 21, 34),
+                                            name=token("upper", 595, 21, 35),
+                                            arg=None,
+                                        )
+                                    ],
+                                    [],
+                                    [],
+                                )
+                            ),
+                        ],
+                    ),
+                    is_flag=False,
+                ),
+            ],
+            is_self_closing=False,
+            used_variables=[
+                token("spread_items", 164, 7, 22),
+                token("nums", 320, 12, 26),
+                token("more", 446, 16, 30),
+                token("rest", 547, 20, 19),
+            ],
+            assigned_variables=[],
+        )
+
+        assert tag == expected_tag
+
+        def custom_filter(ctx, src, token, filters, tags, name, value, arg=None):
+            if name == "injectd":
+                return {**value, "injected": True}
+            else:
+                return f"{name}({value}, {arg})"
+
+        tag_func = compile_tag(
+            tag,
+            tag_content,
+            filters={},
+            tags={},
+            template_string=template_resolver,
+            expr=expr_resolver,
+            translation=translation_resolver,
+            filter=custom_filter,
+            variable=variable_resolver,
+        )
+        args1, kwargs1 = tag_func(
+            {
+                "spread_items": None,
+                "nums": [1, 2, 3],
+                "more": "x",
+                "rest": {"a": "b"},
+            }
+        )
+        assert args1 == []
+        assert kwargs1 == [
+            (
+                "data",
+                {
+                    "items": [
+                        "add(1, 2)",
+                        {"upper(x, None)": "add(2, 3)"},
+                        *list("default(None, )"),
+                    ],
+                    "nested": {
+                        "a": ["add(1, 2)", *list("default([1, 2, 3], )")],
+                        "b": {"x": [*list("default(x, )")]},
+                    },
+                    "a": "b",
+                    "injected": True,
+                    "key": "upper(TRANSLATION_RESOLVED:value, None)",
+                },
+            ),
+        ]
+
+
+class TestSpread:
+    # Test that spread operator cannot be used as dictionary value
+    def test_spread_as_dictionary_value(self):
+        with pytest.raises(
+            SyntaxError,
+            match=re.escape("expected value or COMMENT"),
+        ):
+            parse_tag('{% component data={"key": **spread} %}')
+
+    # NOTE: The Rust parser actually parses this successfully,
+    # treating `**spread|abc: 123` as a `spread` variable with a filter `abc`
+    # that has an argument `123`.
+    def test_spread_with_colon_interpreted_as_key(self):
+        tag_content = "{% component data={**spread|abc: 123 } %}"
+        tag = parse_tag(tag_content)
+
+        expected_tag = GenericTag(
+            token=token("{% component data={**spread|abc: 123 } %}", 0, 1, 1),
+            name=token("component", 3, 1, 4),
+            attrs=[
+                TagAttr(
+                    token=token("data={**spread|abc: 123 }", 13, 1, 14),
+                    key=token("data", 13, 1, 14),
+                    value=plain_dict_value(
+                        token("{**spread|abc: 123 }", 18, 1, 19),
+                        [
+                            ValueChild(
+                                variable_value(
+                                    token("**spread|abc: 123", 19, 1, 20),
+                                    token("spread", 21, 1, 22),
+                                    "**",
+                                    [
+                                        TagValueFilter(
+                                            token=token("|abc: 123", 27, 1, 28),
+                                            name=token("abc", 28, 1, 29),
+                                            arg=plain_int_value("123", 33, 1, 34, None),
+                                        )
+                                    ],
+                                    [],
+                                    [],
+                                )
+                            ),
+                        ],
+                    ),
+                    is_flag=False,
+                ),
+            ],
+            is_self_closing=False,
+            used_variables=[token("spread", 21, 1, 22)],
+            assigned_variables=[],
+        )
+
+        assert tag == expected_tag
+
+        # Override the filter resolver for this test
+        def custom_filter(ctx, src, token, filters, tags, name, value, arg=None):
+            if name == "abc":
+                return {
+                    **value,
+                    "ABC": arg,
+                }
+            else:
+                return f"{name}({value}, {arg})"
+
+        tag_func = compile_tag(
+            tag,
+            tag_content,
+            filters={},
+            tags={},
+            template_string=template_resolver,
+            expr=expr_resolver,
+            translation=translation_resolver,
+            filter=custom_filter,
+            variable=variable_resolver,
+        )
+        args1, kwargs1 = tag_func({"spread": {6: 7}})
+        assert args1 == []
+        assert kwargs1 == [
+            ("data", {6: 7, "ABC": 123}),
+        ]
+
+    def test_spread_in_filter_position(self):
+        with pytest.raises(
+            SyntaxError,
+            match=re.escape("expected filter_name or COMMENT"),
+        ):
+            parse_tag("{% component data=val|...spread|abc } %}")
+
+    def test_spread_whitespace_1(self):
+        # NOTE: Separating `...` from its variable is NOT valid, and will result in error.
+        with pytest.raises(
+            SyntaxError,
+            match=re.escape("expected value"),
+        ):
+            parse_tag("{% component ... attrs %}")
+
+    # NOTE: But there CAN be whitespace between `*` / `**` and the value,
+    #       because we're scoped inside `{ ... }` dict or `[ ... ]` list.
+    def test_spread_whitespace_2(self):
+        tag_content = (
+            '{% component dict={"a": "b", ** my_attr} list=["a", * my_list] %}'
+        )
+        tag = parse_tag(tag_content)
+
+        expected_tag = GenericTag(
+            token=token(
+                '{% component dict={"a": "b", ** my_attr} list=["a", * my_list] %}',
+                0,
+                1,
+                1,
+            ),
+            name=token("component", 3, 1, 4),
+            attrs=[
+                TagAttr(
+                    token=token('dict={"a": "b", ** my_attr}', 13, 1, 14),
+                    key=token("dict", 13, 1, 14),
+                    value=plain_dict_value(
+                        token('{"a": "b", ** my_attr}', 18, 1, 19),
+                        [
+                            ValueChild(plain_string_value('"a"', 19, 1, 20, None)),
+                            ValueChild(plain_string_value('"b"', 24, 1, 25, None)),
+                            ValueChild(
+                                TagValue(
+                                    token=token("** my_attr", 29, 1, 30),
+                                    value=token("my_attr", 32, 1, 33),
+                                    children=[],
+                                    kind=ValueKind("variable"),
+                                    spread="**",
+                                    filters=[],
+                                    used_variables=[token("my_attr", 32, 1, 33)],
+                                    assigned_variables=[],
+                                ),
+                            ),
+                        ],
+                    ),
+                    is_flag=False,
+                ),
+                TagAttr(
+                    token=token('list=["a", * my_list]', 41, 1, 42),
+                    key=token("list", 41, 1, 42),
+                    value=plain_list_value(
+                        token('["a", * my_list]', 46, 1, 47),
+                        [
+                            ValueChild(plain_string_value('"a"', 47, 1, 48, None)),
+                            ValueChild(
+                                TagValue(
+                                    token=token("* my_list", 52, 1, 53),
+                                    value=token("my_list", 54, 1, 55),
+                                    children=[],
+                                    kind=ValueKind("variable"),
+                                    spread="*",
+                                    filters=[],
+                                    used_variables=[token("my_list", 54, 1, 55)],
+                                    assigned_variables=[],
+                                ),
+                            ),
+                        ],
+                    ),
+                    is_flag=False,
+                ),
+            ],
+            is_self_closing=False,
+            used_variables=[
+                token("my_attr", 32, 1, 33),
+                token("my_list", 54, 1, 55),
+            ],
+            assigned_variables=[],
+        )
+
+        assert tag == expected_tag
+
+        tag_func = _simple_compile_tag(tag, tag_content)
+        args1, kwargs1 = tag_func({"my_attr": {6: 7}, "my_list": [8, 9]})
+        assert args1 == []
+        assert kwargs1 == [
+            ("dict", {"a": "b", 6: 7}),
+            ("list", ["a", 8, 9]),
+        ]
+
+        with pytest.raises(
+            TypeError,
+            match=re.escape("list' object is not a mapping"),
+        ):
+            tag_func({"my_attr": [6, 7], "my_list": [8, 9]})
+
+        # NOTE: This still works because even tho my_list is not a list,
+        #       dictionaries are still iterable (same as dict.keys()).
+        args2, kwargs2 = tag_func({"my_attr": {6: 7}, "my_list": {8: 9}})
+        assert args2 == []
+        assert kwargs2 == [
+            ("dict", {"a": "b", 6: 7}),
+            ("list", ["a", 8]),
+        ]
+
+    # Test that one cannot use e.g. `...`, `**`, `*` in wrong places
+    def test_spread_incorrect_syntax(self):
+        with pytest.raises(
+            SyntaxError,
+            match=re.escape("expected dict_item_spread_op, dict_key, or COMMENT"),
+        ):
+            parse_tag('{% component dict={"a": "b", *my_attr} %}')
+
+        with pytest.raises(
+            SyntaxError,
+            match=re.escape("expected dict_item_spread_op, dict_key, or COMMENT"),
+        ):
+            _ = parse_tag('{% component dict={"a": "b", ...my_attr} %}')
+
+        with pytest.raises(
+            SyntaxError,
+            match=re.escape("expected value or COMMENT"),
+        ):
+            _ = parse_tag('{% component list=["a", "b", **my_list] %}')
+
+        with pytest.raises(
+            SyntaxError,
+            match=re.escape("expected list_item or COMMENT"),
+        ):
+            _ = parse_tag('{% component list=["a", "b", ...my_list] %}')
+
+        with pytest.raises(
+            SyntaxError,
+            match=re.escape("expected self_closing_slash, attribute, or COMMENT"),
+        ):
+            _ = parse_tag("{% component *attrs %}")
+
+        with pytest.raises(
+            SyntaxError,
+            match=re.escape("expected self_closing_slash, attribute, or COMMENT"),
+        ):
+            _ = parse_tag("{% component **attrs %}")
+
+        with pytest.raises(
+            SyntaxError,
+            match=re.escape("expected value"),
+        ):
+            _ = parse_tag("{% component key=*attrs %}")
+
+        with pytest.raises(
+            SyntaxError,
+            match=re.escape("expected value"),
+        ):
+            _ = parse_tag("{% component key=**attrs %}")
+
+    # Test that one cannot do `key=...{"a": "b"}`
+    def test_spread_onto_key(self):
+        with pytest.raises(
+            SyntaxError,
+            match=re.escape("expected value"),
+        ):
+            parse_tag('{% component key=...{"a": "b"} %}')
+
+        with pytest.raises(
+            SyntaxError,
+            match=re.escape("expected value"),
+        ):
+            parse_tag('{% component key=...["a", "b"] %}')
+
+        with pytest.raises(
+            SyntaxError,
+            match=re.escape("expected value"),
+        ):
+            parse_tag("{% component key=...attrs %}")
+
+    def test_spread_dict_literal_nested(self):
+        tag_content = '{% component { **{"key": val2}, "key": val1 } %}'
+        tag = parse_tag(tag_content)
+
+        expected_tag = GenericTag(
+            token=token('{% component { **{"key": val2}, "key": val1 } %}', 0, 1, 1),
+            name=token("component", 3, 1, 4),
+            attrs=[
+                TagAttr(
+                    token=token('{ **{"key": val2}, "key": val1 }', 13, 1, 14),
+                    key=None,
+                    value=plain_dict_value(
+                        token('{ **{"key": val2}, "key": val1 }', 13, 1, 14),
+                        [
+                            ValueChild(
+                                TagValue(
+                                    token=token('**{"key": val2}', 15, 1, 16),
+                                    value=token('{"key": val2}', 17, 1, 18),
+                                    children=[
+                                        ValueChild(
+                                            plain_string_value('"key"', 18, 1, 19, None)
+                                        ),
+                                        ValueChild(
+                                            plain_variable_value(
+                                                "val2", 25, 1, 26, None
+                                            )
+                                        ),
+                                    ],
+                                    kind=ValueKind("dict"),
+                                    spread="**",
+                                    filters=[],
+                                    used_variables=[],
+                                    assigned_variables=[],
+                                )
+                            ),
+                            ValueChild(plain_string_value('"key"', 32, 1, 33, None)),
+                            ValueChild(plain_variable_value("val1", 39, 1, 40, None)),
+                        ],
+                    ),
+                    is_flag=False,
+                ),
+            ],
+            is_self_closing=False,
+            used_variables=[
+                token("val2", 25, 1, 26),
+                token("val1", 39, 1, 40),
+            ],
+            assigned_variables=[],
+        )
+
+        assert tag == expected_tag
+
+        tag_func = _simple_compile_tag(tag, tag_content)
+        args, kwargs = tag_func({"val1": 1, "val2": 2})
+        assert args == [{"key": 1}]
+        assert kwargs == []
+
+    def test_spread_dict_literal_as_attribute(self):
+        tag_content = '{% component ...{"key": val2} %}'
+        tag = parse_tag(tag_content)
+
+        expected_tag = GenericTag(
+            token=token('{% component ...{"key": val2} %}', 0, 1, 1),
+            name=token("component", 3, 1, 4),
+            attrs=[
+                TagAttr(
+                    token=token('...{"key": val2}', 13, 1, 14),
+                    key=None,
+                    value=TagValue(
+                        token=token('...{"key": val2}', 13, 1, 14),
+                        value=token('{"key": val2}', 16, 1, 17),
+                        children=[
+                            ValueChild(plain_string_value('"key"', 17, 1, 18, None)),
+                            ValueChild(plain_variable_value("val2", 24, 1, 25, None)),
+                        ],
+                        kind=ValueKind("dict"),
+                        spread="...",
+                        filters=[],
+                        used_variables=[],
+                        assigned_variables=[],
+                    ),
+                    is_flag=False,
+                ),
+            ],
+            is_self_closing=False,
+            used_variables=[token("val2", 24, 1, 25)],
+            assigned_variables=[],
+        )
+
+        assert tag == expected_tag
+
+        tag_func = _simple_compile_tag(tag, tag_content)
+        args, kwargs = tag_func({"val1": 1, "val2": 2})
+        assert args == []
+        assert kwargs == [("key", 2)]
+
+    def test_spread_list_literal_nested(self):
+        tag_content = "{% component [ *[val1], val2 ] %}"
+        tag = parse_tag(tag_content)
+
+        expected_tag = GenericTag(
+            token=token("{% component [ *[val1], val2 ] %}", 0, 1, 1),
+            name=token("component", 3, 1, 4),
+            attrs=[
+                TagAttr(
+                    token=token("[ *[val1], val2 ]", 13, 1, 14),
+                    key=None,
+                    value=plain_list_value(
+                        token("[ *[val1], val2 ]", 13, 1, 14),
+                        [
+                            ValueChild(
+                                TagValue(
+                                    token=token("*[val1]", 15, 1, 16),
+                                    value=token("[val1]", 16, 1, 17),
+                                    children=[
+                                        ValueChild(
+                                            plain_variable_value(
+                                                "val1", 17, 1, 18, None
+                                            )
+                                        ),
+                                    ],
+                                    kind=ValueKind("list"),
+                                    spread="*",
+                                    filters=[],
+                                    used_variables=[],
+                                    assigned_variables=[],
+                                )
+                            ),
+                            ValueChild(plain_variable_value("val2", 24, 1, 25, None)),
+                        ],
+                    ),
+                    is_flag=False,
+                ),
+            ],
+            is_self_closing=False,
+            used_variables=[
+                token("val1", 17, 1, 18),
+                token("val2", 24, 1, 25),
+            ],
+            assigned_variables=[],
+        )
+
+        assert tag == expected_tag
+
+        tag_func = _simple_compile_tag(tag, tag_content)
+        args, kwargs = tag_func({"val1": 1, "val2": 2})
+        assert args == [[1, 2]]
+        assert kwargs == []
+
+    def test_spread_list_literal_as_attribute(self):
+        tag_content = "{% component ...[val1] %}"
+        tag = parse_tag(tag_content)
+
+        expected_tag = GenericTag(
+            token=token("{% component ...[val1] %}", 0, 1, 1),
+            name=token("component", 3, 1, 4),
+            attrs=[
+                TagAttr(
+                    token=token("...[val1]", 13, 1, 14),
+                    key=None,
+                    value=TagValue(
+                        token=token("...[val1]", 13, 1, 14),
+                        value=token("[val1]", 16, 1, 17),
+                        children=[
+                            ValueChild(plain_variable_value("val1", 17, 1, 18, None)),
+                        ],
+                        kind=ValueKind("list"),
+                        spread="...",
+                        filters=[],
+                        used_variables=[],
+                        assigned_variables=[],
+                    ),
+                    is_flag=False,
+                ),
+            ],
+            is_self_closing=False,
+            used_variables=[token("val1", 17, 1, 18)],
+            assigned_variables=[],
+        )
+
+        assert tag == expected_tag
+
+        tag_func = _simple_compile_tag(tag, tag_content)
+        args, kwargs = tag_func({"val1": 1, "val2": 2})
+        assert args == [1]
+        assert kwargs == []
+
+
+class TestTemplateString:
+    def test_template_string(self):
+        tag_content = "{% component '{% lorem w 4 %}' %}"
+        tag = parse_tag(tag_content)
+
+        expected_tag = GenericTag(
+            token=token("{% component '{% lorem w 4 %}' %}", 0, 1, 1),
+            name=token("component", 3, 1, 4),
+            attrs=[
+                TagAttr(
+                    token=token("'{% lorem w 4 %}'", 13, 1, 14),
+                    key=None,
+                    value=plain_template_string_value(
+                        "'{% lorem w 4 %}'", 13, 1, 14, None
+                    ),
+                    is_flag=False,
+                ),
+            ],
+            is_self_closing=False,
+            used_variables=[],
+            assigned_variables=[],
+        )
+
+        assert tag == expected_tag
+
+        tag_func = _simple_compile_tag(tag, tag_content)
+        args, kwargs = tag_func({"val1": 1, "val2": 2})
+        assert args == ["TEMPLATE_RESOLVED:{% lorem w 4 %}"]
+        assert kwargs == []
+
+    def test_template_string_in_dict(self):
+        tag_content = '{% component { "key": "{% lorem w 4 %}" } %}'
+        tag = parse_tag(tag_content)
+
+        expected_tag = GenericTag(
+            token=token('{% component { "key": "{% lorem w 4 %}" } %}', 0, 1, 1),
+            name=token("component", 3, 1, 4),
+            attrs=[
+                TagAttr(
+                    token=token('{ "key": "{% lorem w 4 %}" }', 13, 1, 14),
+                    key=None,
+                    value=plain_dict_value(
+                        token('{ "key": "{% lorem w 4 %}" }', 13, 1, 14),
+                        [
+                            ValueChild(plain_string_value('"key"', 15, 1, 16, None)),
+                            ValueChild(
+                                plain_template_string_value(
+                                    '"{% lorem w 4 %}"', 22, 1, 23, None
+                                )
+                            ),
+                        ],
+                    ),
+                    is_flag=False,
+                ),
+            ],
+            is_self_closing=False,
+            used_variables=[],
+            assigned_variables=[],
+        )
+
+        assert tag == expected_tag
+
+        tag_func = _simple_compile_tag(tag, tag_content)
+        args, kwargs = tag_func({"val1": 1, "val2": 2})
+        assert args == [{"key": "TEMPLATE_RESOLVED:{% lorem w 4 %}"}]
+        assert kwargs == []
+
+    def test_template_string_in_list(self):
+        tag_content = "{% component [ '{% lorem w 4 %}' ] %}"
+        tag = parse_tag(tag_content)
+
+        expected_tag = GenericTag(
+            token=token("{% component [ '{% lorem w 4 %}' ] %}", 0, 1, 1),
+            name=token("component", 3, 1, 4),
+            attrs=[
+                TagAttr(
+                    token=token("[ '{% lorem w 4 %}' ]", 13, 1, 14),
+                    key=None,
+                    value=plain_list_value(
+                        token("[ '{% lorem w 4 %}' ]", 13, 1, 14),
+                        [
+                            ValueChild(
+                                plain_template_string_value(
+                                    "'{% lorem w 4 %}'", 15, 1, 16, None
+                                )
+                            ),
+                        ],
+                    ),
+                    is_flag=False,
+                ),
+            ],
+            is_self_closing=False,
+            used_variables=[],
+            assigned_variables=[],
+        )
+
+        assert tag == expected_tag
+
+        tag_func = _simple_compile_tag(tag, tag_content)
+        args, kwargs = tag_func({"val1": 1, "val2": 2})
+        assert args == [["TEMPLATE_RESOLVED:{% lorem w 4 %}"]]
+        assert kwargs == []
+
+    def test_template_string_with_filter(self):
+        tag_content = "{% component '{% lorem w 4 %}'|upper %}"
+        tag = parse_tag(tag_content)
+
+        expected_tag = GenericTag(
+            token=token(tag_content, 0, 1, 1),
+            name=token("component", 3, 1, 4),
+            attrs=[
+                TagAttr(
+                    token=token("'{% lorem w 4 %}'|upper", 13, 1, 14),
+                    key=None,
+                    value=template_string_value(
+                        token("'{% lorem w 4 %}'|upper", 13, 1, 14),
+                        token("'{% lorem w 4 %}'", 13, 1, 14),
+                        None,
+                        [
+                            TagValueFilter(
+                                token=token("|upper", 30, 1, 31),
+                                name=token("upper", 31, 1, 32),
+                                arg=None,
+                            )
+                        ],
+                        [],
+                        [],
+                    ),
+                    is_flag=False,
+                ),
+            ],
+            is_self_closing=False,
+            used_variables=[],
+            assigned_variables=[],
+        )
+
+        assert tag == expected_tag
+
+        tag_func = _simple_compile_tag(tag, tag_content)
+        args, kwargs = tag_func({})
+
+        assert args == ["upper(TEMPLATE_RESOLVED:{% lorem w 4 %}, None)"]
+        assert kwargs == []
+
+    def test_template_string_as_filter_arg(self):
+        tag_content = '{% component my_var|default:"{% lorem w 4 %}" %}'
+        tag = parse_tag(tag_content)
+
+        expected_tag = GenericTag(
+            token=token(tag_content, 0, 1, 1),
+            name=token("component", 3, 1, 4),
+            attrs=[
+                TagAttr(
+                    token=token('my_var|default:"{% lorem w 4 %}"', 13, 1, 14),
+                    key=None,
+                    value=variable_value(
+                        token('my_var|default:"{% lorem w 4 %}"', 13, 1, 14),
+                        token("my_var", 13, 1, 14),
+                        None,
+                        [
+                            TagValueFilter(
+                                token=token('|default:"{% lorem w 4 %}"', 19, 1, 20),
+                                name=token("default", 20, 1, 21),
+                                arg=plain_template_string_value(
+                                    '"{% lorem w 4 %}"', 28, 1, 29, None
+                                ),
+                            )
+                        ],
+                        [],
+                        [],
+                    ),
+                    is_flag=False,
+                ),
+            ],
+            is_self_closing=False,
+            used_variables=[token("my_var", 13, 1, 14)],
+            assigned_variables=[],
+        )
+
+        assert tag == expected_tag
+
+        tag_func = _simple_compile_tag(tag, tag_content)
+        args, kwargs = tag_func({"my_var": None})
+
+        assert args == ["default(None, TEMPLATE_RESOLVED:{% lorem w 4 %})"]
+        assert kwargs == []
+
+
+class TestComments:
+    def test_comments(self):
+        tag_content = "{% component {# comment #} val %}"
+        tag = parse_tag(tag_content)
+
+        expected_tag = GenericTag(
+            token=token("{% component {# comment #} val %}", 0, 1, 1),
+            name=token("component", 3, 1, 4),
+            attrs=[
+                TagAttr(
+                    token=token("val", 27, 1, 28),
+                    key=None,
+                    value=plain_variable_value("val", 27, 1, 28, None),
+                    is_flag=False,
+                ),
+            ],
+            is_self_closing=False,
+            used_variables=[token("val", 27, 1, 28)],
+            assigned_variables=[],
+        )
+
+        assert tag == expected_tag
+
+        tag_func = _simple_compile_tag(tag, tag_content)
+        args, kwargs = tag_func({"val": 1, "val2": 2})
+        assert args == [1]
+        assert kwargs == []
+
+    def test_comments_within_list(self):
+        tag_content = "{% component [ *[val1], {# comment #} val2 ] %}"
+        tag = parse_tag(tag_content)
+
+        expected_tag = GenericTag(
+            token=token("{% component [ *[val1], {# comment #} val2 ] %}", 0, 1, 1),
+            name=token("component", 3, 1, 4),
+            attrs=[
+                TagAttr(
+                    token=token("[ *[val1], {# comment #} val2 ]", 13, 1, 14),
+                    key=None,
+                    value=plain_list_value(
+                        token("[ *[val1], {# comment #} val2 ]", 13, 1, 14),
+                        [
+                            ValueChild(
+                                TagValue(
+                                    token=token("*[val1]", 15, 1, 16),
+                                    value=token("[val1]", 16, 1, 17),
+                                    children=[
+                                        ValueChild(
+                                            plain_variable_value(
+                                                "val1", 17, 1, 18, None
+                                            )
+                                        ),
+                                    ],
+                                    kind=ValueKind("list"),
+                                    spread="*",
+                                    filters=[],
+                                    used_variables=[],
+                                    assigned_variables=[],
+                                )
+                            ),
+                            ValueChild(plain_variable_value("val2", 38, 1, 39, None)),
+                        ],
+                    ),
+                    is_flag=False,
+                ),
+            ],
+            is_self_closing=False,
+            used_variables=[
+                token("val1", 17, 1, 18),
+                token("val2", 38, 1, 39),
+            ],
+            assigned_variables=[],
+        )
+
+        assert tag == expected_tag
+
+        tag_func = _simple_compile_tag(tag, tag_content)
+        args, kwargs = tag_func({"val1": 1, "val2": 2})
+        assert args == [[1, 2]]
+        assert kwargs == []
+
+    def test_comments_within_dict(self):
+        tag = parse_tag('{% component { "key": "123" {# comment #} } %}')
+
+        expected_tag = GenericTag(
+            token=token('{% component { "key": "123" {# comment #} } %}', 0, 1, 1),
+            name=token("component", 3, 1, 4),
+            attrs=[
+                TagAttr(
+                    token=token('{ "key": "123" {# comment #} }', 13, 1, 14),
+                    key=None,
+                    value=plain_dict_value(
+                        token('{ "key": "123" {# comment #} }', 13, 1, 14),
+                        children=[
+                            ValueChild(plain_string_value('"key"', 15, 1, 16, None)),
+                            ValueChild(plain_string_value('"123"', 22, 1, 23, None)),
+                        ],
+                    ),
+                    is_flag=False,
+                ),
+            ],
+            is_self_closing=False,
+            used_variables=[],
+            assigned_variables=[],
+        )
+
+        assert tag == expected_tag
+
+        tag_func = _simple_compile_tag(tag, tag)
+        args, kwargs = tag_func({"val1": 1, "val2": 2})
+        assert args == [{"key": "123"}]
+        assert kwargs == []
+
+
+class TestParamsOrder:
+    def test_arg_after_kwarg_is_error(self):
+        tag_content = "{% my_tag key='value' positional_arg %}"
+        ast = parse_tag(input=tag_content)
+        with pytest.raises(
+            SyntaxError, match="positional argument follows keyword argument"
+        ):
+            _simple_compile_tag(ast, tag_content)
+
+    def test_arg_after_dict_spread_is_error(self):
+        tag_content = "{% my_tag ...{'key': 'value'} positional_arg %}"
+        ast = parse_tag(input=tag_content)
+        tag_func = _simple_compile_tag(ast, tag_content)
+
+        with pytest.raises(
+            SyntaxError, match="positional argument follows keyword argument"
+        ):
+            tag_func({})
+
+    def test_arg_after_list_spread_is_ok(self):
+        tag_content = "{% my_tag ...[1, 2, 3] positional_arg %}"
+        ast = parse_tag(input=tag_content)
+        tag_func = _simple_compile_tag(ast, tag_content)
+        args, kwargs = tag_func({"positional_arg": 4})
+        assert args == [1, 2, 3, 4]
+        assert kwargs == []
+
+    def test_dict_spread_after_arg_is_ok(self):
+        tag_content = "{% my_tag positional_arg ...{'key': 'value'} %}"
+        ast = parse_tag(input=tag_content)
+        tag_func = _simple_compile_tag(ast, tag_content)
+        args, kwargs = tag_func({"positional_arg": 1})
+        assert args == [1]
+        assert kwargs == [("key", "value")]
+
+    def test_dict_spread_after_kwarg_is_ok(self):
+        tag_content = "{% my_tag key='value' ...{'key2': 'value2'} %}"
+        ast = parse_tag(input=tag_content)
+        tag_func = _simple_compile_tag(ast, tag_content)
+        args, kwargs = tag_func({})
+        assert args == []
+        assert kwargs == [("key", "value"), ("key2", "value2")]
+
+    def test_list_spread_after_arg_is_ok(self):
+        tag_content = "{% my_tag positional_arg ...[1, 2, 3] %}"
+        ast = parse_tag(input=tag_content)
+        tag_func = _simple_compile_tag(ast, tag_content)
+        args, kwargs = tag_func({"positional_arg": 4})
+        assert args == [4, 1, 2, 3]
+        assert kwargs == []
+
+    def test_list_spread_after_kwarg_is_error(self):
+        tag_content = "{% my_tag key='value' ...[1, 2, 3] %}"
+        ast = parse_tag(input=tag_content)
+        tag_func = _simple_compile_tag(ast, tag_content)
+        with pytest.raises(
+            SyntaxError, match="positional argument follows keyword argument"
+        ):
+            tag_func({})
+
+    def test_list_spread_after_list_spread_is_ok(self):
+        tag_content = "{% my_tag ...[1, 2, 3] ...[4, 5, 6] %}"
+        ast = parse_tag(input=tag_content)
+        tag_func = _simple_compile_tag(ast, tag_content)
+        args, kwargs = tag_func({})
+        assert args == [1, 2, 3, 4, 5, 6]
+        assert kwargs == []
+
+    def test_dict_spread_after_dict_spread_is_ok(self):
+        tag_content = "{% my_tag ...{'key': 'value'} ...{'key2': 'value2'} %}"
+        ast = parse_tag(input=tag_content)
+        tag_func = _simple_compile_tag(ast, tag_content)
+        args, kwargs = tag_func({})
+        assert args == []
+        assert kwargs == [("key", "value"), ("key2", "value2")]
+
+    def test_list_spread_after_dict_spread_is_error(self):
+        tag_content = "{% my_tag ...{'key': 'value'} ...[1, 2, 3] %}"
+        ast = parse_tag(input=tag_content)
+        tag_func = _simple_compile_tag(ast, tag_content)
+        with pytest.raises(
+            SyntaxError, match="positional argument follows keyword argument"
+        ):
+            tag_func({})
+
+    def test_dict_spread_after_list_spread_is_ok(self):
+        tag_content = "{% my_tag ...[1, 2, 3] ...{'key': 'value'} %}"
+        ast = parse_tag(input=tag_content)
+        tag_func = _simple_compile_tag(ast, tag_content)
+        args, kwargs = tag_func({})
+        assert args == [1, 2, 3]
+        assert kwargs == [("key", "value")]
+
+
+class TestFlags:
+    def test_flag(self):
+        tag_content = "{% my_tag 123 my_flag key='val' %}"
+        config = ParserConfig(version=TemplateVersion.v1)
+        config.set_tag(
+            TagConfig(tag=TagSpec("my_tag", flags={"my_flag"}), sections=None)
+        )
+        ast = parse_tag(tag_content, config)
+
+        assert ast.attrs[1].value.token.content == "my_flag"
+        assert ast.attrs[1].is_flag
+
+        # The compiled function should omit the flag
+        compiled_func = _simple_compile_tag(ast, tag_content)
+        args, kwargs = compiled_func({})
+
+        assert args == [123]
+        assert kwargs == [("key", "val")]
+
+        # Same as before, but with flags=None
+        ast2 = parse_tag(tag_content, config=None)
+        assert ast2.attrs[1].value.token.content == "my_flag"
+        assert not ast2.attrs[1].is_flag
+
+        # The compiled function should omit the flag
+        compiled_func2 = _simple_compile_tag(ast2, tag_content)
+        args2, kwargs2 = compiled_func2({"my_flag": "x"})
+
+        assert args2 == [123, "x"]
+        assert kwargs2 == [("key", "val")]
+
+    # Since flags are NOT treated as args, this should be OK
+    def test_flag_after_kwarg(self):
+        tag_content = "{% my_tag key='value' my_flag %}"
+        config = ParserConfig(version=TemplateVersion.v1)
+        config.set_tag(
+            TagConfig(tag=TagSpec("my_tag", flags={"my_flag"}), sections=None)
+        )
+        ast1 = parse_tag(tag_content, config)
+
+        assert ast1.attrs[1].value.token.content == "my_flag"
+        assert ast1.attrs[1].is_flag
+
+        compiled_func1 = _simple_compile_tag(ast1, tag_content)
+        args1, kwargs1 = compiled_func1({})
+        assert args1 == []
+        assert kwargs1 == [("key", "value")]
+
+        # Same as before, but with flags=None
+        ast2 = parse_tag(tag_content, config=None)
+        assert ast2.attrs[1].value.token.content == "my_flag"
+        assert not ast2.attrs[1].is_flag
+
+        with pytest.raises(
+            SyntaxError, match="positional argument follows keyword argument"
+        ):
+            _simple_compile_tag(ast2, tag_content)
+
+    # my_flag is NOT treated as flag because it's used as spread
+    def test_flag_as_spread(self):
+        tag_content = "{% my_tag ...my_flag %}"
+        config = ParserConfig(version=TemplateVersion.v1)
+        config.set_tag(
+            TagConfig(tag=TagSpec("my_tag", flags={"my_flag"}), sections=None)
+        )
+        ast1 = parse_tag(tag_content, config)
+
+        assert ast1.attrs[0].value.token.content == "...my_flag"
+        assert not ast1.attrs[0].is_flag
+
+        compiled_func1 = _simple_compile_tag(ast1, tag_content)
+        args1, kwargs1 = compiled_func1({"my_flag": ["arg1", "arg2"]})
+
+        assert args1 == ["arg1", "arg2"]
+        assert kwargs1 == []
+
+        # Same as before, but with flags=None
+        ast2 = parse_tag(tag_content, config=None)
+        assert ast2.attrs[0].value.token.content == "...my_flag"
+        assert not ast2.attrs[0].is_flag
+
+        compiled_func2 = _simple_compile_tag(ast2, tag_content)
+        args2, kwargs2 = compiled_func2({"my_flag": ["arg1", "arg2"]})
+
+        assert args2 == ["arg1", "arg2"]
+        assert kwargs2 == []
+
+    # my_flag is NOT treated as flag because it's used as kwarg
+    def test_flag_as_kwarg(self):
+        tag_content = "{% my_tag my_flag=123 %}"
+        config = ParserConfig(version=TemplateVersion.v1)
+        config.set_tag(
+            TagConfig(tag=TagSpec("my_tag", flags={"my_flag"}), sections=None)
+        )
+        ast1 = parse_tag(tag_content, config)
+
+        assert ast1.attrs[0].key
+        assert ast1.attrs[0].key.content == "my_flag"
+        assert not ast1.attrs[0].is_flag
+
+        compiled_func1 = _simple_compile_tag(ast1, tag_content)
+        args1, kwargs1 = compiled_func1({})
+        assert args1 == []
+        assert kwargs1 == [("my_flag", 123)]
+
+        # Same as before, but with no flags
+        ast2 = parse_tag(tag_content, config=None)
+        assert ast2.attrs[0].key
+        assert ast2.attrs[0].key.content == "my_flag"
+        assert not ast2.attrs[0].is_flag
+
+        compiled_func2 = _simple_compile_tag(ast2, tag_content)
+        args2, kwargs2 = compiled_func2({})
+        assert args2 == []
+        assert kwargs2 == [("my_flag", 123)]
+
+    def test_flag_duplicate(self):
+        tag_content = "{% my_tag my_flag my_flag %}"
+        config = ParserConfig(version=TemplateVersion.v1)
+        config.set_tag(
+            TagConfig(tag=TagSpec("my_tag", flags={"my_flag"}), sections=None)
+        )
+        with pytest.raises(
+            SyntaxError, match=r"Flag 'my_flag' may be specified only once."
+        ):
+            parse_tag(tag_content, config)
+
+    def test_flag_case_sensitive(self):
+        tag_content = "{% my_tag my_flag %}"
+        config = ParserConfig(version=TemplateVersion.v1)
+        config.set_tag(
+            TagConfig(tag=TagSpec("my_tag", flags={"MY_FLAG"}), sections=None)
+        )
+        ast = parse_tag(tag_content, config)
+        assert ast.attrs[0].value.token.content == "my_flag"
+        assert not ast.attrs[0].is_flag
+
+
+class TestSelfClosing:
+    def test_self_closing_simple(self):
+        ast = parse_tag("{% my_tag / %}")
+        assert ast.meta.name.content == "my_tag"
+        assert ast.is_self_closing is True
+        assert ast.attrs == []
+
+    def test_self_closing_with_args(self):
+        ast = parse_tag("{% my_tag key=val / %}")
+        assert ast.meta.name.content == "my_tag"
+        assert ast.is_self_closing is True
+        assert len(ast.attrs) == 1
+        assert ast.attrs[0].key
+        assert ast.attrs[0].key.content == "key"
+        assert ast.attrs[0].value.token.content == "val"
+
+    def test_self_closing_in_middle_errors(self):
+        with pytest.raises(
+            SyntaxError,
+            match=r"Parse error:  --> 1:13\n  |\n1 | {% my_tag / key=val %}\n  |             ^---\n  |\n  = expected COMMENT",
+        ):
+            parse_tag("{% my_tag / key=val %}")

--- a/tests/test_template_parser__value.py
+++ b/tests/test_template_parser__value.py
@@ -1,0 +1,345 @@
+# ruff: noqa: ANN201,ARG005,S101,S105,S106,E501
+from typing import Any
+from unittest.mock import Mock
+
+from djc_core.template_parser import (
+    TagValue,
+    compile_value,
+    parse_tag,
+)
+
+###############################
+# RESOLVERS
+###############################
+
+
+def expr_resolver(ctx, src, token, filters, tags, expr):
+    return f"EXPR_RESOLVED:{expr}"
+
+
+def template_resolver(ctx, src, token, filters, tags, template):
+    return f"TEMPLATE_RESOLVED:{template}"
+
+
+def translation_resolver(ctx, src, token, filters, tags, text):
+    return f"TRANSLATION_RESOLVED:{text}"
+
+
+###############################
+# HELPERS
+###############################
+
+
+def _upper_filter(value, arg):
+    if isinstance(value, (list, tuple)):
+        return [item.upper() for item in value]
+    elif isinstance(value, dict):
+        return {key: value.upper() for key, value in value.items()}
+    return value.upper()
+
+
+def _simple_compile_value(value: TagValue, source: str):
+    return compile_value(
+        value,
+        source,
+        filters={
+            "upper": _upper_filter,
+            "add": lambda value, arg: value + arg,
+            "round": lambda value, arg: round(value, arg),
+        },
+        tags={},
+        template_string=template_resolver,
+        expr=expr_resolver,
+        translation=translation_resolver,
+        filter=lambda ctx, src, token, filters, tags, name, value, arg: filters[name](
+            value, arg
+        ),
+        variable=lambda ctx, src, token, filters, tags, var: ctx[var],
+    )
+
+
+############################################################
+# TESTS
+############################################################
+
+
+# Test that resolvers are called correctly
+class TestResolvers:
+    def _setup_resolver_test(self, tag_content: str, context: Any):
+        value = parse_tag(tag_content).attrs[0].value
+
+        # Mock variable resolver to return different values for different variables
+        def variable_side_effect(ctx, src, token, filters, tags, var):
+            if var == "my_var":
+                return "test_value"
+            elif var == "arg":
+                return "arg_value"
+            return None
+
+        mock_variable = Mock(side_effect=variable_side_effect)
+        mock_template_string = Mock(return_value="resolved_template")
+        mock_translation = Mock(return_value="resolved_translation")
+        mock_filter = Mock(return_value="resolved_filter")
+        mock_expr = Mock(return_value="resolved_expr")
+
+        filters = {"my_filter": lambda *args, **kwargs: "<my_filter>"}
+        tags = {"my_tag": lambda *args, **kwargs: "<my_tag>"}
+
+        tag_func = compile_value(
+            value,
+            tag_content,
+            filters=filters,
+            tags=tags,
+            variable=mock_variable,
+            template_string=mock_template_string,
+            translation=mock_translation,
+            filter=mock_filter,
+            expr=mock_expr,
+        )
+
+        tag_func(context)
+
+        return (
+            mock_variable,
+            mock_template_string,
+            mock_translation,
+            mock_filter,
+            mock_expr,
+            filters,
+            tags,
+        )
+
+    def test_variable_resolver(self):
+        context = {"my_var": "test"}
+        tag_content = "{% component my_var %}"
+        (
+            mock_variable,
+            mock_template_string,
+            mock_translation,
+            mock_filter,
+            mock_expr,
+            filters,
+            tags,
+        ) = self._setup_resolver_test(tag_content, context)
+
+        # Assert variable resolver was called once with expected arguments
+        mock_variable.assert_called_once()
+        call_args = mock_variable.call_args
+        assert call_args[0][0] == context  # context
+        assert call_args[0][1] == tag_content  # source
+        assert call_args[0][2] == (13, 19)  # token (start_index, end_index)
+        assert call_args[0][3] == filters  # filters
+        assert call_args[0][4] == tags  # tags
+        assert call_args[0][5] == "my_var"  # var
+
+        # Other resolvers should not be called
+        mock_template_string.assert_not_called()
+        mock_translation.assert_not_called()
+        mock_filter.assert_not_called()
+        mock_expr.assert_not_called()
+
+    def test_template_string_resolver(self):
+        context = {}
+        tag_content = "{% component '{% lorem w 4 %}' %}"
+        (
+            mock_variable,
+            mock_template_string,
+            mock_translation,
+            mock_filter,
+            mock_expr,
+            filters,
+            tags,
+        ) = self._setup_resolver_test(tag_content, context)
+
+        # Assert template_string resolver was called once with expected arguments
+        mock_template_string.assert_called_once()
+        call_args = mock_template_string.call_args
+        assert call_args[0][0] == context  # context
+        assert call_args[0][1] == tag_content  # source
+        assert call_args[0][2] == (13, 30)  # token (start_index, end_index)
+        assert call_args[0][3] == filters  # filters
+        assert call_args[0][4] == tags  # tags
+        assert call_args[0][5] == "{% lorem w 4 %}"  # expr
+
+        # Other resolvers should not be called
+        mock_variable.assert_not_called()
+        mock_translation.assert_not_called()
+        mock_filter.assert_not_called()
+        mock_expr.assert_not_called()
+
+    def test_translation_resolver(self):
+        context = {}
+        tag_content = '{% component _("hello world") %}'
+        (
+            mock_variable,
+            mock_template_string,
+            mock_translation,
+            mock_filter,
+            mock_expr,
+            filters,
+            tags,
+        ) = self._setup_resolver_test(tag_content, context)
+
+        # Assert translation resolver was called once with expected arguments
+        mock_translation.assert_called_once()
+        call_args = mock_translation.call_args
+        assert call_args[0][0] == context  # context
+        assert call_args[0][1] == tag_content  # source
+        assert call_args[0][2] == (13, 29)  # token (start_index, end_index)
+        assert call_args[0][3] == filters  # filters
+        assert call_args[0][4] == tags  # tags
+        assert call_args[0][5] == "hello world"  # text (inner string without quotes)
+
+        # Other resolvers should not be called
+        mock_variable.assert_not_called()
+        mock_template_string.assert_not_called()
+        mock_filter.assert_not_called()
+        mock_expr.assert_not_called()
+
+    def test_expr_resolver(self):
+        context = {}
+        tag_content = "{% component (1 + 2) %}"
+        (
+            mock_variable,
+            mock_template_string,
+            mock_translation,
+            mock_filter,
+            mock_expr,
+            filters,
+            tags,
+        ) = self._setup_resolver_test(tag_content, context)
+
+        # Assert expr resolver was called once with expected arguments
+        mock_expr.assert_called_once()
+        call_args = mock_expr.call_args
+        assert call_args[0][0] == context  # context
+        assert call_args[0][1] == tag_content  # source
+        assert call_args[0][2] == (13, 20)  # token (start_index, end_index)
+        assert call_args[0][3] == filters  # filters
+        assert call_args[0][4] == tags  # tags
+        assert call_args[0][5] == "(1 + 2)"  # code
+
+        # Other resolvers should not be called
+        mock_variable.assert_not_called()
+        mock_template_string.assert_not_called()
+        mock_translation.assert_not_called()
+        mock_filter.assert_not_called()
+
+    def test_filter_resolver(self):
+        context = {}
+        tag_content = "{% component my_var|upper:arg %}"
+        (
+            mock_variable,
+            mock_template_string,
+            mock_translation,
+            mock_filter,
+            mock_expr,
+            filters,
+            tags,
+        ) = self._setup_resolver_test(tag_content, context)
+
+        # Assert filter resolver was called once with expected arguments
+        mock_filter.assert_called_once()
+        call_args = mock_filter.call_args
+        assert call_args[0][0] == context  # context
+        assert call_args[0][1] == tag_content  # source
+        assert call_args[0][2] == (
+            19,
+            29,
+        )  # token (start_index, end_index) - filter token |upper:arg
+        assert call_args[0][3] == filters  # filters
+        assert call_args[0][4] == tags  # tags
+        assert call_args[0][5] == "upper"  # name
+        assert call_args[0][6] == "test_value"  # value (from variable resolver)
+        assert call_args[0][7] == "arg_value"  # arg (from variable resolver)
+
+        # Variable resolver should be called twice (for the value and arg)
+        assert mock_variable.call_count == 2
+
+        # Other resolvers should not be called
+        mock_template_string.assert_not_called()
+        mock_translation.assert_not_called()
+        mock_expr.assert_not_called()
+
+
+class TestValueCompiler:
+    def test_string_value(self):
+        tag_content = "{% component 'hello world'|upper %}"
+        tag = parse_tag(tag_content)
+        value = tag.attrs[0].value
+        value_func = _simple_compile_value(value, tag_content)
+        result = value_func({})
+
+        assert result == "HELLO WORLD"
+
+    def test_int_value(self):
+        tag_content = "{% component 42|add:10 %}"
+        tag = parse_tag(tag_content)
+        value = tag.attrs[0].value
+        value_func = _simple_compile_value(value, tag_content)
+        result = value_func({})
+
+        assert result == 52
+
+    def test_float_value(self):
+        tag_content = "{% component 3.1415|round:2 %}"
+        tag = parse_tag(tag_content)
+        value = tag.attrs[0].value
+        value_func = _simple_compile_value(value, tag_content)
+        result = value_func({})
+
+        assert result == 3.14
+
+    def test_variable_value(self):
+        tag_content = "{% component my_var|upper %}"
+        tag = parse_tag(tag_content)
+        value = tag.attrs[0].value
+        value_func = _simple_compile_value(value, tag_content)
+        result = value_func({"my_var": "test_value"})
+
+        assert result == "TEST_VALUE"
+
+    def test_template_string_value(self):
+        tag_content = "{% component '{% lorem w 4 %}'|upper %}"
+        tag = parse_tag(tag_content)
+        value = tag.attrs[0].value
+        value_func = _simple_compile_value(value, tag_content)
+        result = value_func({})
+
+        assert result == "TEMPLATE_RESOLVED:{% LOREM W 4 %}"
+
+    def test_translation_value(self):
+        tag_content = '{% component _("hello")|upper %}'
+        tag = parse_tag(tag_content)
+        value = tag.attrs[0].value
+        value_func = _simple_compile_value(value, tag_content)
+        result = value_func({})
+
+        assert result == "TRANSLATION_RESOLVED:HELLO"
+
+    def test_python_expr_value(self):
+        tag_content = "{% component (1 + 2)|add:' :)' %}"
+        tag = parse_tag(tag_content)
+        value = tag.attrs[0].value
+        value_func = _simple_compile_value(value, tag_content)
+        result = value_func({})
+
+        assert result == "EXPR_RESOLVED:(1 + 2) :)"
+
+    def test_list_value(self):
+        tag_content = "{% component ['one', 'two', my_var]|upper %}"
+        tag = parse_tag(tag_content)
+        value = tag.attrs[0].value
+        value_func = _simple_compile_value(value, tag_content)
+        result = value_func({"my_var": "car"})
+
+        assert result == ["ONE", "TWO", "CAR"]
+
+    def test_dict_value(self):
+        tag_content = '{% component {"key": "val", "num": my_var}|upper %}'
+        tag = parse_tag(tag_content)
+        value = tag.attrs[0].value
+        value_func = _simple_compile_value(value, tag_content)
+        result = value_func({"my_var": "car"})
+
+        assert result == {"key": "VAL", "num": "CAR"}


### PR DESCRIPTION
Follow up for https://github.com/django-components/djc-core/pull/14. This just adds tests. Kept as a separate PR due to the sheer size of it.

The tests are huge because there's a lot of data types that can interact with each other:
 - data types: int, float, str, nested template, translation, list, dict, variable, python expression
 - Each data type can:
   - have filter(s)
   - be nested in dict, list or nested template
- some data types require certain variables to be present in the context (e.g. plain `{{ my_var }}`)