### PR TITLE
Fix multiline failure

### DIFF
--- a/crates/djc-template-parser/src/tag_compiler.rs
+++ b/crates/djc-template-parser/src/tag_compiler.rs
@@ -135,8 +135,19 @@ pub fn compile_value(value: &TagValue) -> Result<String, CompileError> {
     let compiled_value = match value.kind {
         ValueKind::Int | ValueKind::Float => Ok(value.value.content.clone()),
         ValueKind::String => {
-            // The token includes quotes, which is what we want for a Python string literal
-            Ok(value.value.content.clone())
+            let content = value.value.content.trim();
+            // Strip surrounding quotes
+            let (quote_char, inner) = if content.starts_with('"') && content.ends_with('"') {
+                ('"', &content[1..content.len() - 1])
+            } else if content.starts_with('\'') && content.ends_with('\'') {
+                ('\'', &content[1..content.len() - 1])
+            } else {
+                // No surrounding quotes, emit as-is
+                return Ok(content.to_string());
+            };
+            // Escape literal newlines so the string stays a valid single-line Python literal
+            let escaped = inner.replace('\\', "\\\\").replace('\n', "\\n").replace('\r', "\\r");
+            Ok(format!("{}{}{}", quote_char, escaped, quote_char))
         }
         ValueKind::Variable => {
             let wrapped = escape_and_wrap_triple_quotes(&value.value.content);

--- a/crates/djc-template-parser/tests/tag_compiler.rs
+++ b/crates/djc-template-parser/tests/tag_compiler.rs
@@ -267,12 +267,12 @@ mod tests {
 
     #[test]
     fn test_multiline_plain_string() {
-        // A plain multiline string (no template tags) should use triple quotes
-        // so the generated Python code is valid (not an unterminated string literal).
+        // A plain multiline string (no template tags) should have its newlines escaped
+        // so the generated Python code is a valid single-line string literal.
         let input = "{% my_tag key=\"on click\ndo something\" / %}";
         assert_compile_tag_attrs(
             input,
-            "def compiled_func(context):\n    args = []\n    kwargs = []\n    kwargs.append(('key', \"\"\"on click\ndo something\"\"\"))\n    return args, kwargs",
+            "def compiled_func(context):\n    args = []\n    kwargs = []\n    kwargs.append(('key', \"on click\\ndo something\"))\n    return args, kwargs",
         );
     }
 

--- a/crates/djc-template-parser/tests/tag_compiler.rs
+++ b/crates/djc-template-parser/tests/tag_compiler.rs
@@ -266,6 +266,17 @@ mod tests {
     }
 
     #[test]
+    fn test_multiline_plain_string() {
+        // A plain multiline string (no template tags) should use triple quotes
+        // so the generated Python code is valid (not an unterminated string literal).
+        let input = "{% my_tag key=\"on click\ndo something\" / %}";
+        assert_compile_tag_attrs(
+            input,
+            "def compiled_func(context):\n    args = []\n    kwargs = []\n    kwargs.append(('key', \"\"\"on click\ndo something\"\"\"))\n    return args, kwargs",
+        );
+    }
+
+    #[test]
     fn test_multiline_template_string() {
         // Test multiline template string (contains {{ }}) - should use triple quotes
         let input = r#"{% my_tag key="{{ var1 }}


### PR DESCRIPTION
Code that looked like this would fail with a SyntaxError. This is something that we want to avoid and we want to allow multiline text like this as this worked in prior versions. 

```html
{% component "small_button"
      theme="danger"
      icon="fa-solid fa-xmark"
      _="on click
          set replyForm to closest <form />" %}
{% endcomponent %}
```

