### PR TITLE
refactor: Allow to get allowed flags from `TagConfig`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Release notes
 
+## v1.2.1
+
+- Allow to get allowed flags from `TagConfig`
+
 ## v1.2.0
 
 - Added template parsing and compiling with `parse_tag()` and `compile_tag()`

--- a/crates/djc-template-parser/src/parser_config.rs
+++ b/crates/djc-template-parser/src/parser_config.rs
@@ -119,6 +119,13 @@ impl TagConfig {
             None => Self::PlainTag(tag),
         }
     }
+
+    pub fn get_flags(&self) -> &HashSet<String> {
+        match self {
+            TagConfig::PlainTag(tag) => &tag.flags,
+            TagConfig::TagWithBody(tag_with_body) => &tag_with_body.tag.flags,
+        }
+    }
 }
 
 /// Parser config

--- a/djc_core/rust.pyi
+++ b/djc_core/rust.pyi
@@ -278,6 +278,7 @@ class template_parser:
             tag: "template_parser.TagSpec",
             sections: Optional[List["template_parser.TagSectionSpec"]] = None,
         ) -> None: ...
+        def get_flags(self) -> Set[str]: ...  # Get the flags for this tag config
 
     class ParserConfig:
         """Parser config

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "djc_core"
-version = "1.2.0"
+version = "1.2.1"
 requires-python = ">=3.8, <4.0"
 description = "Core library for django-components written in Rust."
 keywords = ["django", "components", "html"]

--- a/tests/test_template_parser__tag.py
+++ b/tests/test_template_parser__tag.py
@@ -20,6 +20,7 @@ from djc_core.template_parser import (
     TagAttr,
     TagConfig,
     TagSpec,
+    TagSectionSpec,
     TemplateVersion,
     Token,
     TagValue,
@@ -5072,6 +5073,84 @@ class TestFlags:
         ast = parse_tag(tag_content, config)
         assert ast.attrs[0].value.token.content == "my_flag"
         assert not ast.attrs[0].is_flag
+
+
+class TestTagConfigGetFlags:
+    def test_get_flags_plain_tag(self):
+        tag_config = TagConfig(
+            tag=TagSpec("my_tag", flags={"flag1", "flag2"}),
+            sections=None,
+        )
+
+        flags = tag_config.get_flags()
+        assert flags == {"flag1", "flag2"}
+
+    def test_get_flags_tag_with_body(self):
+        tag_config = TagConfig(
+            tag=TagSpec("if", flags={"flag1", "flag2", "flag3"}),
+            sections=[
+                TagSectionSpec(
+                    tag=TagSpec("elif", flags={"section_flag"}),
+                    repeatable=True,
+                )
+            ],
+        )
+
+        flags = tag_config.get_flags()
+        assert flags == {"flag1", "flag2", "flag3"}
+
+    def test_get_flags_mutation_does_not_affect_original(self):
+        original_flags = {"flag1", "flag2"}
+        tag_config = TagConfig(
+            tag=TagSpec("my_tag", flags=original_flags.copy()),
+            sections=None,
+        )
+
+        flags = tag_config.get_flags()
+        assert flags == {"flag1", "flag2"}
+
+        # Mutate the returned set
+        flags.add("flag3")
+        flags.discard("flag1")
+
+        # Verify the original TagConfig is NOT affected
+        flags_after_mutation = tag_config.get_flags()
+        assert flags_after_mutation == {"flag1", "flag2"}
+
+    def test_get_flags_mutation_does_not_affect_original_tag_with_body(self):
+        original_flags = {"flag1", "flag2", "flag3"}
+        tag_config = TagConfig(
+            tag=TagSpec("if", flags=original_flags.copy()),
+            sections=[
+                TagSectionSpec(
+                    tag=TagSpec("elif", flags={"section_flag"}),
+                    repeatable=True,
+                )
+            ],
+        )
+
+        # Get flags and verify initial state
+        flags = tag_config.get_flags()
+        assert flags == {"flag1", "flag2", "flag3"}
+
+        # Mutate the returned set
+        flags.add("flag4")
+        flags.clear()
+        flags.add("mutated_flag")
+
+        # Verify the original TagConfig is NOT affected
+        flags_after_mutation = tag_config.get_flags()
+        assert flags_after_mutation == {"flag1", "flag2", "flag3"}
+
+    def test_get_flags_empty_flags(self):
+        tag_config = TagConfig(
+            tag=TagSpec("my_tag", flags=set()),
+            sections=None,
+        )
+
+        flags = tag_config.get_flags()
+        assert flags == set()
+        assert len(flags) == 0
 
 
 class TestSelfClosing:


### PR DESCRIPTION
Small change needed in order to use djc-core by django-components