### PR TITLE
release: 1.3.1 (multiline plain-string fix)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,24 @@
 # Release notes
 
+## v1.3.1
+
+### Fix
+
+- Fix `SyntaxError` when a tag value was a multiline plain string (a quoted
+  string that spans multiple lines and contains no `{{ }}` template
+  expressions), e.g. an Alpine.js or hyperscript handler:
+
+    ```django
+    {% component "small_button"
+        _="on click
+            set replyForm to closest <form />"
+    %}{% endcomponent %}
+    ```
+
+    Literal newlines are now escaped when the string is compiled to a Python
+    literal, so the value stays a valid single-line literal. Regression from
+    v1.3.0. ([#37](https://github.com/django-components/djc-core/pull/37))
+
 ## v1.3.0
 
 Drop support for Python 3.8 and 3.9.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "djc_core"
-version = "1.3.0"
+version = "1.3.1"
 requires-python = ">=3.10, <4.0"
 description = "Core library for django-components written in Rust."
 keywords = ["django", "components", "html"]

--- a/tests/test_template_parser__tag.py
+++ b/tests/test_template_parser__tag.py
@@ -1817,6 +1817,39 @@ class TestString:
         assert args == []
         assert kwargs == [("key", "world")]
 
+    def test_string_multiline_value(self):
+        # A quoted string value that spans multiple lines but contains no
+        # `{{ }}` expressions (e.g. an Alpine.js or hyperscript handler) must
+        # compile to a valid single-line Python literal, with the newline
+        # escaped, instead of raising `SyntaxError`. Regression from 1.3.0
+        # (PR #37).
+        tag_content = '{% component key="on click\n    set x to 1" %}'
+        tag = parse_tag(tag_content)
+
+        expected_tag = GenericTag(
+            token=token(tag_content, 0, 1, 1),
+            name=token("component", 3, 1, 4),
+            attrs=[
+                TagAttr(
+                    token=token('key="on click\n    set x to 1"', 13, 1, 14),
+                    key=token("key", 13, 1, 14),
+                    value=plain_string_value('"on click\n    set x to 1"', 17, 1, 18, None),
+                    is_flag=False,
+                ),
+            ],
+            is_self_closing=False,
+            used_variables=[],
+            assigned_variables=[],
+        )
+
+        assert tag == expected_tag
+
+        tag_func = _simple_compile_tag(tag, tag_content)
+        args, kwargs = tag_func({})
+
+        assert args == []
+        assert kwargs == [("key", "on click\n    set x to 1")]
+
     def test_string_with_filter(self):
         tag_content = "{% component 'hello'|upper %}"
         tag = parse_tag(tag_content)


### PR DESCRIPTION
(Opus 4.8)

Release **djc-core 1.3.1**.

### What's in this PR

- **Bump version** `1.3.0` → `1.3.1` in `pyproject.toml` (the version maturin publishes).
- **CHANGELOG** entry for v1.3.1.
- **Regression test** for the multiline plain-string fix, added to the source-of-truth
  Python test file (`tests/test_template_parser__tag.py::TestString::test_string_multiline_value`).
  PR #37 fixed the bug and added a Rust test, but the Python test file had no case for it;
  this closes that gap.

### Why 1.3.1

PR #37 (merged) fixed a `SyntaxError` regression from 1.3.0: a tag value that is a
quoted string spanning multiple lines and containing no `{{ }}` expressions (e.g. an
Alpine.js / hyperscript handler) compiled to an invalid single-line Python literal.

```django
{% component "small_button"
    _="on click
        set replyForm to closest <form />"
%}{% endcomponent %}
```

### Verification

Built a release wheel from this branch locally (`djc_core-1.3.1-cp314-…-arm64.whl`) and ran
the tests against the real build:

- `tests/test_template_parser__tag.py::TestString` — 7 passed (incl. the new test).
- The same case mirrored into django-components passes too.

### After merge

Tag `1.3.1` to trigger the PyPI publish workflow. django-components will then raise its
floor to `djc-core>=1.3.1`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
