### PR TITLE
refactor: Add `get_tag()` method to `ParserConfig`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Release notes
 
+## v1.2.2
+
+- Add `get_tag()` method to `ParserConfig` to retrieve tag configurations
+- Remove `ParserConfig.tags` attribute (use `get_tag()` instead)
+
 ## v1.2.1
 
 - Allow to get allowed flags from `TagConfig`

--- a/crates/djc-template-parser/src/parser_config.rs
+++ b/crates/djc-template-parser/src/parser_config.rs
@@ -155,6 +155,11 @@ impl ParserConfig {
         let tag_name = tag_config.tag_name().to_string();
         self.tags.insert(tag_name, tag_config);
     }
+
+    /// Get config for a tag
+    pub fn get_tag(&self, tag_name: &str) -> Option<TagConfig> {
+        self.tags.get(tag_name).cloned()
+    }
 }
 
 impl ParserConfig {
@@ -220,9 +225,7 @@ impl ParserConfig {
 
         // Check that "for" is not specified, as it's a reserved special tag
         if self.tags.contains_key("for") {
-            return Err(
-                "Tag 'for' is reserved and cannot be specified in tag config".to_string(),
-            );
+            return Err("Tag 'for' is reserved and cannot be specified in tag config".to_string());
         }
 
         Ok(flags_map)

--- a/djc_core/rust.pyi
+++ b/djc_core/rust.pyi
@@ -287,8 +287,10 @@ class template_parser:
         It can be constructed from Python or Rust.
         """
         def __init__(self, version: "template_parser.TemplateVersion") -> None: ...
-        tags: dict[str, "template_parser.TagConfig"]  # Map from tag name to TagConfig
         version: "template_parser.TemplateVersion"  # Template version
         def set_tag(
             self, tag_config: "template_parser.TagConfig"
         ) -> None: ...  # Set config for a tag
+        def get_tag(
+            self, tag_name: str
+        ) -> Optional["template_parser.TagConfig"]: ...  # Get config for a tag

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "djc_core"
-version = "1.2.1"
+version = "1.2.2"
 requires-python = ">=3.8, <4.0"
 description = "Core library for django-components written in Rust."
 keywords = ["django", "components", "html"]

--- a/tests/test_template_parser__tag.py
+++ b/tests/test_template_parser__tag.py
@@ -5153,6 +5153,71 @@ class TestTagConfigGetFlags:
         assert len(flags) == 0
 
 
+class TestParserConfigGetTag:
+    def test_get_tag_plain_tag(self):
+        config = ParserConfig(version=TemplateVersion.v1)
+        tag_config = TagConfig(
+            tag=TagSpec("my_tag", flags={"flag1", "flag2"}),
+            sections=None,
+        )
+        config.set_tag(tag_config)
+
+        retrieved = config.get_tag("my_tag")
+        assert retrieved is not None
+        assert retrieved.get_flags() == {"flag1", "flag2"}
+
+    def test_get_tag_tag_with_body(self):
+        config = ParserConfig(version=TemplateVersion.v1)
+        tag_config = TagConfig(
+            tag=TagSpec("if", flags={"flag1", "flag2", "flag3"}),
+            sections=[
+                TagSectionSpec(
+                    tag=TagSpec("elif", flags={"section_flag"}),
+                    repeatable=True,
+                )
+            ],
+        )
+        config.set_tag(tag_config)
+
+        retrieved = config.get_tag("if")
+        assert retrieved is not None
+        assert retrieved.get_flags() == {"flag1", "flag2", "flag3"}
+
+    def test_get_tag_not_found(self):
+        config = ParserConfig(version=TemplateVersion.v1)
+        tag_config = TagConfig(
+            tag=TagSpec("my_tag", flags={"flag1"}),
+            sections=None,
+        )
+        config.set_tag(tag_config)
+
+        retrieved = config.get_tag("nonexistent")
+        assert retrieved is None
+
+    def test_get_tag_mutation_does_not_affect_original(self):
+        config = ParserConfig(version=TemplateVersion.v1)
+        original_tag_config = TagConfig(
+            tag=TagSpec("my_tag", flags={"flag1", "flag2"}),
+            sections=None,
+        )
+        config.set_tag(original_tag_config)
+
+        # Get the tag config
+        retrieved = config.get_tag("my_tag")
+        assert retrieved is not None
+        assert retrieved.get_flags() == {"flag1", "flag2"}
+
+        # Mutate the retrieved TagConfig's flags
+        retrieved_flags = retrieved.get_flags()
+        retrieved_flags.add("flag3")
+        retrieved_flags.discard("flag1")
+
+        # Verify the original config is NOT affected
+        retrieved_again = config.get_tag("my_tag")
+        assert retrieved_again is not None
+        assert retrieved_again.get_flags() == {"flag1", "flag2"}
+
+
 class TestSelfClosing:
     def test_self_closing_simple(self):
         ast = parse_tag("{% my_tag / %}")


### PR DESCRIPTION
Another small addition to make djc-core work with django-components